### PR TITLE
[#12] Agent lifecycle start/stop/restart

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -28,12 +28,86 @@ app.get("/api/config", (_req, res) => {
 // In-memory process state: key = "project/agent" → { process, state, error }
 const agentProcesses = new Map();
 
+// AgentChattr server process
+let chattrProcess = { process: null, state: "stopped", error: null };
+
 app.get("/api/agents", (_req, res) => {
   const agents = {};
   for (const [key, info] of agentProcesses) {
     agents[key] = { state: info.state, error: info.error || null };
   }
+  agents["_agentchattr"] = { state: chattrProcess.state, error: chattrProcess.error };
   res.json(agents);
+});
+
+app.post("/api/agentchattr/:action", (req, res) => {
+  const { action } = req.params;
+  const cfg = readConfig();
+  const chattrUrl = cfg.agentchattr_url || "http://127.0.0.1:8300";
+  const chattrPort = new URL(chattrUrl).port || "8300";
+
+  if (action === "start") {
+    if (chattrProcess.state === "running" && chattrProcess.process) {
+      return res.json({ ok: true, state: "running", message: "Already running" });
+    }
+    try {
+      const child = spawn("agentchattr", ["--port", chattrPort], {
+        env: process.env,
+        stdio: "ignore",
+        detached: true,
+      });
+      child.unref();
+      child.on("error", (err) => {
+        chattrProcess = { process: null, state: "error", error: err.message };
+      });
+      child.on("exit", (code) => {
+        if (chattrProcess.process === child) {
+          chattrProcess = { process: null, state: "stopped", error: code ? `exit:${code}` : null };
+        }
+      });
+      chattrProcess = { process: child, state: "running", error: null };
+      res.json({ ok: true, state: "running", pid: child.pid });
+    } catch (err) {
+      chattrProcess = { process: null, state: "error", error: err.message };
+      res.status(500).json({ ok: false, state: "error", error: err.message });
+    }
+  } else if (action === "stop") {
+    if (chattrProcess.process) {
+      try { chattrProcess.process.kill("SIGTERM"); } catch {}
+    }
+    chattrProcess = { process: null, state: "stopped", error: null };
+    res.json({ ok: true, state: "stopped" });
+  } else if (action === "restart") {
+    if (chattrProcess.process) {
+      try { chattrProcess.process.kill("SIGTERM"); } catch {}
+    }
+    chattrProcess = { process: null, state: "stopped", error: null };
+    setTimeout(() => {
+      try {
+        const child = spawn("agentchattr", ["--port", chattrPort], {
+          env: process.env,
+          stdio: "ignore",
+          detached: true,
+        });
+        child.unref();
+        child.on("error", (err) => {
+          chattrProcess = { process: null, state: "error", error: err.message };
+        });
+        child.on("exit", (code) => {
+          if (chattrProcess.process === child) {
+            chattrProcess = { process: null, state: "stopped", error: code ? `exit:${code}` : null };
+          }
+        });
+        chattrProcess = { process: child, state: "running", error: null };
+        res.json({ ok: true, state: "running", pid: child.pid });
+      } catch (err) {
+        chattrProcess = { process: null, state: "error", error: err.message };
+        res.status(500).json({ ok: false, state: "error", error: err.message });
+      }
+    }, 500);
+  } else {
+    res.status(400).json({ error: "Unknown action" });
+  }
 });
 
 app.post("/api/agents/:project/:agent/start", (req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -2,12 +2,14 @@ const express = require("express");
 const http = require("http");
 const { WebSocketServer } = require("ws");
 const pty = require("node-pty");
+const { spawn } = require("child_process");
 const { readConfig, resolveAgentCwd } = require("./config");
 
 const config = readConfig();
 const PORT = config.port || 3001;
 
 const app = express();
+app.use(express.json());
 const server = http.createServer(app);
 
 // --- REST endpoints ---
@@ -19,6 +21,135 @@ app.get("/api/health", (_req, res) => {
 app.get("/api/config", (_req, res) => {
   const cfg = readConfig();
   res.json(cfg);
+});
+
+// --- Agent lifecycle ---
+
+// In-memory process state: key = "project/agent" → { process, state, error }
+const agentProcesses = new Map();
+
+app.get("/api/agents", (_req, res) => {
+  const agents = {};
+  for (const [key, info] of agentProcesses) {
+    agents[key] = { state: info.state, error: info.error || null };
+  }
+  res.json(agents);
+});
+
+app.post("/api/agents/:project/:agent/start", (req, res) => {
+  const { project, agent } = req.params;
+  const key = `${project}/${agent}`;
+
+  if (agentProcesses.has(key) && agentProcesses.get(key).state === "running") {
+    return res.json({ ok: true, state: "running", message: "Already running" });
+  }
+
+  const cfg = readConfig();
+  const proj = cfg.projects && cfg.projects.find((p) => p.id === project);
+  if (!proj || !proj.agents || !proj.agents[agent]) {
+    return res.status(400).json({ ok: false, error: `Unknown agent: ${key}` });
+  }
+
+  const agentCfg = proj.agents[agent];
+  const cwd = agentCfg.cwd || proj.working_dir || process.env.HOME;
+  const command = agentCfg.command || "claude";
+
+  try {
+    const child = spawn(command, [], {
+      cwd,
+      env: { ...process.env, TERM: "xterm-256color" },
+      stdio: "ignore",
+      detached: true,
+    });
+    child.unref();
+
+    child.on("error", (err) => {
+      agentProcesses.set(key, { process: null, state: "error", error: err.message });
+    });
+
+    child.on("exit", (code) => {
+      const existing = agentProcesses.get(key);
+      if (existing && existing.process === child) {
+        agentProcesses.set(key, { process: null, state: "stopped", error: code ? `exit:${code}` : null });
+      }
+    });
+
+    agentProcesses.set(key, { process: child, state: "running", error: null });
+    res.json({ ok: true, state: "running", pid: child.pid });
+  } catch (err) {
+    agentProcesses.set(key, { process: null, state: "error", error: err.message });
+    res.status(500).json({ ok: false, state: "error", error: err.message });
+  }
+});
+
+app.post("/api/agents/:project/:agent/stop", (req, res) => {
+  const { project, agent } = req.params;
+  const key = `${project}/${agent}`;
+  const info = agentProcesses.get(key);
+
+  if (!info || !info.process) {
+    agentProcesses.set(key, { process: null, state: "stopped", error: null });
+    return res.json({ ok: true, state: "stopped" });
+  }
+
+  try {
+    info.process.kill("SIGTERM");
+    agentProcesses.set(key, { process: null, state: "stopped", error: null });
+    res.json({ ok: true, state: "stopped" });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+app.post("/api/agents/:project/:agent/restart", (req, res) => {
+  const { project, agent } = req.params;
+  const key = `${project}/${agent}`;
+  const info = agentProcesses.get(key);
+
+  // Stop first
+  if (info && info.process) {
+    try { info.process.kill("SIGTERM"); } catch {}
+  }
+  agentProcesses.set(key, { process: null, state: "stopped", error: null });
+
+  // Then start (delegate to start handler by forwarding)
+  req.params.project = project;
+  req.params.agent = agent;
+  // Small delay to let process die
+  setTimeout(() => {
+    const cfg = readConfig();
+    const proj = cfg.projects && cfg.projects.find((p) => p.id === project);
+    if (!proj || !proj.agents || !proj.agents[agent]) {
+      return res.status(400).json({ ok: false, error: `Unknown agent: ${key}` });
+    }
+    const agentCfg = proj.agents[agent];
+    const cwd = agentCfg.cwd || proj.working_dir || process.env.HOME;
+    const command = agentCfg.command || "claude";
+
+    try {
+      const child = spawn(command, [], {
+        cwd,
+        env: { ...process.env, TERM: "xterm-256color" },
+        stdio: "ignore",
+        detached: true,
+      });
+      child.unref();
+      child.on("error", (err) => {
+        agentProcesses.set(key, { process: null, state: "error", error: err.message });
+      });
+      child.on("exit", (code) => {
+        const existing = agentProcesses.get(key);
+        if (existing && existing.process === child) {
+          agentProcesses.set(key, { process: null, state: "stopped", error: code ? `exit:${code}` : null });
+        }
+      });
+      agentProcesses.set(key, { process: child, state: "running", error: null });
+      res.json({ ok: true, state: "running", pid: child.pid });
+    } catch (err) {
+      agentProcesses.set(key, { process: null, state: "error", error: err.message });
+      res.status(500).json({ ok: false, state: "error", error: err.message });
+    }
+  }, 500);
 });
 
 // --- Active sessions tracking ---

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+function getBackendPort(): number {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    return JSON.parse(raw).port || 3001;
+  } catch {
+    return 3001;
+  }
+}
+
+// GET /api/agents — list all agent states
+export async function GET() {
+  const port = getBackendPort();
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/agents`);
+    if (!res.ok) return NextResponse.json({}, { status: res.status });
+    return NextResponse.json(await res.json());
+  } catch {
+    return NextResponse.json({}, { status: 502 });
+  }
+}
+
+// POST /api/agents?project=X&agent=Y&action=start|stop|restart
+export async function POST(req: NextRequest) {
+  const project = req.nextUrl.searchParams.get("project") || "";
+  const agent = req.nextUrl.searchParams.get("agent") || "";
+  const action = req.nextUrl.searchParams.get("action") || "start";
+  const port = getBackendPort();
+
+  if (!project || !agent || !["start", "stop", "restart"].includes(action)) {
+    return NextResponse.json({ error: "Missing project, agent, or valid action" }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/agents/${project}/${agent}/${action}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ error: "Backend unreachable" }, { status: 502 });
+  }
+}

--- a/src/components/PanelHeader.tsx
+++ b/src/components/PanelHeader.tsx
@@ -3,9 +3,12 @@
 interface PanelHeaderProps {
   label: string;
   status?: "running" | "stopped" | "error";
+  projectId?: string;
+  agentId?: string;
+  onStatusChange?: (newStatus: string) => void;
 }
 
-export default function PanelHeader({ label, status }: PanelHeaderProps) {
+export default function PanelHeader({ label, status, projectId, agentId, onStatusChange }: PanelHeaderProps) {
   const dotColor =
     status === "running"
       ? "bg-accent"
@@ -13,14 +16,59 @@ export default function PanelHeader({ label, status }: PanelHeaderProps) {
         ? "bg-error"
         : "bg-text-muted";
 
+  const lifecycleAction = (action: string) => {
+    if (!projectId || !agentId) return;
+    fetch(`/api/agents?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}&action=${action}`, {
+      method: "POST",
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        if (onStatusChange && d.state) onStatusChange(d.state);
+      })
+      .catch(() => {});
+  };
+
+  const showControls = projectId && agentId;
+
   return (
-    <div className="flex items-center gap-2 px-3 h-7 shrink-0 border-b border-border">
-      {status && (
-        <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+    <div className="flex items-center justify-between gap-2 px-3 h-7 shrink-0 border-b border-border">
+      <div className="flex items-center gap-2">
+        {status && (
+          <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+        )}
+        <span className="text-[11px] text-text-muted uppercase tracking-wider">
+          {label}
+        </span>
+      </div>
+      {showControls && (
+        <div className="flex items-center gap-1">
+          {status !== "running" && (
+            <button
+              onClick={() => lifecycleAction("start")}
+              className="text-[10px] text-text-muted hover:text-accent transition-colors px-1"
+              title="Start"
+            >
+              ▶
+            </button>
+          )}
+          {status === "running" && (
+            <button
+              onClick={() => lifecycleAction("stop")}
+              className="text-[10px] text-text-muted hover:text-error transition-colors px-1"
+              title="Stop"
+            >
+              ■
+            </button>
+          )}
+          <button
+            onClick={() => lifecycleAction("restart")}
+            className="text-[10px] text-text-muted hover:text-accent transition-colors px-1"
+            title="Restart"
+          >
+            ↻
+          </button>
+        </div>
       )}
-      <span className="text-[11px] text-text-muted uppercase tracking-wider">
-        {label}
-      </span>
     </div>
   );
 }

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -10,16 +10,44 @@ import GitHubPanel from "./GitHubPanel";
 const MIN_SIZE = 150; // px
 const DIVIDER = 4; // px
 
+type AgentState = "running" | "stopped" | "error";
+
 interface ProjectDashboardProps {
   projectId: string;
 }
 
 export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Ratios: 0–1, where colRatio is left column width fraction, rowRatio is top row height fraction
   const [colRatio, setColRatio] = useState(0.5);
   const [rowRatio, setRowRatio] = useState(0.5);
   const dragging = useRef<"col" | "row" | null>(null);
+  const [agentStates, setAgentStates] = useState<Record<string, AgentState>>({});
+
+  // Poll agent states
+  useEffect(() => {
+    const poll = () => {
+      fetch("/api/agents")
+        .then((r) => r.ok ? r.json() : {})
+        .then((data) => {
+          const states: Record<string, AgentState> = {};
+          for (const [key, info] of Object.entries(data)) {
+            if (key.startsWith(`${projectId}/`)) {
+              const agent = key.split("/")[1];
+              states[agent] = (info as { state: string }).state as AgentState;
+            }
+          }
+          setAgentStates(states);
+        })
+        .catch(() => {});
+    };
+    poll();
+    const interval = setInterval(poll, 5000);
+    return () => clearInterval(interval);
+  }, [projectId]);
+
+  const updateAgentState = (agent: string, state: string) => {
+    setAgentStates((prev) => ({ ...prev, [agent]: state as AgentState }));
+  };
 
   const clamp = useCallback(
     (ratio: number, totalPx: number) => {
@@ -81,7 +109,13 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
     >
       {/* Panel 1: T1 Terminal — top-left */}
       <div className="flex flex-col overflow-hidden">
-        <PanelHeader label="T1" status="running" />
+        <PanelHeader
+          label="T1"
+          status={agentStates["t1"] || "stopped"}
+          projectId={projectId}
+          agentId="t1"
+          onStatusChange={(s) => updateAgentState("t1", s)}
+        />
         <div className="flex-1 min-h-0">
           <TerminalPanel projectId={projectId} agentId="t1" />
         </div>
@@ -137,7 +171,11 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
       <div className="flex flex-col overflow-hidden">
         <PanelHeader label="Panel 4" />
         <div className="flex-1 min-h-0">
-          <TerminalGrid projectId={projectId} />
+          <TerminalGrid
+            projectId={projectId}
+            agentStates={agentStates}
+            onStatusChange={updateAgentState}
+          />
         </div>
       </div>
     </div>

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -94,6 +94,16 @@ export default function TerminalGrid({
                     title="Stop"
                   >■</button>
                 )}
+                <button
+                  onClick={() => {
+                    fetch(`/api/agents?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agent.id)}&action=restart`, { method: "POST" })
+                      .then((r) => r.json())
+                      .then((d) => { if (d.state && onStatusChange) onStatusChange(agent.id, d.state); })
+                      .catch(() => {});
+                  }}
+                  className="text-[10px] text-text-muted hover:text-accent transition-colors px-0.5"
+                  title="Restart"
+                >↻</button>
                 {isExpanded && (
                   <button
                     onClick={() => setExpanded(null)}

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -11,6 +11,8 @@ interface Agent {
 interface TerminalGridProps {
   projectId: string;
   agents?: Agent[];
+  agentStates?: Record<string, string>;
+  onStatusChange?: (agentId: string, state: string) => void;
 }
 
 const DEFAULT_AGENTS: Agent[] = [
@@ -28,6 +30,8 @@ const GRID_CLASSES = [
 export default function TerminalGrid({
   projectId,
   agents = DEFAULT_AGENTS,
+  agentStates = {},
+  onStatusChange,
 }: TerminalGridProps) {
   const [expanded, setExpanded] = useState<string | null>(null);
 
@@ -48,22 +52,57 @@ export default function TerminalGrid({
             style={isHidden ? { visibility: "hidden", overflow: "hidden" } : undefined}
           >
             <div
-              className={`flex items-center px-3 shrink-0 border-b border-border ${
-                isExpanded ? "h-7 justify-between" : "h-6 cursor-pointer"
+              className={`flex items-center justify-between px-3 shrink-0 border-b border-border ${
+                isExpanded ? "h-7" : "h-6"
               }`}
-              onClick={isExpanded ? undefined : () => setExpanded(agent.id)}
             >
-              <span className="text-[11px] text-text-muted uppercase tracking-wider">
-                {agent.label}
-              </span>
-              {isExpanded && (
-                <button
-                  onClick={() => setExpanded(null)}
-                  className="text-[11px] text-text-muted hover:text-text transition-colors"
-                >
-                  esc
-                </button>
-              )}
+              <div
+                className={`flex items-center gap-1.5 ${!isExpanded ? "cursor-pointer" : ""}`}
+                onClick={isExpanded ? undefined : () => setExpanded(agent.id)}
+              >
+                <span className={`w-1.5 h-1.5 rounded-full ${
+                  agentStates[agent.id] === "running" ? "bg-accent"
+                    : agentStates[agent.id] === "error" ? "bg-error"
+                    : "bg-text-muted"
+                }`} />
+                <span className="text-[11px] text-text-muted uppercase tracking-wider">
+                  {agent.label}
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                {agentStates[agent.id] !== "running" && (
+                  <button
+                    onClick={() => {
+                      fetch(`/api/agents?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agent.id)}&action=start`, { method: "POST" })
+                        .then((r) => r.json())
+                        .then((d) => { if (d.state && onStatusChange) onStatusChange(agent.id, d.state); })
+                        .catch(() => {});
+                    }}
+                    className="text-[10px] text-text-muted hover:text-accent transition-colors px-0.5"
+                    title="Start"
+                  >▶</button>
+                )}
+                {agentStates[agent.id] === "running" && (
+                  <button
+                    onClick={() => {
+                      fetch(`/api/agents?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agent.id)}&action=stop`, { method: "POST" })
+                        .then((r) => r.json())
+                        .then((d) => { if (d.state && onStatusChange) onStatusChange(agent.id, d.state); })
+                        .catch(() => {});
+                    }}
+                    className="text-[10px] text-text-muted hover:text-error transition-colors px-0.5"
+                    title="Stop"
+                  >■</button>
+                )}
+                {isExpanded && (
+                  <button
+                    onClick={() => setExpanded(null)}
+                    className="text-[11px] text-text-muted hover:text-text transition-colors ml-1"
+                  >
+                    esc
+                  </button>
+                )}
+              </div>
             </div>
             <div className="flex-1 min-h-0">
               <TerminalPanel projectId={projectId} agentId={agent.id} />


### PR DESCRIPTION
## Summary
**Backend** (`server/index.js`):
- `POST /api/agents/:project/:agent/start` — spawns agent CLI with configured command + cwd
- `POST /api/agents/:project/:agent/stop` — kills agent process via SIGTERM
- `POST /api/agents/:project/:agent/restart` — stop + start with 500ms delay
- `GET /api/agents` — returns all agent states (running/stopped/error)
- In-memory process tracking with exit/error callbacks

**Frontend**:
- `PanelHeader`: status dot (green=running, gray=stopped, red=error) + start(▶)/stop(■)/restart(↻) buttons
- `ProjectDashboard`: polls agent states every 5s, passes to all panels
- T1 panel header has full lifecycle controls
- `TerminalGrid`: per-agent status dots + start/stop buttons in sub-pane headers
- Next.js API proxy at `/api/agents` forwarding to backend

All agents start as stopped on server restart. `npm run build` passes clean.

Fixes #12

## Test plan
- [ ] Start spawns agent process, status changes to running (green dot)
- [ ] Stop kills agent process, status changes to stopped (gray dot)
- [ ] Restart cycles stop+start, status returns to running
- [ ] Error state shows red dot
- [ ] T1 panel header shows lifecycle controls
- [ ] TerminalGrid sub-panes show per-agent status + controls
- [ ] Agent states poll every 5s
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)