### PR TITLE
[#4] Discord-style sidebar + page routing

### DIFF
--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+const DEFAULT_CONFIG = {
+  port: 3001,
+  agentchattr_url: "http://127.0.0.1:8300",
+  projects: [],
+};
+
+export async function GET() {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    return NextResponse.json(JSON.parse(raw));
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return NextResponse.json(DEFAULT_CONFIG);
+    }
+    return NextResponse.json(DEFAULT_CONFIG);
+  }
+}

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -19,6 +19,9 @@ export async function GET() {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
       return NextResponse.json(DEFAULT_CONFIG);
     }
-    return NextResponse.json(DEFAULT_CONFIG);
+    return NextResponse.json(
+      { error: "Failed to read config", detail: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Sidebar from "@/components/Sidebar";
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -20,8 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geistMono.variable} h-full`}>
       <body className="h-full flex">
-        {/* Sidebar placeholder — 64px, will be built out in #4 */}
-        <aside className="w-16 shrink-0 border-r border-border bg-bg-surface" />
+        <Sidebar />
         <main className="flex-1 min-w-0 overflow-auto">{children}</main>
       </body>
     </html>

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1,0 +1,20 @@
+interface ProjectPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ProjectPage({ params }: ProjectPageProps) {
+  const { id } = await params;
+
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="text-center space-y-3">
+        <h1 className="text-2xl font-semibold tracking-tight text-text">
+          {id}
+        </h1>
+        <p className="text-sm text-text-muted">
+          Project dashboard — panels coming in #7
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,14 @@
+export default function SettingsPage() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="text-center space-y-3">
+        <h1 className="text-2xl font-semibold tracking-tight text-text">
+          Settings
+        </h1>
+        <p className="text-sm text-text-muted">
+          Configuration — coming in #11
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface Project {
+  id: string;
+  name: string;
+}
+
+function HomeIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 10L10 3l7 7" />
+      <path d="M5 8.5V16h3.5v-4h3v4H15V8.5" />
+    </svg>
+  );
+}
+
+function GearIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="9" cy="9" r="2.5" />
+      <path d="M7.5 1.5h3l.4 2.1a5.5 5.5 0 011.3.7l2-.8 1.5 2.6-1.6 1.3a5.5 5.5 0 010 1.5l1.6 1.3-1.5 2.6-2-.8a5.5 5.5 0 01-1.3.7l-.4 2.1h-3l-.4-2.1a5.5 5.5 0 01-1.3-.7l-2 .8-1.5-2.6 1.6-1.3a5.5 5.5 0 010-1.5L2.3 6.1l1.5-2.6 2 .8a5.5 5.5 0 011.3-.7z" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    >
+      <path d="M8 3v10M3 8h10" />
+    </svg>
+  );
+}
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    fetch("/api/config")
+      .then((r) => r.json())
+      .then((cfg) => setProjects(cfg.projects || []))
+      .catch(() => {});
+  }, []);
+
+  const isHome = pathname === "/";
+  const isSettings = pathname === "/settings";
+  const activeProjectId = pathname.startsWith("/project/")
+    ? pathname.split("/")[2]
+    : null;
+
+  return (
+    <aside className="w-16 shrink-0 h-full border-r border-border bg-bg-surface flex flex-col items-center py-3">
+      {/* Home */}
+      <Link
+        href="/"
+        className={`w-10 h-10 flex items-center justify-center rounded-sm transition-colors ${
+          isHome
+            ? "text-accent"
+            : "text-text-muted hover:text-text hover:bg-[#1a1a1a]"
+        }`}
+        title="Home"
+      >
+        <HomeIcon />
+      </Link>
+
+      {/* Divider */}
+      <div className="w-6 h-px bg-border my-2" />
+
+      {/* Projects */}
+      <div className="flex-1 flex flex-col items-center gap-2 overflow-y-auto min-h-0">
+        {projects.map((project) => {
+          const isActive = activeProjectId === project.id;
+          return (
+            <Link
+              key={project.id}
+              href={`/project/${project.id}`}
+              className="relative group"
+              title={project.name}
+            >
+              <div
+                className={`w-10 h-10 flex items-center justify-center rounded-full text-xs font-semibold uppercase transition-colors ${
+                  isActive
+                    ? "border-2 border-accent text-accent"
+                    : "border border-border text-text-muted hover:text-text hover:bg-[#1a1a1a]"
+                }`}
+              >
+                {project.name.charAt(0)}
+              </div>
+              {/* Tooltip */}
+              <div className="absolute left-14 top-1/2 -translate-y-1/2 px-2 py-1 bg-bg-surface border border-border text-text text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity z-50">
+                {project.name}
+              </div>
+            </Link>
+          );
+        })}
+
+        {/* Add project placeholder */}
+        <button
+          className="w-10 h-10 flex items-center justify-center rounded-full border border-dashed border-border text-text-muted hover:text-text hover:bg-[#1a1a1a] transition-colors"
+          title="Add project"
+        >
+          <PlusIcon />
+        </button>
+      </div>
+
+      {/* Divider */}
+      <div className="w-6 h-px bg-border my-2" />
+
+      {/* Settings */}
+      <Link
+        href="/settings"
+        className={`w-10 h-10 flex items-center justify-center rounded-sm transition-colors ${
+          isSettings
+            ? "text-accent"
+            : "text-text-muted hover:text-text hover:bg-[#1a1a1a]"
+        }`}
+        title="Settings"
+      >
+        <GearIcon />
+      </Link>
+    </aside>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -104,9 +104,12 @@ export default function Sidebar() {
 
   useEffect(() => {
     fetch("/api/config")
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`Config fetch failed: ${r.status}`);
+        return r.json();
+      })
       .then((cfg) => setProjects(cfg.projects || []))
-      .catch(() => {});
+      .catch((err) => console.error(err.message));
   }, []);
 
   const isHome = pathname === "/";

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface Project {
   id: string;
@@ -61,6 +61,43 @@ function PlusIcon() {
   );
 }
 
+function ProjectIcon({ project, isActive }: { project: Project; isActive: boolean }) {
+  const [tooltip, setTooltip] = useState<{ top: number } | null>(null);
+  const ref = useRef<HTMLAnchorElement>(null);
+
+  return (
+    <>
+      <Link
+        ref={ref}
+        href={`/project/${project.id}`}
+        onMouseEnter={() => {
+          const rect = ref.current?.getBoundingClientRect();
+          if (rect) setTooltip({ top: rect.top + rect.height / 2 });
+        }}
+        onMouseLeave={() => setTooltip(null)}
+      >
+        <div
+          className={`w-10 h-10 flex items-center justify-center rounded-full text-xs font-semibold uppercase transition-colors ${
+            isActive
+              ? "border-2 border-accent text-accent"
+              : "border border-border text-text-muted hover:text-text hover:bg-[#1a1a1a]"
+          }`}
+        >
+          {project.name.charAt(0)}
+        </div>
+      </Link>
+      {tooltip && (
+        <div
+          className="fixed px-2 py-1 bg-bg-surface border border-border text-text text-xs whitespace-nowrap pointer-events-none z-50"
+          style={{ left: 72, top: tooltip.top, transform: "translateY(-50%)" }}
+        >
+          {project.name}
+        </div>
+      )}
+    </>
+  );
+}
+
 export default function Sidebar() {
   const pathname = usePathname();
   const [projects, setProjects] = useState<Project[]>([]);
@@ -101,26 +138,11 @@ export default function Sidebar() {
         {projects.map((project) => {
           const isActive = activeProjectId === project.id;
           return (
-            <Link
+            <ProjectIcon
               key={project.id}
-              href={`/project/${project.id}`}
-              className="relative group"
-              title={project.name}
-            >
-              <div
-                className={`w-10 h-10 flex items-center justify-center rounded-full text-xs font-semibold uppercase transition-colors ${
-                  isActive
-                    ? "border-2 border-accent text-accent"
-                    : "border border-border text-text-muted hover:text-text hover:bg-[#1a1a1a]"
-                }`}
-              >
-                {project.name.charAt(0)}
-              </div>
-              {/* Tooltip */}
-              <div className="absolute left-14 top-1/2 -translate-y-1/2 px-2 py-1 bg-bg-surface border border-border text-text text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity z-50">
-                {project.name}
-              </div>
-            </Link>
+              project={project}
+              isActive={isActive}
+            />
           );
         })}
 


### PR DESCRIPTION
## Summary
- Discord-style sidebar: 64px wide, fixed left, `#111111` surface with `1px solid #2a2a2a` border
- Home icon at top navigating to `/`, active state shows accent color
- Circular project icons from `~/.quadwork/config.json` with first-letter, hover tooltips, active project gets `#00ff88` border
- Dividers between projects and actions sections
- Dashed `+` button placeholder for add-project flow
- Settings gear at bottom navigating to `/settings`
- All SVG icons inline — no icon library
- App Router pages: `/` (home), `/project/[id]` (project dashboard), `/settings`
- Next.js API route `/api/config` reads config from `~/.quadwork/config.json`
- Sidebar persists across all pages via root layout
- `npm run build` passes clean

Fixes #4

## Test plan
- [ ] Sidebar renders at 64px with dark surface background
- [ ] Home icon navigates to `/`, highlights when active
- [ ] Project icons show first letter, tooltip on hover
- [ ] Active project shows `#00ff88` accent border
- [ ] Divider visible between projects and actions
- [ ] `+` button renders with dashed border
- [ ] Settings gear navigates to `/settings`
- [ ] `/project/[id]` route renders project placeholder
- [ ] Sidebar persists across page navigation
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)