### PR TITLE
[#16] Scheduled agent trigger messages

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -261,6 +261,81 @@ app.post("/api/agents/:project/:agent/write", (req, res) => {
   }
 });
 
+// --- Scheduled Triggers ---
+
+const triggers = new Map(); // projectId → { interval, timer, lastSent, nextAt }
+
+const DEFAULT_MESSAGE = `@t1 @t2a @t2b @t3 — Queue check.
+T1: Merge any PR with both approvals, assign next from queue.
+T3: Work on assigned ticket or address review feedback.
+T2a/T2b: Review open PRs. If T3 pushed fixes, re-review. Post verdict on PR AND notify here.
+ALL: Communicate via this chat by tagging agents. Your terminal is NOT visible.`;
+
+async function sendTriggerMessage(projectId) {
+  const cfg = readConfig();
+  const project = cfg.projects && cfg.projects.find((p) => p.id === projectId);
+  const chattrUrl = cfg.agentchattr_url || "http://127.0.0.1:8300";
+  const token = cfg.agentchattr_token || "";
+  const message = (project && project.trigger_message) || DEFAULT_MESSAGE;
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers["x-session-token"] = token;
+
+  try {
+    await fetch(`${chattrUrl}/api/send`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ text: message, channel: "general", sender: "user" }),
+    });
+  } catch {}
+
+  const info = triggers.get(projectId);
+  if (info) {
+    info.lastSent = Date.now();
+    info.nextAt = Date.now() + info.interval;
+  }
+}
+
+app.get("/api/triggers", (_req, res) => {
+  const result = {};
+  for (const [id, info] of triggers) {
+    result[id] = {
+      enabled: true,
+      interval: info.interval,
+      lastSent: info.lastSent,
+      nextAt: info.nextAt,
+    };
+  }
+  res.json(result);
+});
+
+app.post("/api/triggers/:project/start", (req, res) => {
+  const { project } = req.params;
+  const { interval } = req.body || {};
+  const ms = (interval || 30) * 60 * 1000;
+
+  // Clear existing
+  const existing = triggers.get(project);
+  if (existing && existing.timer) clearInterval(existing.timer);
+
+  const timer = setInterval(() => sendTriggerMessage(project), ms);
+  triggers.set(project, { interval: ms, timer, lastSent: null, nextAt: Date.now() + ms });
+  res.json({ ok: true, enabled: true, interval: ms, nextAt: Date.now() + ms });
+});
+
+app.post("/api/triggers/:project/stop", (req, res) => {
+  const { project } = req.params;
+  const existing = triggers.get(project);
+  if (existing && existing.timer) clearInterval(existing.timer);
+  triggers.delete(project);
+  res.json({ ok: true, enabled: false });
+});
+
+app.post("/api/triggers/:project/send-now", (req, res) => {
+  const { project } = req.params;
+  sendTriggerMessage(project);
+  res.json({ ok: true, sent: true });
+});
+
 // --- WebSocket + PTY ---
 
 const wss = new WebSocketServer({ server, path: "/ws/terminal" });

--- a/server/index.js
+++ b/server/index.js
@@ -280,15 +280,27 @@ async function sendTriggerMessage(projectId) {
   const headers = { "Content-Type": "application/json" };
   if (token) headers["x-session-token"] = token;
 
+  const info = triggers.get(projectId);
   try {
-    await fetch(`${chattrUrl}/api/send`, {
+    // Try with session token header
+    let tokenParam = token ? `?token=${encodeURIComponent(token)}` : "";
+    const res = await fetch(`${chattrUrl}/api/send${tokenParam}`, {
       method: "POST",
       headers,
       body: JSON.stringify({ text: message, channel: "general", sender: "user" }),
     });
-  } catch {}
+    if (!res.ok) {
+      const err = await res.text().catch(() => "");
+      console.error(`Trigger send failed for ${projectId}: ${res.status} ${err}`);
+      if (info) info.lastError = `${res.status}: ${err.slice(0, 100)}`;
+    } else {
+      if (info) info.lastError = null;
+    }
+  } catch (err) {
+    console.error(`Trigger send error for ${projectId}:`, err.message);
+    if (info) info.lastError = err.message;
+  }
 
-  const info = triggers.get(projectId);
   if (info) {
     info.lastSent = Date.now();
     info.nextAt = Date.now() + info.interval;
@@ -303,6 +315,7 @@ app.get("/api/triggers", (_req, res) => {
       interval: info.interval,
       lastSent: info.lastSent,
       nextAt: info.nextAt,
+      lastError: info.lastError || null,
     };
   }
   res.json(result);

--- a/server/index.js
+++ b/server/index.js
@@ -427,8 +427,47 @@ wss.on("connection", (ws, req) => {
   });
 });
 
+// --- Trigger auto-start from config ---
+
+function syncTriggersFromConfig() {
+  const cfg = readConfig();
+  const activeIds = new Set();
+
+  if (cfg.projects) {
+    for (const project of cfg.projects) {
+      if (project.trigger_enabled) {
+        activeIds.add(project.id);
+        const ms = (project.trigger_interval || 30) * 60 * 1000;
+        const existing = triggers.get(project.id);
+        // Only restart if interval changed or not running
+        if (!existing || existing.interval !== ms) {
+          if (existing && existing.timer) clearInterval(existing.timer);
+          const timer = setInterval(() => sendTriggerMessage(project.id), ms);
+          triggers.set(project.id, { interval: ms, timer, lastSent: null, nextAt: Date.now() + ms, lastError: null });
+        }
+      }
+    }
+  }
+
+  // Stop triggers for projects no longer enabled
+  for (const [id, info] of triggers) {
+    if (!activeIds.has(id)) {
+      if (info.timer) clearInterval(info.timer);
+      triggers.delete(id);
+    }
+  }
+}
+
+// Sync triggers when config changes (called after PUT /api/config from Next.js)
+app.post("/api/triggers/sync", (_req, res) => {
+  syncTriggersFromConfig();
+  res.json({ ok: true });
+});
+
 // --- Start ---
 
 server.listen(PORT, () => {
   console.log(`QuadWork server listening on http://localhost:${PORT}`);
+  // Auto-start enabled triggers from config
+  syncTriggersFromConfig();
 });

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -19,6 +19,11 @@ export async function PUT(req: Request) {
       fs.mkdirSync(dir, { recursive: true });
     }
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(body, null, 2));
+
+    // Notify backend to sync triggers from updated config
+    const port = body.port || 3001;
+    fetch(`http://127.0.0.1:${port}/api/triggers/sync`, { method: "POST" }).catch(() => {});
+
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {
     return NextResponse.json(

--- a/src/app/api/triggers/route.ts
+++ b/src/app/api/triggers/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+function getBackendPort(): number {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    return JSON.parse(raw).port || 3001;
+  } catch {
+    return 3001;
+  }
+}
+
+export async function GET() {
+  const port = getBackendPort();
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/triggers`);
+    return NextResponse.json(await res.json());
+  } catch {
+    return NextResponse.json({}, { status: 502 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const project = req.nextUrl.searchParams.get("project") || "";
+  const action = req.nextUrl.searchParams.get("action") || "start";
+  const port = getBackendPort();
+  const body = await req.json().catch(() => ({}));
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/triggers/${project}/${action}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch {
+    return NextResponse.json({ error: "Backend unreachable" }, { status: 502 });
+  }
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -6,6 +6,7 @@ import TerminalGrid from "./TerminalGrid";
 import PanelHeader from "./PanelHeader";
 import ChatPanel from "./ChatPanel";
 import GitHubPanel from "./GitHubPanel";
+import TriggerWidget from "./TriggerWidget";
 
 const MIN_SIZE = 150; // px
 const DIVIDER = 4; // px
@@ -153,12 +154,13 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
         onMouseDown={() => startDrag("row")}
       />
 
-      {/* Panel 3: Chat placeholder — bottom-left */}
+      {/* Panel 3: Chat — bottom-left */}
       <div className="flex flex-col overflow-hidden">
         <PanelHeader label="Chat" />
         <div className="flex-1 min-h-0">
           <ChatPanel />
         </div>
+        <TriggerWidget projectId={projectId} />
       </div>
 
       {/* Vertical divider — bottom segment */}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -25,6 +25,8 @@ interface ProjectConfig {
   working_dir: string;
   agents: Record<string, AgentConfig>;
   telegram?: TelegramConfig;
+  trigger_interval?: number;
+  trigger_message?: string;
 }
 
 interface Config {
@@ -354,6 +356,31 @@ export default function SettingsPage() {
                           )}
                         </div>
                       ))}
+                    </div>
+                  </div>
+
+                  {/* Scheduled Trigger */}
+                  <div className="mt-4">
+                    <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Scheduled Trigger</h3>
+                    <div className="border border-border p-3">
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
+                        <Input
+                          label="Interval (minutes)"
+                          value={String(project.trigger_interval || 30)}
+                          onChange={(v) => updateProject(idx, { trigger_interval: parseInt(v, 10) || 30 } as Partial<ProjectConfig>)}
+                          type="number"
+                        />
+                        <div className="flex flex-col gap-1">
+                          <label className="text-[11px] text-text-muted uppercase tracking-wider">Message Template</label>
+                          <textarea
+                            value={project.trigger_message || ""}
+                            onChange={(e) => updateProject(idx, { trigger_message: e.target.value } as Partial<ProjectConfig>)}
+                            placeholder="@t1 @t2a @t2b @t3 — Queue check..."
+                            rows={4}
+                            className="bg-transparent border border-border px-2 py-1.5 text-[11px] text-text outline-none focus:border-accent resize-y"
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -25,6 +25,7 @@ interface ProjectConfig {
   working_dir: string;
   agents: Record<string, AgentConfig>;
   telegram?: TelegramConfig;
+  trigger_enabled?: boolean;
   trigger_interval?: number;
   trigger_message?: string;
 }
@@ -363,6 +364,21 @@ export default function SettingsPage() {
                   <div className="mt-4">
                     <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Scheduled Trigger</h3>
                     <div className="border border-border p-3">
+                      <div className="flex items-center gap-3 mb-3">
+                        <button
+                          onClick={() => updateProject(idx, { trigger_enabled: !project.trigger_enabled } as Partial<ProjectConfig>)}
+                          className={`w-8 h-4 rounded-full transition-colors relative ${
+                            project.trigger_enabled ? "bg-accent" : "bg-border"
+                          }`}
+                        >
+                          <span
+                            className={`absolute top-0.5 w-3 h-3 rounded-full bg-text transition-transform ${
+                              project.trigger_enabled ? "left-4" : "left-0.5"
+                            }`}
+                          />
+                        </button>
+                        <span className="text-[11px] text-text">{project.trigger_enabled ? "Enabled" : "Disabled"}</span>
+                      </div>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
                         <Input
                           label="Interval (minutes)"

--- a/src/components/TriggerWidget.tsx
+++ b/src/components/TriggerWidget.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface TriggerInfo {
+  enabled: boolean;
+  interval: number;
+  lastSent: number | null;
+  nextAt: number | null;
+}
+
+interface TriggerWidgetProps {
+  projectId: string;
+}
+
+export default function TriggerWidget({ projectId }: TriggerWidgetProps) {
+  const [trigger, setTrigger] = useState<TriggerInfo | null>(null);
+  const [interval, setInterval_] = useState(30); // minutes
+  const [countdown, setCountdown] = useState("");
+
+  // Poll trigger status
+  useEffect(() => {
+    const poll = () => {
+      fetch("/api/triggers")
+        .then((r) => r.ok ? r.json() : {})
+        .then((data: Record<string, TriggerInfo>) => {
+          const t = data[projectId];
+          if (t) {
+            setTrigger(t);
+            setInterval_(Math.round(t.interval / 60000));
+          } else {
+            setTrigger(null);
+          }
+        })
+        .catch(() => {});
+    };
+    poll();
+    const id = window.setInterval(poll, 10000);
+    return () => window.clearInterval(id);
+  }, [projectId]);
+
+  // Countdown timer
+  useEffect(() => {
+    if (!trigger?.nextAt) { setCountdown(""); return; }
+    const tick = () => {
+      const remaining = Math.max(0, (trigger.nextAt || 0) - Date.now());
+      const mins = Math.floor(remaining / 60000);
+      const secs = Math.floor((remaining % 60000) / 1000);
+      setCountdown(`${mins}m ${secs}s`);
+    };
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [trigger?.nextAt]);
+
+  const start = () => {
+    fetch(`/api/triggers?project=${encodeURIComponent(projectId)}&action=start`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ interval }),
+    })
+      .then((r) => r.json())
+      .then((d) => { if (d.ok) setTrigger({ enabled: true, interval: d.interval, lastSent: null, nextAt: d.nextAt }); })
+      .catch(() => {});
+  };
+
+  const stop = () => {
+    fetch(`/api/triggers?project=${encodeURIComponent(projectId)}&action=stop`, { method: "POST" })
+      .then((r) => r.json())
+      .then((d) => { if (d.ok) setTrigger(null); })
+      .catch(() => {});
+  };
+
+  const sendNow = () => {
+    fetch(`/api/triggers?project=${encodeURIComponent(projectId)}&action=send-now`, { method: "POST" })
+      .catch(() => {});
+  };
+
+  const isEnabled = trigger?.enabled;
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 border-t border-border text-[11px]">
+      <span className={`w-1.5 h-1.5 rounded-full ${isEnabled ? "bg-accent" : "bg-text-muted"}`} />
+      <span className="text-text-muted">Trigger:</span>
+
+      {isEnabled ? (
+        <>
+          <span className="text-text tabular-nums">{countdown}</span>
+          <button
+            onClick={sendNow}
+            className="text-accent hover:underline"
+          >
+            Send Now
+          </button>
+          <button
+            onClick={stop}
+            className="text-text-muted hover:text-error"
+          >
+            Stop
+          </button>
+        </>
+      ) : (
+        <>
+          <input
+            type="number"
+            value={interval}
+            onChange={(e) => setInterval_(parseInt(e.target.value, 10) || 30)}
+            min={1}
+            max={1440}
+            className="w-12 bg-transparent border border-border px-1 py-0.5 text-[11px] text-text outline-none focus:border-accent text-center"
+          />
+          <span className="text-text-muted">min</span>
+          <button
+            onClick={start}
+            className="text-accent hover:underline"
+          >
+            Start
+          </button>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
**Backend** (`server/index.js`):
- Trigger scheduler with configurable interval per project
- `POST /api/triggers/:project/start|stop|send-now` endpoints
- `GET /api/triggers` returns all trigger states (enabled, interval, lastSent, nextAt)
- Reads `trigger_message` from project config, defaults to queue-check template
- Posts to AgentChattr `/api/send` on interval with session token auth

**Frontend**:
- `TriggerWidget` in Chat panel: status dot, live countdown timer, interval input, Start/Stop/Send Now buttons
- Settings page: trigger interval (minutes) + message template textarea per project
- Next.js API proxy at `/api/triggers`
- `npm run build` passes clean

Fixes #16

## Test plan
- [ ] Start trigger with interval, countdown shows
- [ ] Message posts to AgentChattr on schedule
- [ ] Send Now immediately posts
- [ ] Stop clears timer
- [ ] Settings page saves trigger interval + message template
- [ ] Status indicator shows enabled/disabled
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)