### PR TITLE
[#9] GitHub issues + PRs panel (Panel 2)

### DIFF
--- a/src/app/api/github/issues/route.ts
+++ b/src/app/api/github/issues/route.ts
@@ -1,17 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
 
 const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+const REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 
 function getRepo(projectId: string): string | null {
   try {
     const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
     const cfg = JSON.parse(raw);
     const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
-    return project?.repo || null;
+    const repo = project?.repo;
+    if (repo && REPO_RE.test(repo)) return repo;
+    return null;
   } catch {
     return null;
   }
@@ -26,8 +29,9 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const out = execSync(
-      `gh issue list -R ${repo} --json number,title,state,assignees,labels,createdAt,url --limit 50`,
+    const out = execFileSync(
+      "gh",
+      ["issue", "list", "-R", repo, "--json", "number,title,state,assignees,labels,createdAt,url", "--limit", "50"],
       { encoding: "utf-8", timeout: 15000 }
     );
     return NextResponse.json(JSON.parse(out));

--- a/src/app/api/github/issues/route.ts
+++ b/src/app/api/github/issues/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+function getRepo(projectId: string): string | null {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    const cfg = JSON.parse(raw);
+    const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
+    return project?.repo || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const projectId = req.nextUrl.searchParams.get("project") || "";
+  const repo = getRepo(projectId);
+
+  if (!repo) {
+    return NextResponse.json({ error: "No repo configured for project" }, { status: 400 });
+  }
+
+  try {
+    const out = execSync(
+      `gh issue list -R ${repo} --json number,title,state,assignees,labels,createdAt,url --limit 50`,
+      { encoding: "utf-8", timeout: 15000 }
+    );
+    return NextResponse.json(JSON.parse(out));
+  } catch (err) {
+    return NextResponse.json(
+      { error: "gh issue list failed", detail: err instanceof Error ? err.message : String(err) },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/api/github/prs/route.ts
+++ b/src/app/api/github/prs/route.ts
@@ -1,17 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
 
 const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+const REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 
 function getRepo(projectId: string): string | null {
   try {
     const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
     const cfg = JSON.parse(raw);
     const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
-    return project?.repo || null;
+    const repo = project?.repo;
+    if (repo && REPO_RE.test(repo)) return repo;
+    return null;
   } catch {
     return null;
   }
@@ -26,8 +29,9 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const out = execSync(
-      `gh pr list -R ${repo} --json number,title,state,author,assignees,reviewDecision,statusCheckRollup,url,createdAt --limit 50`,
+    const out = execFileSync(
+      "gh",
+      ["pr", "list", "-R", repo, "--json", "number,title,state,author,assignees,reviews,statusCheckRollup,url,createdAt", "--limit", "50"],
       { encoding: "utf-8", timeout: 15000 }
     );
     return NextResponse.json(JSON.parse(out));

--- a/src/app/api/github/prs/route.ts
+++ b/src/app/api/github/prs/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+function getRepo(projectId: string): string | null {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    const cfg = JSON.parse(raw);
+    const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
+    return project?.repo || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const projectId = req.nextUrl.searchParams.get("project") || "";
+  const repo = getRepo(projectId);
+
+  if (!repo) {
+    return NextResponse.json({ error: "No repo configured for project" }, { status: 400 });
+  }
+
+  try {
+    const out = execSync(
+      `gh pr list -R ${repo} --json number,title,state,author,assignees,reviewDecision,statusCheckRollup,url,createdAt --limit 50`,
+      { encoding: "utf-8", timeout: 15000 }
+    );
+    return NextResponse.json(JSON.parse(out));
+  } catch (err) {
+    return NextResponse.json(
+      { error: "gh pr list failed", detail: err instanceof Error ? err.message : String(err) },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/api/github/prs/route.ts
+++ b/src/app/api/github/prs/route.ts
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
   try {
     const out = execFileSync(
       "gh",
-      ["pr", "list", "-R", repo, "--json", "number,title,state,author,assignees,reviews,statusCheckRollup,url,createdAt", "--limit", "50"],
+      ["pr", "list", "-R", repo, "--json", "number,title,state,author,assignees,reviewDecision,reviews,statusCheckRollup,url,createdAt", "--limit", "50"],
       { encoding: "utf-8", timeout: 15000 }
     );
     return NextResponse.json(JSON.parse(out));

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -10,13 +10,18 @@ interface Issue {
   url: string;
 }
 
+interface Review {
+  author: { login: string };
+  state: string;
+}
+
 interface PR {
   number: number;
   title: string;
   state: string;
   author: { login: string };
   assignees: { login: string }[];
-  reviewDecision: string;
+  reviews: Review[];
   statusCheckRollup: { state: string }[];
   url: string;
 }
@@ -128,28 +133,54 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
       {prs.length === 0 && (
         <div className="px-3 py-2 text-[11px] text-text-muted">No PRs</div>
       )}
-      {prs.map((pr) => (
-        <a
-          key={pr.number}
-          href={pr.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 px-3 py-1 hover:bg-[#1a1a1a] transition-colors cursor-pointer border-b border-border/50"
-        >
-          <StatusDot color={reviewColor(pr.reviewDecision)} />
-          <span className="text-[11px] text-text-muted w-8 shrink-0">#{pr.number}</span>
-          <span className="text-[11px] text-text truncate flex-1 min-w-0">{pr.title}</span>
-          <span className="text-[10px] text-text-muted shrink-0">
-            {pr.author?.login}
-          </span>
-          <span className={`text-[10px] shrink-0 ${reviewColor(pr.reviewDecision).replace("bg-", "text-")}`}>
-            {reviewLabel(pr.reviewDecision)}
-          </span>
-          <span className={`text-[10px] shrink-0 ${ciColor(pr.statusCheckRollup)}`}>
-            {ciLabel(pr.statusCheckRollup)}
-          </span>
-        </a>
-      ))}
+      {prs.map((pr) => {
+        // Extract latest review state per reviewer
+        const reviewerStates: Record<string, string> = {};
+        (pr.reviews || []).forEach((r: Review) => {
+          if (r.author?.login) reviewerStates[r.author.login] = r.state;
+        });
+        // Compute overall review status from individual reviews
+        const reviewValues = Object.values(reviewerStates);
+        const overallReview = reviewValues.some((s) => s === "CHANGES_REQUESTED")
+          ? "CHANGES_REQUESTED"
+          : reviewValues.every((s) => s === "APPROVED") && reviewValues.length > 0
+            ? "APPROVED"
+            : "REVIEW_REQUIRED";
+
+        return (
+          <a
+            key={pr.number}
+            href={pr.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-3 py-1 hover:bg-[#1a1a1a] transition-colors cursor-pointer border-b border-border/50"
+          >
+            <StatusDot color={reviewColor(overallReview)} />
+            <span className="text-[11px] text-text-muted w-8 shrink-0">#{pr.number}</span>
+            <span className="text-[11px] text-text truncate flex-1 min-w-0">{pr.title}</span>
+            {pr.assignees?.[0] && (
+              <span className="text-[10px] text-text-muted shrink-0">
+                {pr.assignees[0].login}
+              </span>
+            )}
+            {/* Per-reviewer status */}
+            {Object.entries(reviewerStates).map(([login, state]) => (
+              <span
+                key={login}
+                className={`text-[10px] shrink-0 ${reviewColor(state).replace("bg-", "text-")}`}
+              >
+                {login.replace(/^.*-/, "")}:{reviewLabel(state)}
+              </span>
+            ))}
+            {Object.keys(reviewerStates).length === 0 && (
+              <span className="text-[10px] text-[#ffcc00] shrink-0">rev</span>
+            )}
+            <span className={`text-[10px] shrink-0 ${ciColor(pr.statusCheckRollup)}`}>
+              {ciLabel(pr.statusCheckRollup)}
+            </span>
+          </a>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -21,6 +21,7 @@ interface PR {
   state: string;
   author: { login: string };
   assignees: { login: string }[];
+  reviewDecision: string;
   reviews: Review[];
   statusCheckRollup: { state: string }[];
   url: string;
@@ -134,18 +135,10 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
         <div className="px-3 py-2 text-[11px] text-text-muted">No PRs</div>
       )}
       {prs.map((pr) => {
-        // Extract latest review state per reviewer
-        const reviewerStates: Record<string, string> = {};
-        (pr.reviews || []).forEach((r: Review) => {
-          if (r.author?.login) reviewerStates[r.author.login] = r.state;
-        });
-        // Compute overall review status from individual reviews
-        const reviewValues = Object.values(reviewerStates);
-        const overallReview = reviewValues.some((s) => s === "CHANGES_REQUESTED")
-          ? "CHANGES_REQUESTED"
-          : reviewValues.every((s) => s === "APPROVED") && reviewValues.length > 0
-            ? "APPROVED"
-            : "REVIEW_REQUIRED";
+        const reviews = pr.reviews || [];
+        const approvals = reviews.filter((r) => r.state === "APPROVED").length;
+        const changes = reviews.filter((r) => r.state === "CHANGES_REQUESTED").length;
+        const decision = pr.reviewDecision || "REVIEW_REQUIRED";
 
         return (
           <a
@@ -155,7 +148,7 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
             rel="noopener noreferrer"
             className="flex items-center gap-2 px-3 py-1 hover:bg-[#1a1a1a] transition-colors cursor-pointer border-b border-border/50"
           >
-            <StatusDot color={reviewColor(overallReview)} />
+            <StatusDot color={reviewColor(decision)} />
             <span className="text-[11px] text-text-muted w-8 shrink-0">#{pr.number}</span>
             <span className="text-[11px] text-text truncate flex-1 min-w-0">{pr.title}</span>
             {pr.assignees?.[0] && (
@@ -163,18 +156,14 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
                 {pr.assignees[0].login}
               </span>
             )}
-            {/* Per-reviewer status */}
-            {Object.entries(reviewerStates).map(([login, state]) => (
-              <span
-                key={login}
-                className={`text-[10px] shrink-0 ${reviewColor(state).replace("bg-", "text-")}`}
-              >
-                {login.replace(/^.*-/, "")}:{reviewLabel(state)}
-              </span>
-            ))}
-            {Object.keys(reviewerStates).length === 0 && (
-              <span className="text-[10px] text-[#ffcc00] shrink-0">rev</span>
-            )}
+            {/* Review summary: approvals / changes requested */}
+            <span className={`text-[10px] shrink-0 ${reviewColor(decision).replace("bg-", "text-")}`}>
+              {changes > 0
+                ? `${changes}chg`
+                : approvals > 0
+                  ? `${approvals}ok`
+                  : "rev"}
+            </span>
             <span className={`text-[10px] shrink-0 ${ciColor(pr.statusCheckRollup)}`}>
               {ciLabel(pr.statusCheckRollup)}
             </span>

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Issue {
+  number: number;
+  title: string;
+  state: string;
+  assignees: { login: string }[];
+  url: string;
+}
+
+interface PR {
+  number: number;
+  title: string;
+  state: string;
+  author: { login: string };
+  assignees: { login: string }[];
+  reviewDecision: string;
+  statusCheckRollup: { state: string }[];
+  url: string;
+}
+
+function StatusDot({ color }: { color: string }) {
+  return <span className={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${color}`} />;
+}
+
+function issueStatusColor(state: string): string {
+  return state === "OPEN" ? "bg-accent" : "bg-error";
+}
+
+function reviewColor(decision: string): string {
+  if (decision === "APPROVED") return "bg-accent";
+  if (decision === "CHANGES_REQUESTED") return "bg-error";
+  return "bg-[#ffcc00]";
+}
+
+function reviewLabel(decision: string): string {
+  if (decision === "APPROVED") return "ok";
+  if (decision === "CHANGES_REQUESTED") return "chg";
+  return "rev";
+}
+
+function ciColor(rollup: { state: string }[]): string {
+  if (!rollup || rollup.length === 0) return "text-text-muted";
+  const states = rollup.map((c) => c.state);
+  if (states.every((s) => s === "SUCCESS")) return "text-accent";
+  if (states.some((s) => s === "FAILURE" || s === "ERROR")) return "text-error";
+  return "text-[#ffcc00]";
+}
+
+function ciLabel(rollup: { state: string }[]): string {
+  if (!rollup || rollup.length === 0) return "—";
+  const states = rollup.map((c) => c.state);
+  if (states.every((s) => s === "SUCCESS")) return "pass";
+  if (states.some((s) => s === "FAILURE" || s === "ERROR")) return "fail";
+  return "run";
+}
+
+interface GitHubPanelProps {
+  projectId: string;
+}
+
+export default function GitHubPanel({ projectId }: GitHubPanelProps) {
+  const [issues, setIssues] = useState<Issue[]>([]);
+  const [prs, setPrs] = useState<PR[]>([]);
+
+  const fetchData = useCallback(() => {
+    fetch(`/api/github/issues?project=${encodeURIComponent(projectId)}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
+      .then((data) => { if (Array.isArray(data)) setIssues(data); })
+      .catch(() => {});
+
+    fetch(`/api/github/prs?project=${encodeURIComponent(projectId)}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
+      .then((data) => { if (Array.isArray(data)) setPrs(data); })
+      .catch(() => {});
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 30000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      {/* Issues */}
+      <div className="px-3 py-1.5 border-b border-border">
+        <span className="text-[10px] text-text-muted uppercase tracking-wider">
+          Issues ({issues.length})
+        </span>
+      </div>
+      {issues.length === 0 && (
+        <div className="px-3 py-2 text-[11px] text-text-muted">No issues</div>
+      )}
+      {issues.map((issue) => (
+        <a
+          key={issue.number}
+          href={issue.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 px-3 py-1 hover:bg-[#1a1a1a] transition-colors cursor-pointer border-b border-border/50"
+        >
+          <StatusDot color={issueStatusColor(issue.state)} />
+          <span className="text-[11px] text-text-muted w-8 shrink-0">#{issue.number}</span>
+          <span className="text-[11px] text-text truncate flex-1 min-w-0">{issue.title}</span>
+          {issue.assignees?.[0] && (
+            <span className="text-[10px] text-text-muted shrink-0">
+              {issue.assignees[0].login}
+            </span>
+          )}
+        </a>
+      ))}
+
+      {/* PRs */}
+      <div className="px-3 py-1.5 border-b border-border mt-1">
+        <span className="text-[10px] text-text-muted uppercase tracking-wider">
+          Pull Requests ({prs.length})
+        </span>
+      </div>
+      {prs.length === 0 && (
+        <div className="px-3 py-2 text-[11px] text-text-muted">No PRs</div>
+      )}
+      {prs.map((pr) => (
+        <a
+          key={pr.number}
+          href={pr.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 px-3 py-1 hover:bg-[#1a1a1a] transition-colors cursor-pointer border-b border-border/50"
+        >
+          <StatusDot color={reviewColor(pr.reviewDecision)} />
+          <span className="text-[11px] text-text-muted w-8 shrink-0">#{pr.number}</span>
+          <span className="text-[11px] text-text truncate flex-1 min-w-0">{pr.title}</span>
+          <span className="text-[10px] text-text-muted shrink-0">
+            {pr.author?.login}
+          </span>
+          <span className={`text-[10px] shrink-0 ${reviewColor(pr.reviewDecision).replace("bg-", "text-")}`}>
+            {reviewLabel(pr.reviewDecision)}
+          </span>
+          <span className={`text-[10px] shrink-0 ${ciColor(pr.statusCheckRollup)}`}>
+            {ciLabel(pr.statusCheckRollup)}
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -13,6 +13,7 @@ interface Issue {
 interface Review {
   author: { login: string };
   state: string;
+  body: string;
 }
 
 interface PR {
@@ -136,9 +137,19 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
       )}
       {prs.map((pr) => {
         const reviews = pr.reviews || [];
-        const approvals = reviews.filter((r) => r.state === "APPROVED").length;
-        const changes = reviews.filter((r) => r.state === "CHANGES_REQUESTED").length;
         const decision = pr.reviewDecision || "REVIEW_REQUIRED";
+
+        // Extract per-agent review status from body text
+        // Reviews start with "T2a" or "T2b", or contain "## Verdict:" (T2a format)
+        const agentStatus: Record<string, string> = {};
+        for (const r of reviews) {
+          const body = (r.body || "").trim();
+          if (/^T2b\b/i.test(body)) {
+            agentStatus["t2b"] = r.state;
+          } else if (/^T2a\b/i.test(body) || /^##\s*Verdict/i.test(body)) {
+            agentStatus["t2a"] = r.state;
+          }
+        }
 
         return (
           <a
@@ -156,14 +167,22 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
                 {pr.assignees[0].login}
               </span>
             )}
-            {/* Review summary: approvals / changes requested */}
-            <span className={`text-[10px] shrink-0 ${reviewColor(decision).replace("bg-", "text-")}`}>
-              {changes > 0
-                ? `${changes}chg`
-                : approvals > 0
-                  ? `${approvals}ok`
-                  : "rev"}
-            </span>
+            {/* Per-agent review slots */}
+            {["t2a", "t2b"].map((agent) => {
+              const state = agentStatus[agent];
+              return (
+                <span
+                  key={agent}
+                  className={`text-[10px] shrink-0 ${
+                    state
+                      ? reviewColor(state).replace("bg-", "text-")
+                      : "text-text-muted"
+                  }`}
+                >
+                  {agent}:{state ? reviewLabel(state) : "—"}
+                </span>
+              );
+            })}
             <span className={`text-[10px] shrink-0 ${ciColor(pr.statusCheckRollup)}`}>
               {ciLabel(pr.statusCheckRollup)}
             </span>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -5,6 +5,7 @@ import TerminalPanel from "./TerminalPanel";
 import TerminalGrid from "./TerminalGrid";
 import PanelHeader from "./PanelHeader";
 import ChatPanel from "./ChatPanel";
+import GitHubPanel from "./GitHubPanel";
 
 const MIN_SIZE = 150; // px
 const DIVIDER = 4; // px
@@ -94,9 +95,9 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
 
       {/* Panel 2: GitHub placeholder — top-right */}
       <div className="flex flex-col overflow-hidden">
-        <PanelHeader label="Panel 2" />
-        <div className="flex-1 min-h-0 flex items-center justify-center">
-          <span className="text-xs text-text-muted">GitHub — #9</span>
+        <PanelHeader label="GitHub" />
+        <div className="flex-1 min-h-0">
+          <GitHubPanel projectId={projectId} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Backend API routes: `GET /api/github/issues` and `GET /api/github/prs` shell out to `gh` CLI
- Repo sourced from `~/.quadwork/config.json` project settings (`project.repo`)
- `GitHubPanel` component: two-section list — Issues and Pull Requests
- Issue rows: status dot (green=open, red=closed), number, title, assignee
- PR rows: review status dot (green=approved, yellow=pending, red=changes), number, title, author, review label, CI status
- Click any row opens GitHub URL in new tab
- Auto-refresh every 30 seconds
- Mounted in Panel 2 (top-right) of `ProjectDashboard`
- `npm run build` passes clean

Fixes #9

## Test plan
- [ ] Issues section shows issues from configured repo
- [ ] PR section shows PRs with review + CI status
- [ ] Status dots: green for open/approved/passing, yellow for pending, red for closed/changes/failing
- [ ] Clicking a row opens GitHub in new tab
- [ ] Data refreshes every 30 seconds
- [ ] Handles missing repo config (returns 400)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)