### PR TITLE
[#15] Task queue manager

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -238,6 +238,29 @@ app.get("/api/sessions", (_req, res) => {
   res.json(sessions);
 });
 
+// Write to an active PTY session
+app.post("/api/agents/:project/:agent/write", (req, res) => {
+  const { project, agent } = req.params;
+  const key = `${project}/${agent}`;
+  const session = activeSessions.get(key);
+
+  if (!session || !session.term) {
+    return res.status(404).json({ ok: false, error: "No active terminal session" });
+  }
+
+  const { text } = req.body || {};
+  if (!text) {
+    return res.status(400).json({ ok: false, error: "Missing text" });
+  }
+
+  try {
+    session.term.write(text);
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
 // --- WebSocket + PTY ---
 
 const wss = new WebSocketServer({ server, path: "/ws/terminal" });
@@ -276,8 +299,8 @@ wss.on("connection", (ws, req) => {
     return;
   }
 
-  // Register session only after successful PTY spawn
-  activeSessions.set(sessionKey, { projectId, agentId });
+  // Register session only after successful PTY spawn (include term for write access)
+  activeSessions.set(sessionKey, { projectId, agentId, term });
 
   // PTY → client
   term.onData((data) => {

--- a/src/app/project/[id]/queue/page.tsx
+++ b/src/app/project/[id]/queue/page.tsx
@@ -1,0 +1,10 @@
+import QueueManager from "@/components/QueueManager";
+
+interface QueuePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function QueuePage({ params }: QueuePageProps) {
+  const { id } = await params;
+  return <QueueManager projectId={id} />;
+}

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -15,6 +15,7 @@ function renderMarkdown(md: string): string {
     .replace(/^- (.+)$/gm, '<div class="pl-4 text-text-muted">– $1</div>')
     .replace(/\*\*(.+?)\*\*/g, '<strong class="text-text">$1</strong>')
     .replace(/`([^`]+)`/g, '<code class="text-accent text-[11px] bg-bg px-1">$1</code>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener" class="text-accent hover:underline">$1</a>')
     .replace(/\n\n/g, '<div class="h-2"></div>')
     .replace(/\n/g, "<br>");
 }
@@ -46,7 +47,7 @@ function generateTemplate(issues: Issue[], repo: string): string {
   ];
 
   issues.forEach((issue, i) => {
-    lines.push(`${i + 1}. #${issue.number} — ${issue.title} (task/${issue.number}-slug)`);
+    lines.push(`${i + 1}. [${repo}#${issue.number}](https://github.com/${repo}/issues/${issue.number}) — ${issue.title} (task/${issue.number}-slug)`);
   });
 
   lines.push("");
@@ -138,22 +139,42 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
       if (!cfgRes.ok) throw new Error("config");
       const cfg = await cfgRes.json();
       const port = cfg.port || 3001;
+      const backendUrl = `http://127.0.0.1:${port}`;
 
-      const res = await fetch(`http://127.0.0.1:${port}/api/agents/${projectId}/t1/write`, {
+      // Try to write directly first
+      let res = await fetch(`${backendUrl}/api/agents/${projectId}/t1/write`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: prompt + "\n" }),
       });
+
+      // If no session exists, create one by opening a WebSocket connection
+      if (res.status === 404) {
+        const wsUrl = `ws://127.0.0.1:${port}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=t1`;
+        const ws = new WebSocket(wsUrl);
+        await new Promise<void>((resolve, reject) => {
+          ws.onopen = () => resolve();
+          ws.onerror = () => reject(new Error("WebSocket failed"));
+          setTimeout(() => reject(new Error("WebSocket timeout")), 5000);
+        });
+
+        // Wait for PTY to initialize
+        await new Promise((r) => setTimeout(r, 1000));
+
+        // Retry write
+        res = await fetch(`${backendUrl}/api/agents/${projectId}/t1/write`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: prompt + "\n" }),
+        });
+      }
+
       if (res.ok) {
         setSent(true);
         setTimeout(() => setSent(false), 3000);
       } else {
         const err = await res.json().catch(() => ({}));
-        if (res.status === 404) {
-          alert("No active T1 terminal session. Open the project dashboard first and ensure T1's terminal is connected, then try again.");
-        } else {
-          alert(`Send failed: ${err.error || res.status}`);
-        }
+        alert(`Send failed: ${err.error || res.status}`);
       }
     } catch {
       await copyPrompt();

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -1,6 +1,23 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
+
+/** Simple markdown to HTML for preview (headings, lists, bold, code, links) */
+function renderMarkdown(md: string): string {
+  return md
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/^### (.+)$/gm, '<h3 class="text-sm font-semibold text-text mt-3 mb-1">$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2 class="text-sm font-semibold text-accent mt-4 mb-1">$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1 class="text-base font-bold text-text mt-2 mb-2">$1</h1>')
+    .replace(/^\d+\. (.+)$/gm, '<div class="pl-4 text-text">• $1</div>')
+    .replace(/^- (.+)$/gm, '<div class="pl-4 text-text-muted">– $1</div>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong class="text-text">$1</strong>')
+    .replace(/`([^`]+)`/g, '<code class="text-accent text-[11px] bg-bg px-1">$1</code>')
+    .replace(/\n\n/g, '<div class="h-2"></div>')
+    .replace(/\n/g, "<br>");
+}
 
 interface Issue {
   number: number;
@@ -106,6 +123,7 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
     URL.revokeObjectURL(url);
   };
 
+  const renderedPreview = useMemo(() => renderMarkdown(content), [content]);
   const prompt = generatePrompt(content, repo);
 
   const copyPrompt = async () => {
@@ -115,14 +133,12 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
   };
 
   const sendToT1 = async () => {
-    // Send prompt to T1 terminal via backend WebSocket write
     try {
       const cfgRes = await fetch("/api/config");
       if (!cfgRes.ok) throw new Error("config");
       const cfg = await cfgRes.json();
       const port = cfg.port || 3001;
 
-      // Use the backend to write to T1's PTY
       const res = await fetch(`http://127.0.0.1:${port}/api/agents/${projectId}/t1/write`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -131,10 +147,17 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
       if (res.ok) {
         setSent(true);
         setTimeout(() => setSent(false), 3000);
+      } else {
+        const err = await res.json().catch(() => ({}));
+        if (res.status === 404) {
+          alert("No active T1 terminal session. Open the project dashboard first and ensure T1's terminal is connected, then try again.");
+        } else {
+          alert(`Send failed: ${err.error || res.status}`);
+        }
       }
     } catch {
-      // Fallback: copy to clipboard
       await copyPrompt();
+      alert("Could not reach backend. Prompt copied to clipboard instead.");
     }
   };
 
@@ -182,8 +205,12 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
           <div className="px-3 py-1.5 border-b border-border">
             <span className="text-[10px] text-text-muted uppercase tracking-wider">Preview</span>
           </div>
-          <div className="flex-1 overflow-y-auto p-3 text-[12px] text-text whitespace-pre-wrap">
-            {content || <span className="text-text-muted">Preview will appear here...</span>}
+          <div className="flex-1 overflow-y-auto p-3 text-[12px] text-text">
+            {content ? (
+              <div dangerouslySetInnerHTML={{ __html: renderedPreview }} />
+            ) : (
+              <span className="text-text-muted">Preview will appear here...</span>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -148,8 +148,13 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
         body: JSON.stringify({ text: prompt + "\n" }),
       });
 
-      // If no session exists, create one by opening a WebSocket connection
+      // If no session exists, create one and start the T1 agent
       if (res.status === 404) {
+        // Get T1 agent command from config
+        const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
+        const t1Command = project?.agents?.t1?.command || "claude";
+
+        // Open WebSocket to create PTY session
         const wsUrl = `ws://127.0.0.1:${port}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=t1`;
         const ws = new WebSocket(wsUrl);
         await new Promise<void>((resolve, reject) => {
@@ -158,10 +163,20 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
           setTimeout(() => reject(new Error("WebSocket timeout")), 5000);
         });
 
-        // Wait for PTY to initialize
-        await new Promise((r) => setTimeout(r, 1000));
+        // Wait for shell to initialize
+        await new Promise((r) => setTimeout(r, 500));
 
-        // Retry write
+        // Start the T1 agent CLI in the PTY shell
+        await fetch(`${backendUrl}/api/agents/${projectId}/t1/write`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: `${t1Command}\n` }),
+        });
+
+        // Wait for agent to initialize
+        await new Promise((r) => setTimeout(r, 3000));
+
+        // Now write the queue prompt to the running agent
         res = await fetch(`${backendUrl}/api/agents/${projectId}/t1/write`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Issue {
+  number: number;
+  title: string;
+  state: string;
+  labels: { name: string }[];
+}
+
+interface QueueManagerProps {
+  projectId: string;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function generateTemplate(issues: Issue[], repo: string): string {
+  const date = today();
+  const lines: string[] = [
+    `# Task Queue — ${date}`,
+    "",
+    `Repo: \`${repo}\``,
+    "",
+    "## Batch 1",
+    "",
+  ];
+
+  issues.forEach((issue, i) => {
+    lines.push(`${i + 1}. #${issue.number} — ${issue.title} (task/${issue.number}-slug)`);
+  });
+
+  lines.push("");
+  lines.push("## Rules");
+  lines.push("");
+  lines.push("1. Assign ONE ticket at a time to @t3");
+  lines.push("2. Wait for @t2a AND @t2b to both approve before merging");
+  lines.push("3. After merge, immediately assign the next ticket");
+  lines.push("4. PR titles: [#<issue>] Short description");
+  lines.push("5. Branch naming: task/<issue-number>-<slug>");
+  lines.push("6. NEVER store keys/secrets");
+  lines.push("7. Communicate via AgentChattr MCP chat by tagging agents");
+  lines.push("8. Do NOT push to main — only merge approved PRs");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function generatePrompt(queueContent: string, repo: string): string {
+  return `@t1 Work through this queue top-to-bottom. Assign ONE ticket at a time to
+   @t3. After each PR is merged, assign the next ticket immediately.
+  All tickets are autonomous — no operator gates.
+
+  IMPORTANT — Repo context:
+  - All work is on repo ${repo}.
+  - Use -R ${repo} for ALL gh commands (issues, PRs, merges).
+  - Branches, PRs, and issues are all on ${repo}.
+
+${queueContent}
+
+  Start now. Assign the first ticket to @t3.`;
+}
+
+export default function QueueManager({ projectId }: QueueManagerProps) {
+  const [content, setContent] = useState("");
+  const [repo, setRepo] = useState("");
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  // Fetch repo from config
+  useEffect(() => {
+    fetch("/api/config")
+      .then((r) => r.ok ? r.json() : null)
+      .then((cfg) => {
+        const project = cfg?.projects?.find((p: { id: string }) => p.id === projectId);
+        if (project?.repo) setRepo(project.repo);
+      })
+      .catch(() => {});
+  }, [projectId]);
+
+  const generateFromIssues = useCallback(() => {
+    fetch(`/api/github/issues?project=${encodeURIComponent(projectId)}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
+      .then((issues: Issue[]) => {
+        const open = issues.filter((i) => i.state === "OPEN");
+        setContent(generateTemplate(open, repo));
+      })
+      .catch(() => {
+        setContent(generateTemplate([], repo));
+      });
+  }, [projectId, repo]);
+
+  const exportMd = () => {
+    const blob = new Blob([content], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `queue-${today()}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const prompt = generatePrompt(content, repo);
+
+  const copyPrompt = async () => {
+    await navigator.clipboard.writeText(prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const sendToT1 = async () => {
+    // Send prompt to T1 terminal via backend WebSocket write
+    try {
+      const cfgRes = await fetch("/api/config");
+      if (!cfgRes.ok) throw new Error("config");
+      const cfg = await cfgRes.json();
+      const port = cfg.port || 3001;
+
+      // Use the backend to write to T1's PTY
+      const res = await fetch(`http://127.0.0.1:${port}/api/agents/${projectId}/t1/write`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: prompt + "\n" }),
+      });
+      if (res.ok) {
+        setSent(true);
+        setTimeout(() => setSent(false), 3000);
+      }
+    } catch {
+      // Fallback: copy to clipboard
+      await copyPrompt();
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col p-6 max-w-5xl">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h1 className="text-lg font-semibold text-text tracking-tight">Task Queue</h1>
+          <p className="text-xs text-text-muted mt-0.5">{repo || projectId}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={generateFromIssues}
+            className="px-3 py-1.5 text-[12px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors"
+          >
+            Generate Template
+          </button>
+          <button
+            onClick={exportMd}
+            className="px-3 py-1.5 text-[12px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors"
+          >
+            Export .md
+          </button>
+        </div>
+      </div>
+
+      {/* Editor + Preview split */}
+      <div className="flex-1 min-h-0 grid grid-cols-2 gap-0 border border-border mb-4">
+        {/* Editor */}
+        <div className="flex flex-col border-r border-border">
+          <div className="px-3 py-1.5 border-b border-border">
+            <span className="text-[10px] text-text-muted uppercase tracking-wider">Editor</span>
+          </div>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="# Task Queue&#10;&#10;Paste or generate a queue template..."
+            className="flex-1 bg-bg-surface p-3 text-[12px] text-text outline-none resize-none"
+          />
+        </div>
+
+        {/* Preview */}
+        <div className="flex flex-col">
+          <div className="px-3 py-1.5 border-b border-border">
+            <span className="text-[10px] text-text-muted uppercase tracking-wider">Preview</span>
+          </div>
+          <div className="flex-1 overflow-y-auto p-3 text-[12px] text-text whitespace-pre-wrap">
+            {content || <span className="text-text-muted">Preview will appear here...</span>}
+          </div>
+        </div>
+      </div>
+
+      {/* Guide */}
+      <div className="mb-4 px-3 py-2 border border-border bg-bg-surface text-[11px] text-text-muted">
+        <strong className="text-text">How to use:</strong> Click &quot;Generate Template&quot; to auto-fill from open issues. Edit the queue, organize into batches, then click &quot;Start Queue&quot; to generate and send the T1 initiation prompt.
+      </div>
+
+      {/* Start Queue */}
+      <div className="border border-border">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+          <span className="text-[11px] text-text-muted uppercase tracking-wider">Start Queue</span>
+          <button
+            onClick={() => setShowPrompt(!showPrompt)}
+            className="text-[10px] text-text-muted hover:text-text transition-colors"
+          >
+            {showPrompt ? "▾ hide prompt" : "▸ show prompt"}
+          </button>
+        </div>
+
+        {showPrompt && (
+          <div className="px-3 py-2 border-b border-border bg-bg-surface max-h-48 overflow-y-auto">
+            <pre className="text-[11px] text-text-muted whitespace-pre-wrap">{prompt}</pre>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 px-3 py-3">
+          <button
+            onClick={sendToT1}
+            className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors"
+          >
+            {sent ? "Sent to T1" : "Send to T1 Terminal"}
+          </button>
+          <button
+            onClick={copyPrompt}
+            className="px-3 py-1.5 text-[12px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors"
+          >
+            {copied ? "Copied" : "Copy Prompt"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Queue page at `/project/[id]/queue` with split-pane markdown editor + live preview
- **Generate Template**: fetches open issues from GitHub, creates queue with batch sections, numbered tickets, and default rules
- **Export .md**: downloads queue as markdown file
- **Start Queue**: generates T1 initiation prompt with repo context, queue content, and rules
- **Send to T1 Terminal**: writes prompt directly to T1's active PTY session via `POST /api/agents/:project/:agent/write`
- **Copy Prompt**: clipboard fallback for manual paste
- Backend: new `/api/agents/:project/:agent/write` endpoint for PTY text injection
- Active sessions now store `term` reference for write access
- Guide text explaining how to use the queue with AgentChattr agents
- `npm run build` passes clean

Fixes #15

## Test plan
- [ ] Queue page renders at `/project/[id]/queue`
- [ ] Generate Template populates from open issues
- [ ] Editor text updates preview in real time
- [ ] Export .md downloads file
- [ ] Start Queue shows generated prompt in collapsible preview
- [ ] Send to T1 Terminal writes to active PTY session
- [ ] Copy Prompt copies to clipboard
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)