### PR TITLE
[#5] Terminal panel component (xterm.js + node-pty)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "quadwork",
       "version": "0.1.0",
       "dependencies": {
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "express": "^5.2.1",
         "next": "16.2.1",
         "node-pty": "^1.2.0-beta.12",
@@ -2140,6 +2142,21 @@
       "optional": true,
       "os": [
         "win32"
+      ]
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
       ]
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "server": "node server/"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "express": "^5.2.1",
     "next": "16.2.1",
     "node-pty": "^1.2.0-beta.12",

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1,3 +1,5 @@
+import TerminalGrid from "@/components/TerminalGrid";
+
 interface ProjectPageProps {
   params: Promise<{ id: string }>;
 }
@@ -6,15 +8,8 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
   const { id } = await params;
 
   return (
-    <div className="flex h-full items-center justify-center">
-      <div className="text-center space-y-3">
-        <h1 className="text-2xl font-semibold tracking-tight text-text">
-          {id}
-        </h1>
-        <p className="text-sm text-text-muted">
-          Project dashboard — panels coming in #7
-        </p>
-      </div>
+    <div className="w-full h-full">
+      <TerminalGrid projectId={id} />
     </div>
   );
 }

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import TerminalPanel from "./TerminalPanel";
+
+interface Agent {
+  id: string;
+  label: string;
+}
+
+interface TerminalGridProps {
+  projectId: string;
+  agents?: Agent[];
+}
+
+const DEFAULT_AGENTS: Agent[] = [
+  { id: "t2a", label: "T2a" },
+  { id: "t2b", label: "T2b" },
+  { id: "t3", label: "T3" },
+];
+
+export default function TerminalGrid({
+  projectId,
+  agents = DEFAULT_AGENTS,
+}: TerminalGridProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  // Expect 3 agents: [0] top-left, [1] top-right, [2] bottom full-width
+  const [topLeft, topRight, bottom] = agents;
+
+  if (expanded) {
+    const agent = agents.find((a) => a.id === expanded);
+    if (!agent) return null;
+
+    return (
+      <div className="w-full h-full flex flex-col">
+        <div className="flex items-center justify-between px-3 h-7 shrink-0 border-b border-border">
+          <span className="text-[11px] text-text-muted uppercase tracking-wider">
+            {agent.label}
+          </span>
+          <button
+            onClick={() => setExpanded(null)}
+            className="text-[11px] text-text-muted hover:text-text transition-colors"
+          >
+            esc
+          </button>
+        </div>
+        <div className="flex-1 min-h-0">
+          <TerminalPanel projectId={projectId} agentId={agent.id} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full grid grid-rows-2 grid-cols-2">
+      {/* Top-left: T2a */}
+      {topLeft && (
+        <div
+          className="border-r border-b border-border flex flex-col cursor-pointer"
+          onClick={() => setExpanded(topLeft.id)}
+        >
+          <div className="flex items-center px-3 h-6 shrink-0 border-b border-border">
+            <span className="text-[11px] text-text-muted uppercase tracking-wider">
+              {topLeft.label}
+            </span>
+          </div>
+          <div className="flex-1 min-h-0">
+            <TerminalPanel projectId={projectId} agentId={topLeft.id} />
+          </div>
+        </div>
+      )}
+
+      {/* Top-right: T2b */}
+      {topRight && (
+        <div
+          className="border-b border-border flex flex-col cursor-pointer"
+          onClick={() => setExpanded(topRight.id)}
+        >
+          <div className="flex items-center px-3 h-6 shrink-0 border-b border-border">
+            <span className="text-[11px] text-text-muted uppercase tracking-wider">
+              {topRight.label}
+            </span>
+          </div>
+          <div className="flex-1 min-h-0">
+            <TerminalPanel projectId={projectId} agentId={topRight.id} />
+          </div>
+        </div>
+      )}
+
+      {/* Bottom full-width: T3 */}
+      {bottom && (
+        <div
+          className="col-span-2 flex flex-col cursor-pointer"
+          onClick={() => setExpanded(bottom.id)}
+        >
+          <div className="flex items-center px-3 h-6 shrink-0 border-b border-border">
+            <span className="text-[11px] text-text-muted uppercase tracking-wider">
+              {bottom.label}
+            </span>
+          </div>
+          <div className="flex-1 min-h-0">
+            <TerminalPanel projectId={projectId} agentId={bottom.id} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -19,91 +19,58 @@ const DEFAULT_AGENTS: Agent[] = [
   { id: "t3", label: "T3" },
 ];
 
+const GRID_CLASSES = [
+  "border-r border-b border-border", // top-left
+  "border-b border-border",          // top-right
+  "col-span-2",                      // bottom full-width
+];
+
 export default function TerminalGrid({
   projectId,
   agents = DEFAULT_AGENTS,
 }: TerminalGridProps) {
   const [expanded, setExpanded] = useState<string | null>(null);
 
-  // Expect 3 agents: [0] top-left, [1] top-right, [2] bottom full-width
-  const [topLeft, topRight, bottom] = agents;
-
-  if (expanded) {
-    const agent = agents.find((a) => a.id === expanded);
-    if (!agent) return null;
-
-    return (
-      <div className="w-full h-full flex flex-col">
-        <div className="flex items-center justify-between px-3 h-7 shrink-0 border-b border-border">
-          <span className="text-[11px] text-text-muted uppercase tracking-wider">
-            {agent.label}
-          </span>
-          <button
-            onClick={() => setExpanded(null)}
-            className="text-[11px] text-text-muted hover:text-text transition-colors"
-          >
-            esc
-          </button>
-        </div>
-        <div className="flex-1 min-h-0">
-          <TerminalPanel projectId={projectId} agentId={agent.id} />
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="w-full h-full grid grid-rows-2 grid-cols-2">
-      {/* Top-left: T2a */}
-      {topLeft && (
-        <div
-          className="border-r border-b border-border flex flex-col cursor-pointer"
-          onClick={() => setExpanded(topLeft.id)}
-        >
-          <div className="flex items-center px-3 h-6 shrink-0 border-b border-border">
-            <span className="text-[11px] text-text-muted uppercase tracking-wider">
-              {topLeft.label}
-            </span>
-          </div>
-          <div className="flex-1 min-h-0">
-            <TerminalPanel projectId={projectId} agentId={topLeft.id} />
-          </div>
-        </div>
-      )}
+    <div className="w-full h-full relative grid grid-rows-2 grid-cols-2">
+      {agents.map((agent, i) => {
+        const isExpanded = expanded === agent.id;
+        const isHidden = expanded !== null && !isExpanded;
 
-      {/* Top-right: T2b */}
-      {topRight && (
-        <div
-          className="border-b border-border flex flex-col cursor-pointer"
-          onClick={() => setExpanded(topRight.id)}
-        >
-          <div className="flex items-center px-3 h-6 shrink-0 border-b border-border">
-            <span className="text-[11px] text-text-muted uppercase tracking-wider">
-              {topRight.label}
-            </span>
+        return (
+          <div
+            key={agent.id}
+            className={`flex flex-col ${
+              isExpanded
+                ? "absolute inset-0 z-10 bg-bg"
+                : `${GRID_CLASSES[i] || ""}`
+            }`}
+            style={isHidden ? { visibility: "hidden", overflow: "hidden" } : undefined}
+          >
+            <div
+              className={`flex items-center px-3 shrink-0 border-b border-border ${
+                isExpanded ? "h-7 justify-between" : "h-6 cursor-pointer"
+              }`}
+              onClick={isExpanded ? undefined : () => setExpanded(agent.id)}
+            >
+              <span className="text-[11px] text-text-muted uppercase tracking-wider">
+                {agent.label}
+              </span>
+              {isExpanded && (
+                <button
+                  onClick={() => setExpanded(null)}
+                  className="text-[11px] text-text-muted hover:text-text transition-colors"
+                >
+                  esc
+                </button>
+              )}
+            </div>
+            <div className="flex-1 min-h-0">
+              <TerminalPanel projectId={projectId} agentId={agent.id} />
+            </div>
           </div>
-          <div className="flex-1 min-h-0">
-            <TerminalPanel projectId={projectId} agentId={topRight.id} />
-          </div>
-        </div>
-      )}
-
-      {/* Bottom full-width: T3 */}
-      {bottom && (
-        <div
-          className="col-span-2 flex flex-col cursor-pointer"
-          onClick={() => setExpanded(bottom.id)}
-        >
-          <div className="flex items-center px-3 h-6 shrink-0 border-b border-border">
-            <span className="text-[11px] text-text-muted uppercase tracking-wider">
-              {bottom.label}
-            </span>
-          </div>
-          <div className="flex-1 min-h-0">
-            <TerminalPanel projectId={projectId} agentId={bottom.id} />
-          </div>
-        </div>
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import "@xterm/xterm/css/xterm.css";
+
+interface TerminalPanelProps {
+  projectId: string;
+  agentId: string;
+  /** WebSocket server base URL */
+  wsUrl?: string;
+}
+
+export default function TerminalPanel({
+  projectId,
+  agentId,
+  wsUrl = "ws://localhost:3001",
+}: TerminalPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const fit = useCallback(() => {
+    if (fitRef.current && termRef.current && containerRef.current) {
+      try {
+        fitRef.current.fit();
+        // Notify backend of new dimensions
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(
+            JSON.stringify({
+              type: "resize",
+              cols: termRef.current.cols,
+              rows: termRef.current.rows,
+            })
+          );
+        }
+      } catch {
+        // Container not visible yet
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const term = new Terminal({
+      scrollback: 1000,
+      fontSize: 13,
+      fontFamily: "var(--font-geist-mono), ui-monospace, monospace",
+      cursorBlink: false,
+      cursorStyle: "block",
+      theme: {
+        background: "#0a0a0a",
+        foreground: "#e0e0e0",
+        cursor: "#00ff88",
+        cursorAccent: "#0a0a0a",
+        selectionBackground: "#00ff8844",
+        black: "#0a0a0a",
+        red: "#ff4444",
+        green: "#00ff88",
+        yellow: "#ffcc00",
+        blue: "#4488ff",
+        magenta: "#cc44ff",
+        cyan: "#44ccff",
+        white: "#e0e0e0",
+        brightBlack: "#737373",
+        brightRed: "#ff6666",
+        brightGreen: "#00ff88",
+        brightYellow: "#ffdd44",
+        brightBlue: "#66aaff",
+        brightMagenta: "#dd66ff",
+        brightCyan: "#66ddff",
+        brightWhite: "#ffffff",
+      },
+      allowTransparency: false,
+      drawBoldTextInBrightColors: true,
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(containerRef.current);
+
+    termRef.current = term;
+    fitRef.current = fitAddon;
+
+    // Initial fit
+    requestAnimationFrame(() => fit());
+
+    // Connect WebSocket
+    const endpoint = `${wsUrl}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}`;
+    const ws = new WebSocket(endpoint);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      // Send initial dimensions
+      ws.send(
+        JSON.stringify({
+          type: "resize",
+          cols: term.cols,
+          rows: term.rows,
+        })
+      );
+    };
+
+    ws.onmessage = (e) => {
+      term.write(e.data);
+    };
+
+    ws.onclose = (e) => {
+      term.write(`\r\n\x1b[38;2;115;115;115m[session closed: ${e.reason || e.code}]\x1b[0m\r\n`);
+    };
+
+    // Terminal input → WebSocket
+    term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(data);
+      }
+    });
+
+    // Resize observer
+    const observer = new ResizeObserver(() => fit());
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+      ws.close();
+      term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+      wsRef.current = null;
+    };
+  }, [projectId, agentId, wsUrl, fit]);
+
+  return <div ref={containerRef} className="w-full h-full" />;
+}

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -15,7 +15,7 @@ interface TerminalPanelProps {
 export default function TerminalPanel({
   projectId,
   agentId,
-  wsUrl = "ws://localhost:3001",
+  wsUrl,
 }: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -89,44 +89,64 @@ export default function TerminalPanel({
     // Initial fit
     requestAnimationFrame(() => fit());
 
-    // Connect WebSocket
-    const endpoint = `${wsUrl}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}`;
-    const ws = new WebSocket(endpoint);
-    wsRef.current = ws;
-
-    ws.onopen = () => {
-      // Send initial dimensions
-      ws.send(
-        JSON.stringify({
-          type: "resize",
-          cols: term.cols,
-          rows: term.rows,
-        })
-      );
-    };
-
-    ws.onmessage = (e) => {
-      term.write(e.data);
-    };
-
-    ws.onclose = (e) => {
-      term.write(`\r\n\x1b[38;2;115;115;115m[session closed: ${e.reason || e.code}]\x1b[0m\r\n`);
-    };
-
-    // Terminal input → WebSocket
-    term.onData((data) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(data);
-      }
-    });
-
     // Resize observer
     const observer = new ResizeObserver(() => fit());
     observer.observe(containerRef.current);
 
+    // Connect WebSocket — resolve backend URL from config if not provided
+    let cancelled = false;
+
+    (async () => {
+      let base = wsUrl;
+      if (!base) {
+        try {
+          const res = await fetch("/api/config");
+          if (res.ok) {
+            const cfg = await res.json();
+            const port = cfg.port || 3001;
+            base = `ws://${window.location.hostname}:${port}`;
+          } else {
+            base = `ws://${window.location.hostname}:3001`;
+          }
+        } catch {
+          base = `ws://${window.location.hostname}:3001`;
+        }
+      }
+      if (cancelled) return;
+
+      const endpoint = `${base}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}`;
+      const ws = new WebSocket(endpoint);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        ws.send(
+          JSON.stringify({
+            type: "resize",
+            cols: term.cols,
+            rows: term.rows,
+          })
+        );
+      };
+
+      ws.onmessage = (e) => {
+        term.write(e.data);
+      };
+
+      ws.onclose = (e) => {
+        term.write(`\r\n\x1b[38;2;115;115;115m[session closed: ${e.reason || e.code}]\x1b[0m\r\n`);
+      };
+
+      term.onData((data) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(data);
+        }
+      });
+    })();
+
     return () => {
+      cancelled = true;
       observer.disconnect();
-      ws.close();
+      wsRef.current?.close();
       term.dispose();
       termRef.current = null;
       fitRef.current = null;


### PR DESCRIPTION
## Summary
- Reusable `TerminalPanel` component: renders xterm.js terminal with bidirectional WebSocket PTY I/O
- Auto-fit on mount and resize via `ResizeObserver` + `FitAddon`, sends resize events to backend
- 1000-line scrollback, block cursor `#00ff88`, Geist Mono 13px, custom color theme
- `TerminalGrid` component: Panel 4 split layout — T2a (top-left), T2b (top-right), T3 (bottom full-width)
- Click any sub-pane to expand to full panel, click "esc" to collapse back
- Muted uppercase agent-name labels, `1px solid #2a2a2a` sub-pane borders
- Uses `@xterm/xterm` (non-deprecated) + `@xterm/addon-fit`
- `npm run build` passes clean

Fixes #5

## Test plan
- [ ] `TerminalPanel` renders xterm.js terminal in container
- [ ] WebSocket connects to `ws://localhost:3001/ws/terminal?project=X&agent=Y`
- [ ] Typing in terminal sends input to PTY, output streams back
- [ ] Terminal auto-fits on container resize
- [ ] `TerminalGrid` shows 3 sub-panes in 2x2 grid layout
- [ ] Agent labels visible at top of each sub-pane
- [ ] Clicking sub-pane expands to full panel
- [ ] Clicking "esc" collapses back to grid view
- [ ] Design matches spec: bg, cursor color, font, borders
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)