### PR TITLE
[#11] Settings page + project config

### DIFF
--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -11,6 +11,23 @@ const DEFAULT_CONFIG = {
   projects: [],
 };
 
+export async function PUT(req: Request) {
+  try {
+    const body = await req.json();
+    const dir = path.dirname(CONFIG_PATH);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(body, null, 2));
+    return NextResponse.json({ ok: true });
+  } catch (err: unknown) {
+    return NextResponse.json(
+      { error: "Failed to write config", detail: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+}
+
 export async function GET() {
   try {
     const raw = fs.readFileSync(CONFIG_PATH, "utf-8");

--- a/src/app/api/telegram/route.ts
+++ b/src/app/api/telegram/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execFileSync, spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const BRIDGE_DIR = path.join(os.homedir(), ".quadwork", "agentchattr-telegram");
+
+// POST /api/telegram?action=test|install|start|stop
+export async function POST(req: NextRequest) {
+  const action = req.nextUrl.searchParams.get("action");
+  const body = await req.json().catch(() => ({}));
+
+  switch (action) {
+    case "test":
+      return testConnection(body.bot_token, body.chat_id);
+    case "install":
+      return installBridge();
+    case "start":
+      return startDaemon(body.project_id);
+    case "stop":
+      return stopDaemon(body.project_id);
+    default:
+      return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+  }
+}
+
+async function testConnection(botToken: string, chatId: string) {
+  if (!botToken || !chatId) {
+    return NextResponse.json({ ok: false, error: "Missing bot_token or chat_id" });
+  }
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${botToken}/getChat?chat_id=${chatId}`);
+    const data = await res.json();
+    return NextResponse.json({ ok: data.ok, error: data.ok ? undefined : data.description });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : "Connection failed" });
+  }
+}
+
+function installBridge() {
+  try {
+    if (!fs.existsSync(BRIDGE_DIR)) {
+      execFileSync("gh", ["repo", "clone", "realproject7/agentchattr-telegram", BRIDGE_DIR], {
+        encoding: "utf-8",
+        timeout: 30000,
+      });
+    }
+    // Install deps
+    execFileSync("pip3", ["install", "-r", path.join(BRIDGE_DIR, "requirements.txt")], {
+      encoding: "utf-8",
+      timeout: 30000,
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : "Install failed" });
+  }
+}
+
+const PID_FILE = path.join(os.homedir(), ".quadwork", "telegram-bridge.pid");
+
+function startDaemon(projectId: string) {
+  if (!projectId) {
+    return NextResponse.json({ ok: false, error: "Missing project_id" });
+  }
+  const configPath = path.join(os.homedir(), ".quadwork", "config.json");
+  const bridgeScript = path.join(BRIDGE_DIR, "telegram_bridge.py");
+
+  if (!fs.existsSync(bridgeScript)) {
+    return NextResponse.json({ ok: false, error: "Bridge not installed. Click Install Bridge first." });
+  }
+
+  try {
+    const child = spawn("python3", [bridgeScript, "--config", configPath], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    if (child.pid) {
+      fs.writeFileSync(PID_FILE, String(child.pid));
+    }
+    return NextResponse.json({ ok: true, pid: child.pid });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : "Start failed" });
+  }
+}
+
+function stopDaemon(_projectId: string) {
+  try {
+    if (fs.existsSync(PID_FILE)) {
+      const pid = parseInt(fs.readFileSync(PID_FILE, "utf-8").trim(), 10);
+      if (pid) process.kill(pid, "SIGTERM");
+      fs.unlinkSync(PID_FILE);
+    }
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : "Stop failed" });
+  }
+}

--- a/src/app/api/telegram/route.ts
+++ b/src/app/api/telegram/route.ts
@@ -4,7 +4,55 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
-const BRIDGE_DIR = path.join(os.homedir(), ".quadwork", "agentchattr-telegram");
+const QUADWORK_DIR = path.join(os.homedir(), ".quadwork");
+const BRIDGE_DIR = path.join(QUADWORK_DIR, "agentchattr-telegram");
+const CONFIG_PATH = path.join(QUADWORK_DIR, "config.json");
+
+function pidFile(projectId: string): string {
+  return path.join(QUADWORK_DIR, `telegram-bridge-${projectId}.pid`);
+}
+
+function configToml(projectId: string): string {
+  return path.join(QUADWORK_DIR, `telegram-${projectId}.toml`);
+}
+
+function isRunning(projectId: string): boolean {
+  const pf = pidFile(projectId);
+  if (!fs.existsSync(pf)) return false;
+  const pid = parseInt(fs.readFileSync(pf, "utf-8").trim(), 10);
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0); // Signal 0 = check if alive
+    return true;
+  } catch {
+    // Process not running — clean up stale PID file
+    fs.unlinkSync(pf);
+    return false;
+  }
+}
+
+function getProjectTelegram(projectId: string): { bot_token: string; chat_id: string; agentchattr_url: string } | null {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    const cfg = JSON.parse(raw);
+    const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
+    if (!project?.telegram) return null;
+    return {
+      bot_token: project.telegram.bot_token || "",
+      chat_id: project.telegram.chat_id || "",
+      agentchattr_url: cfg.agentchattr_url || "http://127.0.0.1:8300",
+    };
+  } catch {
+    return null;
+  }
+}
+
+// GET /api/telegram?project=<id> — check daemon status
+export async function GET(req: NextRequest) {
+  const projectId = req.nextUrl.searchParams.get("project") || "";
+  if (!projectId) return NextResponse.json({ error: "Missing project" }, { status: 400 });
+  return NextResponse.json({ running: isRunning(projectId) });
+}
 
 // POST /api/telegram?action=test|install|start|stop
 export async function POST(req: NextRequest) {
@@ -20,6 +68,8 @@ export async function POST(req: NextRequest) {
       return startDaemon(body.project_id);
     case "stop":
       return stopDaemon(body.project_id);
+    case "status":
+      return NextResponse.json({ running: isRunning(body.project_id || "") });
     default:
       return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   }
@@ -46,7 +96,6 @@ function installBridge() {
         timeout: 30000,
       });
     }
-    // Install deps
     execFileSync("pip3", ["install", "-r", path.join(BRIDGE_DIR, "requirements.txt")], {
       encoding: "utf-8",
       timeout: 30000,
@@ -57,42 +106,61 @@ function installBridge() {
   }
 }
 
-const PID_FILE = path.join(os.homedir(), ".quadwork", "telegram-bridge.pid");
+function writeProjectToml(projectId: string): string | null {
+  const tg = getProjectTelegram(projectId);
+  if (!tg || !tg.bot_token || !tg.chat_id) return null;
+
+  const tomlPath = configToml(projectId);
+  const content = `[telegram]\nbot_token = "${tg.bot_token}"\nchat_id = "${tg.chat_id}"\n\n[agentchattr]\nurl = "${tg.agentchattr_url}"\n`;
+  fs.writeFileSync(tomlPath, content);
+  return tomlPath;
+}
 
 function startDaemon(projectId: string) {
   if (!projectId) {
     return NextResponse.json({ ok: false, error: "Missing project_id" });
   }
-  const configPath = path.join(os.homedir(), ".quadwork", "config.json");
-  const bridgeScript = path.join(BRIDGE_DIR, "telegram_bridge.py");
+  if (isRunning(projectId)) {
+    return NextResponse.json({ ok: true, running: true, message: "Already running" });
+  }
 
+  const bridgeScript = path.join(BRIDGE_DIR, "telegram_bridge.py");
   if (!fs.existsSync(bridgeScript)) {
     return NextResponse.json({ ok: false, error: "Bridge not installed. Click Install Bridge first." });
   }
 
+  const tomlPath = writeProjectToml(projectId);
+  if (!tomlPath) {
+    return NextResponse.json({ ok: false, error: "Save bot_token and chat_id in project settings first." });
+  }
+
   try {
-    const child = spawn("python3", [bridgeScript, "--config", configPath], {
+    const child = spawn("python3", [bridgeScript, "--config", tomlPath], {
       detached: true,
       stdio: "ignore",
     });
     child.unref();
     if (child.pid) {
-      fs.writeFileSync(PID_FILE, String(child.pid));
+      fs.writeFileSync(pidFile(projectId), String(child.pid));
     }
-    return NextResponse.json({ ok: true, pid: child.pid });
+    return NextResponse.json({ ok: true, running: true, pid: child.pid });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : "Start failed" });
   }
 }
 
-function stopDaemon(_projectId: string) {
+function stopDaemon(projectId: string) {
+  if (!projectId) {
+    return NextResponse.json({ ok: false, error: "Missing project_id" });
+  }
+  const pf = pidFile(projectId);
   try {
-    if (fs.existsSync(PID_FILE)) {
-      const pid = parseInt(fs.readFileSync(PID_FILE, "utf-8").trim(), 10);
+    if (fs.existsSync(pf)) {
+      const pid = parseInt(fs.readFileSync(pf, "utf-8").trim(), 10);
       if (pid) process.kill(pid, "SIGTERM");
-      fs.unlinkSync(PID_FILE);
+      fs.unlinkSync(pf);
     }
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true, running: false });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : "Stop failed" });
   }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import SettingsPage from "@/components/SettingsPage";
 
 export default function Settings() {
-  return <SettingsPage />;
+  return (
+    <Suspense fallback={<div className="p-6 text-text-muted text-xs">Loading...</div>}>
+      <SettingsPage />
+    </Suspense>
+  );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,14 +1,5 @@
-export default function SettingsPage() {
-  return (
-    <div className="flex h-full items-center justify-center">
-      <div className="text-center space-y-3">
-        <h1 className="text-2xl font-semibold tracking-tight text-text">
-          Settings
-        </h1>
-        <p className="text-sm text-text-muted">
-          Configuration — coming in #11
-        </p>
-      </div>
-    </div>
-  );
+import SettingsPage from "@/components/SettingsPage";
+
+export default function Settings() {
+  return <SettingsPage />;
 }

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -106,10 +106,13 @@ export default function HomeDashboard() {
           </Link>
         ))}
 
-        {/* + New Project placeholder */}
-        <button className="border border-dashed border-border p-4 flex items-center justify-center text-text-muted hover:text-text hover:border-text-muted transition-colors min-h-[88px]">
+        {/* + New Project */}
+        <Link
+          href="/settings?add=true"
+          className="border border-dashed border-border p-4 flex items-center justify-center text-text-muted hover:text-text hover:border-text-muted transition-colors min-h-[88px]"
+        >
           <span className="text-sm">+ New Project</span>
-        </button>
+        </Link>
       </div>
 
       {/* Activity feed */}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 
 interface AgentConfig {
+  display_name: string;
   command: string;
   cwd: string;
   model: string;
+  agents_md: string;
 }
 
 interface TelegramConfig {
   enabled: boolean;
   bot_token: string;
   chat_id: string;
+  status?: string;
 }
 
 interface ProjectConfig {
@@ -32,10 +36,10 @@ interface Config {
 }
 
 const DEFAULT_AGENTS: Record<string, AgentConfig> = {
-  t1: { command: "claude", cwd: "", model: "opus" },
-  t2a: { command: "claude", cwd: "", model: "sonnet" },
-  t2b: { command: "claude", cwd: "", model: "sonnet" },
-  t3: { command: "claude", cwd: "", model: "sonnet" },
+  t1: { display_name: "T1", command: "claude", cwd: "", model: "opus", agents_md: "" },
+  t2a: { display_name: "T2a", command: "claude", cwd: "", model: "sonnet", agents_md: "" },
+  t2b: { display_name: "T2b", command: "claude", cwd: "", model: "sonnet", agents_md: "" },
+  t3: { display_name: "T3", command: "claude", cwd: "", model: "sonnet", agents_md: "" },
 };
 
 const BACKENDS = ["claude-code", "codex"];
@@ -85,11 +89,13 @@ function Select({ label, value, onChange, options }: {
 }
 
 export default function SettingsPage() {
+  const searchParams = useSearchParams();
   const [config, setConfig] = useState<Config | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [autoAdded, setAutoAdded] = useState(false);
 
   const load = useCallback(() => {
     fetch("/api/config")
@@ -108,6 +114,14 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => { load(); }, [load]);
+
+  // Auto-add project when navigated with ?add=true
+  useEffect(() => {
+    if (config && searchParams.get("add") === "true" && !autoAdded) {
+      setAutoAdded(true);
+      addProject();
+    }
+  }, [config, searchParams, autoAdded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const save = async () => {
     if (!config) return;
@@ -265,39 +279,63 @@ export default function SettingsPage() {
                   <div className="mt-4">
                     <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Agents</h3>
                     <div className="border border-border">
-                      <div className="grid grid-cols-4 gap-0 px-2 py-1 border-b border-border text-[10px] text-text-muted uppercase">
-                        <span>Agent</span>
+                      <div className="grid grid-cols-5 gap-0 px-2 py-1 border-b border-border text-[10px] text-text-muted uppercase">
+                        <span>Name</span>
                         <span>Command</span>
                         <span>Model</span>
                         <span>CWD</span>
+                        <span>AGENTS.md</span>
                       </div>
                       {Object.entries(project.agents || {}).map(([agentId, agent]) => (
-                        <div key={agentId} className="grid grid-cols-4 gap-0 px-2 py-1 border-b border-border/50 last:border-b-0">
-                          <span className="text-[11px] text-text font-semibold self-center">{agentId}</span>
-                          <select
-                            value={agent.command || "claude"}
-                            onChange={(e) => updateAgent(idx, agentId, { command: e.target.value })}
-                            className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
-                          >
-                            {BACKENDS.map((b) => (
-                              <option key={b} value={b} className="bg-bg-surface">{b}</option>
-                            ))}
-                          </select>
-                          <select
-                            value={agent.model || "sonnet"}
-                            onChange={(e) => updateAgent(idx, agentId, { model: e.target.value })}
-                            className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
-                          >
-                            {MODELS.map((m) => (
-                              <option key={m} value={m} className="bg-bg-surface">{m}</option>
-                            ))}
-                          </select>
-                          <input
-                            value={agent.cwd || ""}
-                            onChange={(e) => updateAgent(idx, agentId, { cwd: e.target.value })}
-                            placeholder="/path/to/worktree"
-                            className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
-                          />
+                        <div key={agentId} className="border-b border-border/50 last:border-b-0">
+                          <div className="grid grid-cols-5 gap-0 px-2 py-1">
+                            <input
+                              value={agent.display_name || agentId.toUpperCase()}
+                              onChange={(e) => updateAgent(idx, agentId, { display_name: e.target.value })}
+                              className="bg-transparent text-[11px] text-text font-semibold outline-none border border-border px-1 py-0.5 focus:border-accent"
+                            />
+                            <select
+                              value={agent.command || "claude"}
+                              onChange={(e) => updateAgent(idx, agentId, { command: e.target.value })}
+                              className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
+                            >
+                              {BACKENDS.map((b) => (
+                                <option key={b} value={b} className="bg-bg-surface">{b}</option>
+                              ))}
+                            </select>
+                            <select
+                              value={agent.model || "sonnet"}
+                              onChange={(e) => updateAgent(idx, agentId, { model: e.target.value })}
+                              className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
+                            >
+                              {MODELS.map((m) => (
+                                <option key={m} value={m} className="bg-bg-surface">{m}</option>
+                              ))}
+                            </select>
+                            <input
+                              value={agent.cwd || ""}
+                              onChange={(e) => updateAgent(idx, agentId, { cwd: e.target.value })}
+                              placeholder="/path/to/worktree"
+                              className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
+                            />
+                            <button
+                              onClick={() => setExpanded({ ...expanded, [`${project.id}-${agentId}-md`]: !expanded[`${project.id}-${agentId}-md`] })}
+                              className="text-[10px] text-text-muted hover:text-accent transition-colors text-left px-1"
+                            >
+                              {expanded[`${project.id}-${agentId}-md`] ? "▾ edit" : "▸ edit"}
+                            </button>
+                          </div>
+                          {expanded[`${project.id}-${agentId}-md`] && (
+                            <div className="px-2 pb-2">
+                              <textarea
+                                value={agent.agents_md || ""}
+                                onChange={(e) => updateAgent(idx, agentId, { agents_md: e.target.value })}
+                                placeholder="# AGENTS.md seed content for this agent..."
+                                rows={8}
+                                className="w-full bg-transparent border border-border px-2 py-1.5 text-[11px] text-text outline-none focus:border-accent resize-y"
+                              />
+                            </div>
+                          )}
                         </div>
                       ))}
                     </div>
@@ -323,7 +361,7 @@ export default function SettingsPage() {
                         <span className="text-[11px] text-text">{telegram.enabled ? "Enabled" : "Disabled"}</span>
                         <span className={`w-1.5 h-1.5 rounded-full ${telegram.enabled ? "bg-accent" : "bg-text-muted"}`} />
                       </div>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
                         <Input
                           label="Bot Token"
                           value={telegram.bot_token}
@@ -337,6 +375,57 @@ export default function SettingsPage() {
                           onChange={(v) => updateTelegram(idx, { chat_id: v })}
                           placeholder="-1001234567890"
                         />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => {
+                            fetch("/api/telegram?action=test", {
+                              method: "POST",
+                              headers: { "Content-Type": "application/json" },
+                              body: JSON.stringify({ bot_token: telegram.bot_token, chat_id: telegram.chat_id }),
+                            })
+                              .then((r) => r.json())
+                              .then((d) => alert(d.ok ? "Connection OK" : `Error: ${d.error}`))
+                              .catch(() => alert("Test failed"));
+                          }}
+                          className="px-2 py-1 text-[11px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors"
+                        >
+                          Test Connection
+                        </button>
+                        <button
+                          onClick={() => {
+                            fetch("/api/telegram?action=install", { method: "POST" })
+                              .then((r) => r.json())
+                              .then((d) => alert(d.ok ? "Installed" : `Error: ${d.error}`))
+                              .catch(() => alert("Install failed"));
+                          }}
+                          className="px-2 py-1 text-[11px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors"
+                        >
+                          Install Bridge
+                        </button>
+                        <button
+                          onClick={() => {
+                            const action = telegram.enabled ? "stop" : "start";
+                            fetch(`/api/telegram?action=${action}`, {
+                              method: "POST",
+                              headers: { "Content-Type": "application/json" },
+                              body: JSON.stringify({ project_id: project.id }),
+                            })
+                              .then((r) => r.json())
+                              .then((d) => {
+                                if (d.ok) updateTelegram(idx, { enabled: action === "start", status: action === "start" ? "running" : "stopped" });
+                                else alert(`Error: ${d.error}`);
+                              })
+                              .catch(() => alert(`${action} failed`));
+                          }}
+                          className={`px-2 py-1 text-[11px] border border-border transition-colors ${
+                            telegram.enabled
+                              ? "text-error hover:border-error"
+                              : "text-accent hover:border-accent"
+                          }`}
+                        >
+                          {telegram.enabled ? "Stop Daemon" : "Start Daemon"}
+                        </button>
                       </div>
                     </div>
                   </div>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface AgentConfig {
+  command: string;
+  cwd: string;
+  model: string;
+}
+
+interface TelegramConfig {
+  enabled: boolean;
+  bot_token: string;
+  chat_id: string;
+}
+
+interface ProjectConfig {
+  id: string;
+  name: string;
+  repo: string;
+  working_dir: string;
+  agents: Record<string, AgentConfig>;
+  telegram?: TelegramConfig;
+}
+
+interface Config {
+  port: number;
+  agentchattr_url: string;
+  agentchattr_token: string;
+  default_backend: string;
+  projects: ProjectConfig[];
+}
+
+const DEFAULT_AGENTS: Record<string, AgentConfig> = {
+  t1: { command: "claude", cwd: "", model: "opus" },
+  t2a: { command: "claude", cwd: "", model: "sonnet" },
+  t2b: { command: "claude", cwd: "", model: "sonnet" },
+  t3: { command: "claude", cwd: "", model: "sonnet" },
+};
+
+const BACKENDS = ["claude-code", "codex"];
+const MODELS = ["opus", "sonnet", "haiku"];
+
+function Input({ label, value, onChange, type = "text", placeholder }: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+  placeholder?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[11px] text-text-muted uppercase tracking-wider">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
+      />
+    </div>
+  );
+}
+
+function Select({ label, value, onChange, options }: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: string[];
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[11px] text-text-muted uppercase tracking-wider">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent cursor-pointer"
+      >
+        {options.map((o) => (
+          <option key={o} value={o} className="bg-bg-surface">{o}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default function SettingsPage() {
+  const [config, setConfig] = useState<Config | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    fetch("/api/config")
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
+      .then((data) => setConfig({
+        port: data.port || 3001,
+        agentchattr_url: data.agentchattr_url || "http://127.0.0.1:8300",
+        agentchattr_token: data.agentchattr_token || "",
+        default_backend: data.default_backend || "claude-code",
+        projects: data.projects || [],
+      }))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const save = async () => {
+    if (!config) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(config),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      console.error(err);
+    }
+    setSaving(false);
+  };
+
+  const updateGlobal = (key: keyof Config, value: string | number) => {
+    if (!config) return;
+    setConfig({ ...config, [key]: value });
+  };
+
+  const updateProject = (idx: number, updates: Partial<ProjectConfig>) => {
+    if (!config) return;
+    const projects = [...config.projects];
+    projects[idx] = { ...projects[idx], ...updates };
+    setConfig({ ...config, projects });
+  };
+
+  const updateAgent = (projectIdx: number, agentId: string, updates: Partial<AgentConfig>) => {
+    if (!config) return;
+    const projects = [...config.projects];
+    const agents = { ...projects[projectIdx].agents };
+    agents[agentId] = { ...agents[agentId], ...updates };
+    projects[projectIdx] = { ...projects[projectIdx], agents };
+    setConfig({ ...config, projects });
+  };
+
+  const updateTelegram = (projectIdx: number, updates: Partial<TelegramConfig>) => {
+    if (!config) return;
+    const projects = [...config.projects];
+    const telegram = { enabled: false, bot_token: "", chat_id: "", ...projects[projectIdx].telegram, ...updates };
+    projects[projectIdx] = { ...projects[projectIdx], telegram };
+    setConfig({ ...config, projects });
+  };
+
+  const addProject = () => {
+    if (!config) return;
+    const id = `project-${Date.now()}`;
+    const newProject: ProjectConfig = {
+      id,
+      name: "New Project",
+      repo: "owner/repo",
+      working_dir: "",
+      agents: { ...DEFAULT_AGENTS },
+    };
+    setConfig({ ...config, projects: [...config.projects, newProject] });
+    setExpanded({ ...expanded, [id]: true });
+  };
+
+  const removeProject = (idx: number) => {
+    if (!config) return;
+    const projects = config.projects.filter((_, i) => i !== idx);
+    setConfig({ ...config, projects });
+    setConfirmDelete(null);
+  };
+
+  if (!config) return <div className="p-6 text-text-muted text-xs">Loading...</div>;
+
+  return (
+    <div className="h-full overflow-y-auto p-6 max-w-3xl">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-lg font-semibold text-text tracking-tight">Settings</h1>
+        <button
+          onClick={save}
+          disabled={saving}
+          className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50"
+        >
+          {saving ? "Saving..." : saved ? "Saved" : "Save"}
+        </button>
+      </div>
+
+      {/* Global Settings */}
+      <section className="mb-6">
+        <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">Global</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <Input
+            label="AgentChattr URL"
+            value={config.agentchattr_url}
+            onChange={(v) => updateGlobal("agentchattr_url", v)}
+            placeholder="http://127.0.0.1:8300"
+          />
+          <Select
+            label="Default CLI Backend"
+            value={config.default_backend}
+            onChange={(v) => updateGlobal("default_backend", v)}
+            options={BACKENDS}
+          />
+          <Input
+            label="QuadWork Port"
+            value={String(config.port)}
+            onChange={(v) => updateGlobal("port", parseInt(v, 10) || 3001)}
+            type="number"
+          />
+        </div>
+      </section>
+
+      <hr className="border-border mb-6" />
+
+      {/* Per-project settings */}
+      <section className="mb-6">
+        <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">Projects</h2>
+
+        {config.projects.map((project, idx) => {
+          const isExpanded = expanded[project.id] ?? false;
+          const telegram = project.telegram || { enabled: false, bot_token: "", chat_id: "" };
+
+          return (
+            <div key={project.id} className="border border-border mb-3">
+              {/* Header */}
+              <button
+                className="w-full flex items-center justify-between px-3 py-2 hover:bg-[#1a1a1a] transition-colors"
+                onClick={() => setExpanded({ ...expanded, [project.id]: !isExpanded })}
+              >
+                <span className="text-[12px] text-text font-semibold">{project.name}</span>
+                <span className="text-[11px] text-text-muted">{isExpanded ? "▾" : "▸"}</span>
+              </button>
+
+              {isExpanded && (
+                <div className="px-3 pb-3 border-t border-border">
+                  {/* Basic project info */}
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mt-3">
+                    <Input
+                      label="Project Name"
+                      value={project.name}
+                      onChange={(v) => updateProject(idx, { name: v })}
+                    />
+                    <Input
+                      label="GitHub Repo"
+                      value={project.repo}
+                      onChange={(v) => updateProject(idx, { repo: v })}
+                      placeholder="owner/repo"
+                    />
+                    <Input
+                      label="Working Directory"
+                      value={project.working_dir || ""}
+                      onChange={(v) => updateProject(idx, { working_dir: v })}
+                      placeholder="/path/to/project"
+                    />
+                  </div>
+
+                  {/* Agents table */}
+                  <div className="mt-4">
+                    <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Agents</h3>
+                    <div className="border border-border">
+                      <div className="grid grid-cols-4 gap-0 px-2 py-1 border-b border-border text-[10px] text-text-muted uppercase">
+                        <span>Agent</span>
+                        <span>Command</span>
+                        <span>Model</span>
+                        <span>CWD</span>
+                      </div>
+                      {Object.entries(project.agents || {}).map(([agentId, agent]) => (
+                        <div key={agentId} className="grid grid-cols-4 gap-0 px-2 py-1 border-b border-border/50 last:border-b-0">
+                          <span className="text-[11px] text-text font-semibold self-center">{agentId}</span>
+                          <select
+                            value={agent.command || "claude"}
+                            onChange={(e) => updateAgent(idx, agentId, { command: e.target.value })}
+                            className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
+                          >
+                            {BACKENDS.map((b) => (
+                              <option key={b} value={b} className="bg-bg-surface">{b}</option>
+                            ))}
+                          </select>
+                          <select
+                            value={agent.model || "sonnet"}
+                            onChange={(e) => updateAgent(idx, agentId, { model: e.target.value })}
+                            className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
+                          >
+                            {MODELS.map((m) => (
+                              <option key={m} value={m} className="bg-bg-surface">{m}</option>
+                            ))}
+                          </select>
+                          <input
+                            value={agent.cwd || ""}
+                            onChange={(e) => updateAgent(idx, agentId, { cwd: e.target.value })}
+                            placeholder="/path/to/worktree"
+                            className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Telegram Bridge */}
+                  <div className="mt-4">
+                    <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Telegram Bridge</h3>
+                    <div className="border border-border p-3">
+                      <div className="flex items-center gap-3 mb-3">
+                        <button
+                          onClick={() => updateTelegram(idx, { enabled: !telegram.enabled })}
+                          className={`w-8 h-4 rounded-full transition-colors relative ${
+                            telegram.enabled ? "bg-accent" : "bg-border"
+                          }`}
+                        >
+                          <span
+                            className={`absolute top-0.5 w-3 h-3 rounded-full bg-text transition-transform ${
+                              telegram.enabled ? "left-4" : "left-0.5"
+                            }`}
+                          />
+                        </button>
+                        <span className="text-[11px] text-text">{telegram.enabled ? "Enabled" : "Disabled"}</span>
+                        <span className={`w-1.5 h-1.5 rounded-full ${telegram.enabled ? "bg-accent" : "bg-text-muted"}`} />
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <Input
+                          label="Bot Token"
+                          value={telegram.bot_token}
+                          onChange={(v) => updateTelegram(idx, { bot_token: v })}
+                          type="password"
+                          placeholder="123456:ABC-DEF..."
+                        />
+                        <Input
+                          label="Chat ID"
+                          value={telegram.chat_id}
+                          onChange={(v) => updateTelegram(idx, { chat_id: v })}
+                          placeholder="-1001234567890"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Remove project */}
+                  <div className="mt-4 flex justify-end">
+                    {confirmDelete === project.id ? (
+                      <div className="flex items-center gap-2">
+                        <span className="text-[11px] text-error">Remove this project?</span>
+                        <button
+                          onClick={() => removeProject(idx)}
+                          className="px-2 py-1 text-[11px] bg-error text-bg font-semibold"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          onClick={() => setConfirmDelete(null)}
+                          className="px-2 py-1 text-[11px] text-text-muted border border-border"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmDelete(project.id)}
+                        className="text-[11px] text-error hover:text-text transition-colors"
+                      >
+                        Remove Project
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Add project */}
+        <button
+          onClick={addProject}
+          className="w-full border border-dashed border-border py-2 text-[12px] text-text-muted hover:text-text hover:border-text-muted transition-colors"
+        >
+          + Add Project
+        </button>
+      </section>
+
+      {/* Bottom save */}
+      <div className="flex justify-end pb-6">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50"
+        >
+          {saving ? "Saving..." : saved ? "Saved" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -362,9 +362,23 @@ export default function SettingsPage() {
                     <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Telegram Bridge</h3>
                     <div className="border border-border p-3">
                       <div className="flex items-center gap-3 mb-3">
+                        <button
+                          onClick={() => updateTelegram(idx, { enabled: !telegram.enabled })}
+                          className={`w-8 h-4 rounded-full transition-colors relative ${
+                            telegram.enabled ? "bg-accent" : "bg-border"
+                          }`}
+                        >
+                          <span
+                            className={`absolute top-0.5 w-3 h-3 rounded-full bg-text transition-transform ${
+                              telegram.enabled ? "left-4" : "left-0.5"
+                            }`}
+                          />
+                        </button>
+                        <span className="text-[11px] text-text">{telegram.enabled ? "Enabled" : "Disabled"}</span>
+                        <span className="text-[11px] text-text-muted">·</span>
                         <span className={`w-1.5 h-1.5 rounded-full ${daemonStatus[project.id] ? "bg-accent" : "bg-text-muted"}`} />
-                        <span className="text-[11px] text-text">
-                          {daemonStatus[project.id] ? "Running" : "Stopped"}
+                        <span className="text-[11px] text-text-muted">
+                          {daemonStatus[project.id] ? "running" : "stopped"}
                         </span>
                       </div>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -96,6 +96,7 @@ export default function SettingsPage() {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [autoAdded, setAutoAdded] = useState(false);
+  const [daemonStatus, setDaemonStatus] = useState<Record<string, boolean>>({});
 
   const load = useCallback(() => {
     fetch("/api/config")
@@ -114,6 +115,21 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => { load(); }, [load]);
+
+  // Poll telegram daemon status for each project
+  useEffect(() => {
+    if (!config) return;
+    for (const p of config.projects) {
+      if (p.telegram?.bot_token) {
+        fetch(`/api/telegram?project=${encodeURIComponent(p.id)}`)
+          .then((r) => r.ok ? r.json() : null)
+          .then((d) => {
+            if (d) setDaemonStatus((prev) => ({ ...prev, [p.id]: d.running }));
+          })
+          .catch(() => {});
+      }
+    }
+  }, [config]);
 
   // Auto-add project when navigated with ?add=true
   useEffect(() => {
@@ -346,20 +362,10 @@ export default function SettingsPage() {
                     <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Telegram Bridge</h3>
                     <div className="border border-border p-3">
                       <div className="flex items-center gap-3 mb-3">
-                        <button
-                          onClick={() => updateTelegram(idx, { enabled: !telegram.enabled })}
-                          className={`w-8 h-4 rounded-full transition-colors relative ${
-                            telegram.enabled ? "bg-accent" : "bg-border"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 w-3 h-3 rounded-full bg-text transition-transform ${
-                              telegram.enabled ? "left-4" : "left-0.5"
-                            }`}
-                          />
-                        </button>
-                        <span className="text-[11px] text-text">{telegram.enabled ? "Enabled" : "Disabled"}</span>
-                        <span className={`w-1.5 h-1.5 rounded-full ${telegram.enabled ? "bg-accent" : "bg-text-muted"}`} />
+                        <span className={`w-1.5 h-1.5 rounded-full ${daemonStatus[project.id] ? "bg-accent" : "bg-text-muted"}`} />
+                        <span className="text-[11px] text-text">
+                          {daemonStatus[project.id] ? "Running" : "Stopped"}
+                        </span>
                       </div>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
                         <Input
@@ -405,7 +411,7 @@ export default function SettingsPage() {
                         </button>
                         <button
                           onClick={() => {
-                            const action = telegram.enabled ? "stop" : "start";
+                            const action = daemonStatus[project.id] ? "stop" : "start";
                             fetch(`/api/telegram?action=${action}`, {
                               method: "POST",
                               headers: { "Content-Type": "application/json" },
@@ -413,18 +419,18 @@ export default function SettingsPage() {
                             })
                               .then((r) => r.json())
                               .then((d) => {
-                                if (d.ok) updateTelegram(idx, { enabled: action === "start", status: action === "start" ? "running" : "stopped" });
+                                if (d.ok) setDaemonStatus((prev) => ({ ...prev, [project.id]: d.running }));
                                 else alert(`Error: ${d.error}`);
                               })
                               .catch(() => alert(`${action} failed`));
                           }}
                           className={`px-2 py-1 text-[11px] border border-border transition-colors ${
-                            telegram.enabled
+                            daemonStatus[project.id]
                               ? "text-error hover:border-error"
                               : "text-accent hover:border-accent"
                           }`}
                         >
-                          {telegram.enabled ? "Stop Daemon" : "Start Daemon"}
+                          {daemonStatus[project.id] ? "Stop Daemon" : "Start Daemon"}
                         </button>
                       </div>
                     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -149,13 +149,14 @@ export default function Sidebar() {
           );
         })}
 
-        {/* Add project placeholder */}
-        <button
+        {/* Add project */}
+        <Link
+          href="/settings?add=true"
           className="w-10 h-10 flex items-center justify-center rounded-full border border-dashed border-border text-text-muted hover:text-text hover:bg-[#1a1a1a] transition-colors"
           title="Add project"
         >
           <PlusIcon />
-        </button>
+        </Link>
       </div>
 
       {/* Divider */}


### PR DESCRIPTION
## Summary
- `PUT /api/config` endpoint for saving config to `~/.quadwork/config.json`
- `SettingsPage` component with global and per-project configuration
- **Global settings**: AgentChattr URL, default CLI backend (claude-code/codex), QuadWork port
- **Per-project** (expandable/collapsible):
  - Project name, GitHub repo, working directory
  - Agent table: T1/T2a/T2b/T3 with command, model (opus/sonnet/haiku), cwd
  - Telegram bridge: enable/disable toggle, masked bot token, chat ID, status indicator
  - Remove project with confirmation dialog
- Add project form (generates default agent config)
- All inputs: monospace, `#2a2a2a` border, `#00ff88` focus, label above input
- Save button with accent green background, saving/saved state feedback
- Config persists via `PUT /api/config` to `~/.quadwork/config.json`
- `npm run build` passes clean

Fixes #11

## Test plan
- [ ] Settings page renders at `/settings`
- [ ] Global settings load from config
- [ ] Per-project sections expand/collapse
- [ ] Agent table shows all 4 agents with editable fields
- [ ] Telegram bridge toggle/fields work
- [ ] Add project creates new entry with defaults
- [ ] Remove project shows confirmation, deletes on confirm
- [ ] Save persists to config file
- [ ] Config survives page reload
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)