### PR TITLE
[#6] T1 terminal panel (Panel 1)

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1,4 +1,4 @@
-import TerminalGrid from "@/components/TerminalGrid";
+import ProjectDashboard from "@/components/ProjectDashboard";
 
 interface ProjectPageProps {
   params: Promise<{ id: string }>;
@@ -9,7 +9,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
 
   return (
     <div className="w-full h-full">
-      <TerminalGrid projectId={id} />
+      <ProjectDashboard projectId={id} />
     </div>
   );
 }

--- a/src/components/PanelHeader.tsx
+++ b/src/components/PanelHeader.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+interface PanelHeaderProps {
+  label: string;
+  status?: "running" | "stopped" | "error";
+}
+
+export default function PanelHeader({ label, status }: PanelHeaderProps) {
+  const dotColor =
+    status === "running"
+      ? "bg-accent"
+      : status === "error"
+        ? "bg-error"
+        : "bg-text-muted";
+
+  return (
+    <div className="flex items-center gap-2 px-3 h-7 shrink-0 border-b border-border">
+      {status && (
+        <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+      )}
+      <span className="text-[11px] text-text-muted uppercase tracking-wider">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import TerminalPanel from "./TerminalPanel";
+import TerminalGrid from "./TerminalGrid";
+import PanelHeader from "./PanelHeader";
+
+interface ProjectDashboardProps {
+  projectId: string;
+}
+
+export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
+  return (
+    <div className="w-full h-full grid grid-cols-2 grid-rows-2">
+      {/* Panel 1: T1 terminal — top-left, full left column height */}
+      <div className="row-span-2 border-r border-border flex flex-col">
+        <PanelHeader label="T1" status="running" />
+        <div className="flex-1 min-h-0">
+          <TerminalPanel projectId={projectId} agentId="t1" />
+        </div>
+      </div>
+
+      {/* Panel 2: placeholder — top-right */}
+      <div className="border-b border-border flex flex-col">
+        <PanelHeader label="Panel 2" />
+        <div className="flex-1 min-h-0 flex items-center justify-center">
+          <span className="text-xs text-text-muted">GitHub — coming in #9</span>
+        </div>
+      </div>
+
+      {/* Panel 3: placeholder — bottom-left (occupied by Panel 1 row-span) */}
+      {/* Panel 4: Agent terminals — bottom-right */}
+      <div className="flex flex-col">
+        <PanelHeader label="Panel 4" />
+        <div className="flex-1 min-h-0">
+          <TerminalGrid projectId={projectId} />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `ProjectDashboard` component: 2x2 grid layout for the project page
- Panel 1 (top-left, spans full left column): T1 terminal with `PanelHeader` showing green running-status dot
- Panel 2 (top-right): placeholder for GitHub panel (#9)
- Panel 4 (bottom-right): existing `TerminalGrid` with T2a/T2b/T3 agents
- Reusable `PanelHeader` component: label + optional status indicator (running/stopped/error)
- T1 connects to backend PTY via existing `TerminalPanel` component
- `npm run build` passes clean

Fixes #6

## Test plan
- [ ] Project page renders 2x2 grid layout
- [ ] Panel 1 spans full left column height
- [ ] T1 header shows "T1" label with green dot
- [ ] T1 terminal connects to PTY session and I/O works
- [ ] Panel 4 still renders TerminalGrid with T2a/T2b/T3
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)