### PR TITLE
[#10] Main dashboard home page

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,18 @@ app.get("/api/config", (_req, res) => {
   res.json(cfg);
 });
 
+// --- Active sessions tracking ---
+
+const activeSessions = new Map(); // key: "project/agent" → { projectId, agentId }
+
+app.get("/api/sessions", (_req, res) => {
+  const sessions = [];
+  for (const [, info] of activeSessions) {
+    sessions.push(info);
+  }
+  res.json(sessions);
+});
+
 // --- WebSocket + PTY ---
 
 const wss = new WebSocketServer({ server, path: "/ws/terminal" });
@@ -41,6 +53,9 @@ wss.on("connection", (ws, req) => {
     ws.close(1008, `unknown project/agent: ${projectId}/${agentId}`);
     return;
   }
+
+  const sessionKey = `${projectId}/${agentId}`;
+  activeSessions.set(sessionKey, { projectId, agentId });
 
   let term;
   try {
@@ -89,6 +104,7 @@ wss.on("connection", (ws, req) => {
   });
 
   ws.on("close", () => {
+    activeSessions.delete(sessionKey);
     term.kill();
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -55,7 +55,6 @@ wss.on("connection", (ws, req) => {
   }
 
   const sessionKey = `${projectId}/${agentId}`;
-  activeSessions.set(sessionKey, { projectId, agentId });
 
   let term;
   try {
@@ -71,6 +70,9 @@ wss.on("connection", (ws, req) => {
     ws.close(1011, "pty-spawn-failed");
     return;
   }
+
+  // Register session only after successful PTY spawn
+  activeSessions.set(sessionKey, { projectId, agentId });
 
   // PTY → client
   term.onData((data) => {

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -29,6 +29,27 @@ function getConfig(): ChattrConfig {
   }
 }
 
+let backendAlive: boolean | null = null;
+
+function checkBackendAlive(projectId: string): "active" | "idle" {
+  // Cache the backend check for all projects in one request
+  if (backendAlive === null) {
+    try {
+      const cfg = getConfig();
+      const port = (cfg as unknown as { port?: number }).port || 3001;
+      execFileSync("curl", ["-sf", "--max-time", "1", `http://127.0.0.1:${port}/api/health`], {
+        encoding: "utf-8",
+        timeout: 2000,
+      });
+      backendAlive = true;
+    } catch {
+      backendAlive = false;
+    }
+  }
+  void projectId;
+  return backendAlive ? "active" : "idle";
+}
+
 function ghJson(args: string[]): unknown[] {
   try {
     const out = execFileSync("gh", args, { encoding: "utf-8", timeout: 15000 });
@@ -79,6 +100,7 @@ function getProjectData(repo: string, agents: Record<string, unknown> | undefine
 }
 
 export async function GET() {
+  backendAlive = null; // Reset per-request
   const cfg = getConfig();
 
   // Fetch chat messages for activity feed (has correct agent names)
@@ -101,8 +123,9 @@ export async function GET() {
       repo: p.repo,
       agentCount: p.agents ? Object.keys(p.agents).length : 0,
       openPrs: data.openPrs,
-      // Active = project has agents configured (running state assumed when dashboard is in use)
-      state: hasAgents ? "active" : "idle",
+      // Active = backend server has active PTY sessions for this project
+      // True process monitoring comes in #12 (agent lifecycle); for now check backend health
+      state: hasAgents ? checkBackendAlive(p.id) : "idle",
       lastActivity: data.lastActivity,
     };
   });
@@ -112,8 +135,8 @@ export async function GET() {
     time: m.time,
     text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
     actor: m.sender,
-    // Try to match project by repo mention in message
-    projectName: cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name || cfg.projects[0]?.name || "",
+    // Match project by repo or name mention in message text
+    projectName: cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name || "",
   }));
 
   return NextResponse.json({ projects, recentEvents });

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -142,7 +142,9 @@ export async function GET() {
     text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
     actor: m.sender,
     // Match project by repo or name mention in message text
-    projectName: cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name || "",
+    // If only one project configured, attribute all workflow messages to it
+    projectName: cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name
+      || (cfg.projects.length === 1 ? cfg.projects[0].name : "general"),
   }));
 
   return NextResponse.json({ projects, recentEvents });

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -120,16 +120,20 @@ export async function GET() {
     .slice(-10)
     .reverse();
 
-  // Build PR-number-to-project mapping for activity attribution
-  const prToProject: Record<number, string> = {};
+  // Build number-to-project mapping for activity attribution (issues + PRs share namespace)
+  const numberToProject: Record<number, string> = {};
   const projectResults = cfg.projects.map((p: ProjectConfig) => {
     const data = getProjectData(p.repo, p.agents);
     const hasAgents = p.agents && Object.keys(p.agents).length > 0;
 
-    // Map PR numbers to this project
     if (REPO_RE.test(p.repo)) {
+      // Map PR numbers to this project
       const allPrs = ghJson(["pr", "list", "-R", p.repo, "--state", "all", "--json", "number", "--limit", "100"]) as { number: number }[];
-      for (const pr of allPrs) prToProject[pr.number] = p.name;
+      for (const pr of allPrs) numberToProject[pr.number] = p.name;
+
+      // Map issue numbers to this project (branch task/N uses issue numbers)
+      const allIssues = ghJson(["issue", "list", "-R", p.repo, "--state", "all", "--json", "number", "--limit", "100"]) as { number: number }[];
+      for (const issue of allIssues) numberToProject[issue.number] = p.name;
     }
 
     return {
@@ -155,7 +159,7 @@ export async function GET() {
     if (!projectName) {
       const numMatch = m.text.match(/#(\d+)/);
       if (numMatch) {
-        projectName = prToProject[parseInt(numMatch[1], 10)];
+        projectName = numberToProject[parseInt(numMatch[1], 10)];
       }
     }
 
@@ -163,7 +167,7 @@ export async function GET() {
     if (!projectName) {
       const branchMatch = m.text.match(/task\/(\d+)/);
       if (branchMatch) {
-        projectName = prToProject[parseInt(branchMatch[1], 10)];
+        projectName = numberToProject[parseInt(branchMatch[1], 10)];
       }
     }
 

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -144,15 +144,26 @@ export async function GET() {
   });
 
   // Build activity feed from chat with correct agent identities
-  const recentEvents = workflowMsgs.map((m) => {
-    // Try direct repo/name match first
+  // Attribution: repo/name match → PR/issue number → branch task/N pattern → single-project fallback
+  // Only include events that can be attributed to a project
+  const recentEvents: { time: string; text: string; actor: string; projectName: string }[] = [];
+
+  for (const m of workflowMsgs) {
     let projectName = cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name;
 
-    // Try PR number cross-reference: match "#N" or "PR #N" or "#N "
+    // Try PR/issue number cross-reference
     if (!projectName) {
-      const prMatch = m.text.match(/#(\d+)/);
-      if (prMatch) {
-        projectName = prToProject[parseInt(prMatch[1], 10)];
+      const numMatch = m.text.match(/#(\d+)/);
+      if (numMatch) {
+        projectName = prToProject[parseInt(numMatch[1], 10)];
+      }
+    }
+
+    // Try branch name pattern: task/N-slug → extract issue number
+    if (!projectName) {
+      const branchMatch = m.text.match(/task\/(\d+)/);
+      if (branchMatch) {
+        projectName = prToProject[parseInt(branchMatch[1], 10)];
       }
     }
 
@@ -161,13 +172,18 @@ export async function GET() {
       projectName = cfg.projects[0].name;
     }
 
-    return {
-      time: m.time,
-      text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
-      actor: m.sender,
-      projectName: projectName || "",
-    };
-  });
+    // Only include attributed events
+    if (projectName) {
+      recentEvents.push({
+        time: m.time,
+        text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
+        actor: m.sender,
+        projectName,
+      });
+    }
+
+    if (recentEvents.length >= 10) break;
+  }
 
   return NextResponse.json({ projects: projectResults, recentEvents });
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -120,9 +120,17 @@ export async function GET() {
     .slice(-10)
     .reverse();
 
-  const projects = cfg.projects.map((p: ProjectConfig) => {
+  // Build PR-number-to-project mapping for activity attribution
+  const prToProject: Record<number, string> = {};
+  const projectResults = cfg.projects.map((p: ProjectConfig) => {
     const data = getProjectData(p.repo, p.agents);
     const hasAgents = p.agents && Object.keys(p.agents).length > 0;
+
+    // Map PR numbers to this project
+    if (REPO_RE.test(p.repo)) {
+      const allPrs = ghJson(["pr", "list", "-R", p.repo, "--state", "all", "--json", "number", "--limit", "100"]) as { number: number }[];
+      for (const pr of allPrs) prToProject[pr.number] = p.name;
+    }
 
     return {
       id: p.id,
@@ -130,22 +138,36 @@ export async function GET() {
       repo: p.repo,
       agentCount: p.agents ? Object.keys(p.agents).length : 0,
       openPrs: data.openPrs,
-      // Active = backend has active PTY sessions for this specific project
       state: hasAgents ? isProjectActive(p.id) : "idle",
       lastActivity: data.lastActivity,
     };
   });
 
   // Build activity feed from chat with correct agent identities
-  const recentEvents = workflowMsgs.map((m) => ({
-    time: m.time,
-    text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
-    actor: m.sender,
-    // Match project by repo or name mention in message text
-    // If only one project configured, attribute all workflow messages to it
-    projectName: cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name
-      || (cfg.projects.length === 1 ? cfg.projects[0].name : "general"),
-  }));
+  const recentEvents = workflowMsgs.map((m) => {
+    // Try direct repo/name match first
+    let projectName = cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name;
 
-  return NextResponse.json({ projects, recentEvents });
+    // Try PR number cross-reference: match "#N" or "PR #N" or "#N "
+    if (!projectName) {
+      const prMatch = m.text.match(/#(\d+)/);
+      if (prMatch) {
+        projectName = prToProject[parseInt(prMatch[1], 10)];
+      }
+    }
+
+    // Single project fallback
+    if (!projectName && cfg.projects.length === 1) {
+      projectName = cfg.projects[0].name;
+    }
+
+    return {
+      time: m.time,
+      text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
+      actor: m.sender,
+      projectName: projectName || "",
+    };
+  });
+
+  return NextResponse.json({ projects: projectResults, recentEvents });
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -14,7 +14,13 @@ interface ProjectConfig {
   agents?: Record<string, unknown>;
 }
 
-function getConfig(): { projects: ProjectConfig[] } {
+interface ChattrConfig {
+  agentchattr_url?: string;
+  agentchattr_token?: string;
+  projects: ProjectConfig[];
+}
+
+function getConfig(): ChattrConfig {
   try {
     const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
     return JSON.parse(raw);
@@ -33,83 +39,82 @@ function ghJson(args: string[]): unknown[] {
   }
 }
 
-interface GhEvent {
-  type: string;
-  actor: { login: string };
-  created_at: string;
-  payload: {
-    action?: string;
-    pull_request?: { number: number; title: string };
-    ref?: string;
-    size?: number;
-    review?: { state: string };
-  };
+interface ChatMessage {
+  id: number;
+  sender: string;
+  text: string;
+  time: string;
 }
 
-function formatEvent(e: GhEvent): string {
-  const actor = e.actor?.login || "unknown";
-  switch (e.type) {
-    case "PushEvent":
-      return `${actor} pushed to ${e.payload.ref?.replace("refs/heads/", "") || "branch"}`;
-    case "PullRequestEvent": {
-      const pr = e.payload.pull_request;
-      return `${actor} ${e.payload.action || "updated"} PR #${pr?.number || "?"}: ${pr?.title || ""}`;
-    }
-    case "PullRequestReviewEvent": {
-      const pr = e.payload.pull_request;
-      const state = e.payload.review?.state?.toLowerCase() || "reviewed";
-      return `${actor} ${state} PR #${pr?.number || "?"}: ${pr?.title || ""}`;
-    }
-    case "IssuesEvent":
-      return `${actor} ${e.payload.action || "updated"} an issue`;
-    default:
-      return `${actor}: ${e.type}`;
+async function getChatActivity(cfg: ChattrConfig): Promise<ChatMessage[]> {
+  const url = cfg.agentchattr_url || "http://127.0.0.1:8300";
+  const token = cfg.agentchattr_token;
+  const headers: Record<string, string> = token ? { "x-session-token": token } : {};
+
+  try {
+    const res = await fetch(`${url}/api/messages?channel=general&limit=30`, { headers });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : data.messages || [];
+  } catch {
+    return [];
   }
 }
 
 function getProjectData(repo: string, agents: Record<string, unknown> | undefined) {
   if (!REPO_RE.test(repo)) {
-    return { openPrs: 0, state: "idle", lastActivity: null, recentEvents: [] };
+    return { openPrs: 0, lastActivity: null };
   }
 
   const prs = ghJson(["pr", "list", "-R", repo, "--json", "number", "--limit", "100"]);
-  const openPrs = prs.length;
 
-  // Fetch recent GitHub events for rich activity feed
-  const events = ghJson(["api", `repos/${repo}/events`, "--jq", ".[0:10]"]) as GhEvent[];
+  // Get last activity from most recent PR or event
+  const recentPrs = ghJson(["pr", "list", "-R", repo, "--state", "all", "--json", "updatedAt", "--limit", "1"]) as { updatedAt: string }[];
+  const lastActivity = recentPrs[0]?.updatedAt || null;
 
-  const recentEvents = events.map((e) => ({
-    time: e.created_at,
-    text: formatEvent(e),
-  }));
-
-  const lastActivity = events[0]?.created_at || null;
-
-  // Active = agents configured AND recent activity (push/PR event in last hour)
-  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
-  const hasAgents = agents && Object.keys(agents).length > 0;
-  const hasRecentActivity = lastActivity && lastActivity > oneHourAgo;
-  const state = hasAgents && hasRecentActivity ? "active" : "idle";
-
-  return { openPrs, state, lastActivity, recentEvents: recentEvents.slice(0, 5) };
+  return {
+    openPrs: prs.length,
+    lastActivity,
+  };
 }
 
 export async function GET() {
   const cfg = getConfig();
 
+  // Fetch chat messages for activity feed (has correct agent names)
+  const chatMsgs = await getChatActivity(cfg);
+
+  // Filter for workflow events (PR, merge, push, approve mentions)
+  const eventKeywords = /\b(PR|merged|pushed|approved|opened|closed|review|commit)\b/i;
+  const workflowMsgs = chatMsgs
+    .filter((m) => eventKeywords.test(m.text) && m.sender !== "system")
+    .slice(-10)
+    .reverse();
+
   const projects = cfg.projects.map((p: ProjectConfig) => {
     const data = getProjectData(p.repo, p.agents);
+    const hasAgents = p.agents && Object.keys(p.agents).length > 0;
+
     return {
       id: p.id,
       name: p.name,
       repo: p.repo,
       agentCount: p.agents ? Object.keys(p.agents).length : 0,
       openPrs: data.openPrs,
-      state: data.state,
+      // Active = project has agents configured (running state assumed when dashboard is in use)
+      state: hasAgents ? "active" : "idle",
       lastActivity: data.lastActivity,
-      recentEvents: data.recentEvents,
     };
   });
 
-  return NextResponse.json(projects);
+  // Build activity feed from chat with correct agent identities
+  const recentEvents = workflowMsgs.map((m) => ({
+    time: m.time,
+    text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
+    actor: m.sender,
+    // Try to match project by repo mention in message
+    projectName: cfg.projects.find((p) => m.text.includes(p.repo) || m.text.includes(p.name))?.name || cfg.projects[0]?.name || "",
+  }));
+
+  return NextResponse.json({ projects, recentEvents });
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -23,30 +23,62 @@ function getConfig(): { projects: ProjectConfig[] } {
   }
 }
 
-function getPrCount(repo: string): number {
-  if (!REPO_RE.test(repo)) return 0;
+function ghJson(args: string[]): unknown[] {
   try {
-    const out = execFileSync(
-      "gh",
-      ["pr", "list", "-R", repo, "--json", "number", "--limit", "100"],
-      { encoding: "utf-8", timeout: 15000 }
-    );
-    return JSON.parse(out).length;
+    const out = execFileSync("gh", args, { encoding: "utf-8", timeout: 15000 });
+    const parsed = JSON.parse(out);
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
-    return 0;
+    return [];
   }
+}
+
+function getProjectData(repo: string) {
+  if (!REPO_RE.test(repo)) return { openPrs: 0, lastActivity: null, recentEvents: [] };
+
+  const prs = ghJson(["pr", "list", "-R", repo, "--json", "number,title,createdAt,author", "--limit", "100"]);
+  const openPrs = prs.length;
+
+  // Get recent events: last 5 merged PRs + last 5 closed issues
+  const mergedPrs = ghJson(["pr", "list", "-R", repo, "--state", "merged", "--json", "number,title,mergedAt,author", "--limit", "5"]);
+  const events: { time: string; text: string }[] = [];
+
+  for (const pr of prs.slice(0, 3) as { number: number; title: string; createdAt: string; author: { login: string } }[]) {
+    events.push({ time: pr.createdAt, text: `PR #${pr.number} opened: ${pr.title}` });
+  }
+  for (const pr of mergedPrs.slice(0, 3) as { number: number; title: string; mergedAt: string; author: { login: string } }[]) {
+    events.push({ time: pr.mergedAt, text: `PR #${pr.number} merged: ${pr.title}` });
+  }
+
+  // Sort by time descending
+  events.sort((a, b) => (b.time || "").localeCompare(a.time || ""));
+
+  // Last activity is the most recent event
+  const lastActivity = events[0]?.time || null;
+
+  // Active if any activity in the last hour
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const state = lastActivity && lastActivity > oneHourAgo ? "active" : "idle";
+
+  return { openPrs, lastActivity, state, recentEvents: events.slice(0, 5) };
 }
 
 export async function GET() {
   const cfg = getConfig();
 
-  const projects = cfg.projects.map((p: ProjectConfig) => ({
-    id: p.id,
-    name: p.name,
-    repo: p.repo,
-    agentCount: p.agents ? Object.keys(p.agents).length : 0,
-    openPrs: getPrCount(p.repo),
-  }));
+  const projects = cfg.projects.map((p: ProjectConfig) => {
+    const data = getProjectData(p.repo);
+    return {
+      id: p.id,
+      name: p.name,
+      repo: p.repo,
+      agentCount: p.agents ? Object.keys(p.agents).length : 0,
+      openPrs: data.openPrs,
+      state: data.state || "idle",
+      lastActivity: data.lastActivity,
+      recentEvents: data.recentEvents,
+    };
+  });
 
   return NextResponse.json(projects);
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -29,25 +29,32 @@ function getConfig(): ChattrConfig {
   }
 }
 
-let backendAlive: boolean | null = null;
+let activeProjects: Set<string> | null = null;
 
-function checkBackendAlive(projectId: string): "active" | "idle" {
-  // Cache the backend check for all projects in one request
-  if (backendAlive === null) {
-    try {
-      const cfg = getConfig();
-      const port = (cfg as unknown as { port?: number }).port || 3001;
-      execFileSync("curl", ["-sf", "--max-time", "1", `http://127.0.0.1:${port}/api/health`], {
-        encoding: "utf-8",
-        timeout: 2000,
-      });
-      backendAlive = true;
-    } catch {
-      backendAlive = false;
+function fetchActiveSessions(): Set<string> {
+  if (activeProjects !== null) return activeProjects;
+  activeProjects = new Set();
+  try {
+    const cfg = getConfig();
+    const port = (cfg as unknown as { port?: number }).port || 3001;
+    const out = execFileSync("curl", ["-sf", "--max-time", "1", `http://127.0.0.1:${port}/api/sessions`], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+    const sessions = JSON.parse(out);
+    if (Array.isArray(sessions)) {
+      for (const s of sessions) {
+        if (s.projectId) activeProjects.add(s.projectId);
+      }
     }
+  } catch {
+    // Backend not running — all projects idle
   }
-  void projectId;
-  return backendAlive ? "active" : "idle";
+  return activeProjects;
+}
+
+function isProjectActive(projectId: string): "active" | "idle" {
+  return fetchActiveSessions().has(projectId) ? "active" : "idle";
 }
 
 function ghJson(args: string[]): unknown[] {
@@ -100,7 +107,7 @@ function getProjectData(repo: string, agents: Record<string, unknown> | undefine
 }
 
 export async function GET() {
-  backendAlive = null; // Reset per-request
+  activeProjects = null; // Reset per-request
   const cfg = getConfig();
 
   // Fetch chat messages for activity feed (has correct agent names)
@@ -123,9 +130,8 @@ export async function GET() {
       repo: p.repo,
       agentCount: p.agents ? Object.keys(p.agents).length : 0,
       openPrs: data.openPrs,
-      // Active = backend server has active PTY sessions for this project
-      // True process monitoring comes in #12 (agent lifecycle); for now check backend health
-      state: hasAgents ? checkBackendAlive(p.id) : "idle",
+      // Active = backend has active PTY sessions for this specific project
+      state: hasAgents ? isProjectActive(p.id) : "idle",
       lastActivity: data.lastActivity,
     };
   });

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+const REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+
+interface ProjectConfig {
+  id: string;
+  name: string;
+  repo: string;
+  agents?: Record<string, unknown>;
+}
+
+function getConfig(): { projects: ProjectConfig[] } {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return { projects: [] };
+  }
+}
+
+function getPrCount(repo: string): number {
+  if (!REPO_RE.test(repo)) return 0;
+  try {
+    const out = execFileSync(
+      "gh",
+      ["pr", "list", "-R", repo, "--json", "number", "--limit", "100"],
+      { encoding: "utf-8", timeout: 15000 }
+    );
+    return JSON.parse(out).length;
+  } catch {
+    return 0;
+  }
+}
+
+export async function GET() {
+  const cfg = getConfig();
+
+  const projects = cfg.projects.map((p: ProjectConfig) => ({
+    id: p.id,
+    name: p.name,
+    repo: p.repo,
+    agentCount: p.agents ? Object.keys(p.agents).length : 0,
+    openPrs: getPrCount(p.repo),
+  }));
+
+  return NextResponse.json(projects);
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -33,48 +33,79 @@ function ghJson(args: string[]): unknown[] {
   }
 }
 
-function getProjectData(repo: string) {
-  if (!REPO_RE.test(repo)) return { openPrs: 0, lastActivity: null, recentEvents: [] };
+interface GhEvent {
+  type: string;
+  actor: { login: string };
+  created_at: string;
+  payload: {
+    action?: string;
+    pull_request?: { number: number; title: string };
+    ref?: string;
+    size?: number;
+    review?: { state: string };
+  };
+}
 
-  const prs = ghJson(["pr", "list", "-R", repo, "--json", "number,title,createdAt,author", "--limit", "100"]);
+function formatEvent(e: GhEvent): string {
+  const actor = e.actor?.login || "unknown";
+  switch (e.type) {
+    case "PushEvent":
+      return `${actor} pushed to ${e.payload.ref?.replace("refs/heads/", "") || "branch"}`;
+    case "PullRequestEvent": {
+      const pr = e.payload.pull_request;
+      return `${actor} ${e.payload.action || "updated"} PR #${pr?.number || "?"}: ${pr?.title || ""}`;
+    }
+    case "PullRequestReviewEvent": {
+      const pr = e.payload.pull_request;
+      const state = e.payload.review?.state?.toLowerCase() || "reviewed";
+      return `${actor} ${state} PR #${pr?.number || "?"}: ${pr?.title || ""}`;
+    }
+    case "IssuesEvent":
+      return `${actor} ${e.payload.action || "updated"} an issue`;
+    default:
+      return `${actor}: ${e.type}`;
+  }
+}
+
+function getProjectData(repo: string, agents: Record<string, unknown> | undefined) {
+  if (!REPO_RE.test(repo)) {
+    return { openPrs: 0, state: "idle", lastActivity: null, recentEvents: [] };
+  }
+
+  const prs = ghJson(["pr", "list", "-R", repo, "--json", "number", "--limit", "100"]);
   const openPrs = prs.length;
 
-  // Get recent events: last 5 merged PRs + last 5 closed issues
-  const mergedPrs = ghJson(["pr", "list", "-R", repo, "--state", "merged", "--json", "number,title,mergedAt,author", "--limit", "5"]);
-  const events: { time: string; text: string }[] = [];
+  // Fetch recent GitHub events for rich activity feed
+  const events = ghJson(["api", `repos/${repo}/events`, "--jq", ".[0:10]"]) as GhEvent[];
 
-  for (const pr of prs.slice(0, 3) as { number: number; title: string; createdAt: string; author: { login: string } }[]) {
-    events.push({ time: pr.createdAt, text: `PR #${pr.number} opened: ${pr.title}` });
-  }
-  for (const pr of mergedPrs.slice(0, 3) as { number: number; title: string; mergedAt: string; author: { login: string } }[]) {
-    events.push({ time: pr.mergedAt, text: `PR #${pr.number} merged: ${pr.title}` });
-  }
+  const recentEvents = events.map((e) => ({
+    time: e.created_at,
+    text: formatEvent(e),
+  }));
 
-  // Sort by time descending
-  events.sort((a, b) => (b.time || "").localeCompare(a.time || ""));
+  const lastActivity = events[0]?.created_at || null;
 
-  // Last activity is the most recent event
-  const lastActivity = events[0]?.time || null;
-
-  // Active if any activity in the last hour
+  // Active = agents configured AND recent activity (push/PR event in last hour)
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
-  const state = lastActivity && lastActivity > oneHourAgo ? "active" : "idle";
+  const hasAgents = agents && Object.keys(agents).length > 0;
+  const hasRecentActivity = lastActivity && lastActivity > oneHourAgo;
+  const state = hasAgents && hasRecentActivity ? "active" : "idle";
 
-  return { openPrs, lastActivity, state, recentEvents: events.slice(0, 5) };
+  return { openPrs, state, lastActivity, recentEvents: recentEvents.slice(0, 5) };
 }
 
 export async function GET() {
   const cfg = getConfig();
 
   const projects = cfg.projects.map((p: ProjectConfig) => {
-    const data = getProjectData(p.repo);
+    const data = getProjectData(p.repo, p.agents);
     return {
       id: p.id,
       name: p.name,
       repo: p.repo,
       agentCount: p.agents ? Object.keys(p.agents).length : 0,
       openPrs: data.openPrs,
-      state: data.state || "idle",
+      state: data.state,
       lastActivity: data.lastActivity,
       recentEvents: data.recentEvents,
     };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,5 @@
+import HomeDashboard from "@/components/HomeDashboard";
+
 export default function Home() {
-  return (
-    <div className="flex h-full items-center justify-center">
-      <div className="text-center space-y-3">
-        <h1 className="text-2xl font-semibold tracking-tight text-text">
-          QuadWork
-        </h1>
-        <p className="text-sm text-text-muted">
-          Multi-agent dashboard — panels coming soon
-        </p>
-        <div className="inline-block border border-border px-3 py-1 text-xs text-accent">
-          v0.1.0
-        </div>
-      </div>
-    </div>
-  );
+  return <HomeDashboard />;
 }

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -3,11 +3,6 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 
-interface RecentEvent {
-  time: string;
-  text: string;
-}
-
 interface Project {
   id: string;
   name: string;
@@ -16,7 +11,13 @@ interface Project {
   openPrs: number;
   state: "active" | "idle";
   lastActivity: string | null;
-  recentEvents: RecentEvent[];
+}
+
+interface ActivityEvent {
+  time: string;
+  text: string;
+  actor: string;
+  projectName: string;
 }
 
 function timeAgo(iso: string): string {
@@ -32,6 +33,7 @@ function timeAgo(iso: string): string {
 
 export default function HomeDashboard() {
   const [projects, setProjects] = useState<Project[]>([]);
+  const [activity, setActivity] = useState<ActivityEvent[]>([]);
 
   useEffect(() => {
     fetch("/api/projects")
@@ -40,18 +42,11 @@ export default function HomeDashboard() {
         return r.json();
       })
       .then((data) => {
-        if (Array.isArray(data)) setProjects(data);
+        if (data.projects && Array.isArray(data.projects)) setProjects(data.projects);
+        if (data.recentEvents && Array.isArray(data.recentEvents)) setActivity(data.recentEvents);
       })
       .catch(() => {});
   }, []);
-
-  // Aggregate recent events across all projects
-  const allEvents = projects
-    .flatMap((p) =>
-      (p.recentEvents || []).map((e) => ({ ...e, projectName: p.name, projectId: p.id }))
-    )
-    .sort((a, b) => (b.time || "").localeCompare(a.time || ""))
-    .slice(0, 10);
 
   return (
     <div className="h-full overflow-y-auto p-6">
@@ -121,19 +116,22 @@ export default function HomeDashboard() {
       <div className="mb-6">
         <h2 className="text-xs text-text-muted uppercase tracking-wider mb-3">Recent Activity</h2>
         <div className="border border-border bg-bg-surface">
-          {allEvents.length === 0 && (
+          {activity.length === 0 && (
             <div className="px-3 py-3 text-[11px] text-text-muted">No recent activity</div>
           )}
-          {allEvents.map((item, i) => (
+          {activity.map((item, i) => (
             <div
               key={`${item.time}-${i}`}
               className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
             >
-              <span className="text-text-muted shrink-0 w-14 text-right tabular-nums">
-                {item.time ? timeAgo(item.time) : ""}
+              <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
+                {item.time?.slice(0, 5) || ""}
               </span>
-              <span className="text-accent shrink-0 font-semibold">
+              <span className="text-accent shrink-0 font-semibold w-12">
                 {item.projectName}
+              </span>
+              <span className="text-[#ffcc00] shrink-0 font-semibold w-6">
+                {item.actor}
               </span>
               <span className="text-text truncate min-w-0">
                 {item.text}

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+interface Project {
+  id: string;
+  name: string;
+  repo: string;
+  agentCount: number;
+  openPrs: number;
+}
+
+interface Activity {
+  id: number;
+  time: string;
+  project: string;
+  text: string;
+}
+
+export default function HomeDashboard() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [activity, setActivity] = useState<Activity[]>([]);
+
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
+      .then((data) => {
+        if (Array.isArray(data)) setProjects(data);
+      })
+      .catch(() => {});
+
+    // Activity feed from chat proxy (recent messages as activity)
+    fetch("/api/chat?path=/api/messages&channel=general&limit=10")
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
+      .then((data) => {
+        const msgs = Array.isArray(data) ? data : data.messages || [];
+        setActivity(
+          msgs.slice(-10).reverse().map((m: { id: number; time: string; sender: string; text: string }) => ({
+            id: m.id,
+            time: m.time?.slice(0, 5) || "",
+            project: m.sender,
+            text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
+          }))
+        );
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold text-text tracking-tight">Projects</h1>
+        <p className="text-xs text-text-muted mt-1">
+          {projects.length} configured project{projects.length !== 1 ? "s" : ""}
+        </p>
+      </div>
+
+      {/* Project cards grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 mb-8">
+        {projects.map((project) => (
+          <Link
+            key={project.id}
+            href={`/project/${project.id}`}
+            className="block border border-border bg-bg-surface p-4 hover:bg-[#1a1a1a] transition-colors group"
+          >
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+                <span className="text-sm font-semibold text-text">{project.name}</span>
+              </div>
+              <span className="text-[10px] text-text-muted opacity-0 group-hover:opacity-100 transition-opacity">
+                open →
+              </span>
+            </div>
+
+            <div className="flex gap-4 text-[11px]">
+              <div>
+                <span className="text-text-muted">agents</span>
+                <span className="ml-1.5 text-text">{project.agentCount}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">PRs</span>
+                <span className="ml-1.5 text-text">{project.openPrs}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">repo</span>
+                <span className="ml-1.5 text-text">{project.repo}</span>
+              </div>
+            </div>
+          </Link>
+        ))}
+
+        {/* + New Project placeholder */}
+        <button className="border border-dashed border-border p-4 flex items-center justify-center text-text-muted hover:text-text hover:border-text-muted transition-colors min-h-[88px]">
+          <span className="text-sm">+ New Project</span>
+        </button>
+      </div>
+
+      {/* Activity feed */}
+      <div className="mb-6">
+        <h2 className="text-xs text-text-muted uppercase tracking-wider mb-3">Recent Activity</h2>
+        <div className="border border-border bg-bg-surface">
+          {activity.length === 0 && (
+            <div className="px-3 py-3 text-[11px] text-text-muted">No recent activity</div>
+          )}
+          {activity.map((item) => (
+            <div
+              key={item.id}
+              className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
+            >
+              <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
+                {item.time}
+              </span>
+              <span className="text-accent shrink-0 font-semibold w-12">
+                {item.project}
+              </span>
+              <span className="text-text truncate min-w-0">
+                {item.text}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -3,24 +3,35 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 
+interface RecentEvent {
+  time: string;
+  text: string;
+}
+
 interface Project {
   id: string;
   name: string;
   repo: string;
   agentCount: number;
   openPrs: number;
+  state: "active" | "idle";
+  lastActivity: string | null;
+  recentEvents: RecentEvent[];
 }
 
-interface Activity {
-  id: number;
-  time: string;
-  project: string;
-  text: string;
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }
 
 export default function HomeDashboard() {
   const [projects, setProjects] = useState<Project[]>([]);
-  const [activity, setActivity] = useState<Activity[]>([]);
 
   useEffect(() => {
     fetch("/api/projects")
@@ -32,26 +43,15 @@ export default function HomeDashboard() {
         if (Array.isArray(data)) setProjects(data);
       })
       .catch(() => {});
-
-    // Activity feed from chat proxy (recent messages as activity)
-    fetch("/api/chat?path=/api/messages&channel=general&limit=10")
-      .then((r) => {
-        if (!r.ok) throw new Error(`${r.status}`);
-        return r.json();
-      })
-      .then((data) => {
-        const msgs = Array.isArray(data) ? data : data.messages || [];
-        setActivity(
-          msgs.slice(-10).reverse().map((m: { id: number; time: string; sender: string; text: string }) => ({
-            id: m.id,
-            time: m.time?.slice(0, 5) || "",
-            project: m.sender,
-            text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
-          }))
-        );
-      })
-      .catch(() => {});
   }, []);
+
+  // Aggregate recent events across all projects
+  const allEvents = projects
+    .flatMap((p) =>
+      (p.recentEvents || []).map((e) => ({ ...e, projectName: p.name, projectId: p.id }))
+    )
+    .sort((a, b) => (b.time || "").localeCompare(a.time || ""))
+    .slice(0, 10);
 
   return (
     <div className="h-full overflow-y-auto p-6">
@@ -73,15 +73,22 @@ export default function HomeDashboard() {
           >
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+                <span
+                  className={`w-1.5 h-1.5 rounded-full ${
+                    project.state === "active" ? "bg-accent" : "bg-text-muted"
+                  }`}
+                />
                 <span className="text-sm font-semibold text-text">{project.name}</span>
+                <span className="text-[10px] text-text-muted">
+                  {project.state}
+                </span>
               </div>
               <span className="text-[10px] text-text-muted opacity-0 group-hover:opacity-100 transition-opacity">
                 open →
               </span>
             </div>
 
-            <div className="flex gap-4 text-[11px]">
+            <div className="flex gap-4 text-[11px] mb-2">
               <div>
                 <span className="text-text-muted">agents</span>
                 <span className="ml-1.5 text-text">{project.agentCount}</span>
@@ -95,6 +102,12 @@ export default function HomeDashboard() {
                 <span className="ml-1.5 text-text">{project.repo}</span>
               </div>
             </div>
+
+            {project.lastActivity && (
+              <div className="text-[10px] text-text-muted">
+                last activity: {timeAgo(project.lastActivity)}
+              </div>
+            )}
           </Link>
         ))}
 
@@ -108,19 +121,19 @@ export default function HomeDashboard() {
       <div className="mb-6">
         <h2 className="text-xs text-text-muted uppercase tracking-wider mb-3">Recent Activity</h2>
         <div className="border border-border bg-bg-surface">
-          {activity.length === 0 && (
+          {allEvents.length === 0 && (
             <div className="px-3 py-3 text-[11px] text-text-muted">No recent activity</div>
           )}
-          {activity.map((item) => (
+          {allEvents.map((item, i) => (
             <div
-              key={item.id}
+              key={`${item.time}-${i}`}
               className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
             >
-              <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
-                {item.time}
+              <span className="text-text-muted shrink-0 w-14 text-right tabular-nums">
+                {item.time ? timeAgo(item.time) : ""}
               </span>
-              <span className="text-accent shrink-0 font-semibold w-12">
-                {item.project}
+              <span className="text-accent shrink-0 font-semibold">
+                {item.projectName}
               </span>
               <span className="text-text truncate min-w-0">
                 {item.text}


### PR DESCRIPTION
## Summary
- `GET /api/projects`: returns project list with agent count and open PR count (via `gh pr list`)
- `HomeDashboard` component: responsive cards grid (1-3 columns) from config
- Each card shows: project name, green active dot, agent count, open PR count, repo name
- Cards link to `/project/[id]` with hover "open →" reveal
- "+ New Project" placeholder card with dashed border
- Recent activity feed below cards from AgentChattr chat messages (last 10)
- Activity items: timestamp, sender in accent color, truncated message text
- Repo validation with regex in `/api/projects` (same as #9)
- `npm run build` passes clean

Fixes #10

## Test plan
- [ ] Home page renders project cards from config
- [ ] Each card shows name, agent count, PR count, repo
- [ ] Cards link to `/project/[id]`
- [ ] "+ New Project" card visible with dashed border
- [ ] Activity feed shows recent chat messages
- [ ] Responsive: 1 col mobile, 2 cols medium, 3 cols wide
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)