### PR TITLE
[#17] Project + agent naming with auto-apply

### DIFF
--- a/src/app/api/rename/route.ts
+++ b/src/app/api/rename/route.ts
@@ -80,9 +80,22 @@ export async function POST(req: NextRequest) {
         }
       }
 
-      // Propagate to AgentChattr config.toml
-      const tomlPath = path.join(os.homedir(), ".quadwork", `telegram-${projectId}.toml`);
-      if (replaceInFile(tomlPath, oldDisplayName, newName)) changes.push("config.toml");
+      // Propagate to AgentChattr config.toml (in working_dir or parent agentchattr dir)
+      // AgentChattr config.toml has [agents.X] sections with label = "Display Name"
+      if (workDir) {
+        // Try common AgentChattr config.toml locations
+        const tomlPaths = [
+          path.join(workDir, "agentchattr", "config.toml"),
+          path.join(workDir, "..", "agentchattr", "config.toml"),
+          path.join(workDir, "config.toml"),
+        ];
+        for (const tomlPath of tomlPaths) {
+          if (replaceInFile(tomlPath, `label = "${oldDisplayName}`, `label = "${newName}`)) {
+            changes.push("agentchattr/config.toml");
+            break;
+          }
+        }
+      }
 
       // Propagate to CLAUDE.md in working directory
       if (workDir) {

--- a/src/app/api/rename/route.ts
+++ b/src/app/api/rename/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+function readConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+  } catch {
+    return { projects: [] };
+  }
+}
+
+function writeConfig(cfg: unknown) {
+  const dir = path.dirname(CONFIG_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+}
+
+// POST /api/rename — propagate name changes
+export async function POST(req: NextRequest) {
+  const { type, projectId, oldName, newName, agentId } = await req.json();
+  const cfg = readConfig();
+  const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+
+  const changes: string[] = [];
+
+  if (type === "project") {
+    // Update project name in config
+    project.name = newName;
+    changes.push("config.json");
+
+    // Update trigger message if it references old name
+    if (project.trigger_message && project.trigger_message.includes(oldName)) {
+      project.trigger_message = project.trigger_message.replaceAll(oldName, newName);
+      changes.push("trigger_message");
+    }
+  }
+
+  if (type === "agent" && agentId) {
+    const agent = project.agents?.[agentId];
+    if (agent) {
+      const oldDisplayName = agent.display_name || agentId.toUpperCase();
+      agent.display_name = newName;
+      changes.push("config.json");
+
+      // Update AGENTS.md seed if it references old display name
+      if (agent.agents_md && agent.agents_md.includes(oldDisplayName)) {
+        agent.agents_md = agent.agents_md.replaceAll(oldDisplayName, newName);
+        changes.push("agents_md");
+      }
+
+      // Update trigger message @mentions
+      if (project.trigger_message) {
+        // Replace @oldName with @newName in trigger message
+        const oldMention = `@${oldDisplayName.toLowerCase()}`;
+        const newMention = `@${newName.toLowerCase()}`;
+        if (project.trigger_message.includes(oldMention)) {
+          project.trigger_message = project.trigger_message.replaceAll(oldMention, newMention);
+          changes.push("trigger_message");
+        }
+      }
+    }
+  }
+
+  writeConfig(cfg);
+
+  // Notify backend to sync triggers
+  const port = cfg.port || 3001;
+  fetch(`http://127.0.0.1:${port}/api/triggers/sync`, { method: "POST" }).catch(() => {});
+
+  return NextResponse.json({ ok: true, changes });
+}

--- a/src/app/api/rename/route.ts
+++ b/src/app/api/rename/route.ts
@@ -19,6 +19,18 @@ function writeConfig(cfg: unknown) {
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
 }
 
+function replaceInFile(filePath: string, oldStr: string, newStr: string): boolean {
+  try {
+    if (!fs.existsSync(filePath)) return false;
+    const content = fs.readFileSync(filePath, "utf-8");
+    if (!content.includes(oldStr)) return false;
+    fs.writeFileSync(filePath, content.replaceAll(oldStr, newStr));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // POST /api/rename — propagate name changes
 export async function POST(req: NextRequest) {
   const { type, projectId, oldName, newName, agentId } = await req.json();
@@ -27,16 +39,21 @@ export async function POST(req: NextRequest) {
   if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
 
   const changes: string[] = [];
+  const workDir = project.working_dir || "";
 
   if (type === "project") {
-    // Update project name in config
     project.name = newName;
     changes.push("config.json");
 
-    // Update trigger message if it references old name
     if (project.trigger_message && project.trigger_message.includes(oldName)) {
       project.trigger_message = project.trigger_message.replaceAll(oldName, newName);
       changes.push("trigger_message");
+    }
+
+    // Propagate to CLAUDE.md in working directory
+    if (workDir) {
+      const claudeMd = path.join(workDir, "CLAUDE.md");
+      if (replaceInFile(claudeMd, oldName, newName)) changes.push("CLAUDE.md");
     }
   }
 
@@ -47,7 +64,7 @@ export async function POST(req: NextRequest) {
       agent.display_name = newName;
       changes.push("config.json");
 
-      // Update AGENTS.md seed if it references old display name
+      // Update AGENTS.md seed
       if (agent.agents_md && agent.agents_md.includes(oldDisplayName)) {
         agent.agents_md = agent.agents_md.replaceAll(oldDisplayName, newName);
         changes.push("agents_md");
@@ -55,13 +72,28 @@ export async function POST(req: NextRequest) {
 
       // Update trigger message @mentions
       if (project.trigger_message) {
-        // Replace @oldName with @newName in trigger message
         const oldMention = `@${oldDisplayName.toLowerCase()}`;
         const newMention = `@${newName.toLowerCase()}`;
         if (project.trigger_message.includes(oldMention)) {
           project.trigger_message = project.trigger_message.replaceAll(oldMention, newMention);
           changes.push("trigger_message");
         }
+      }
+
+      // Propagate to AgentChattr config.toml
+      const tomlPath = path.join(os.homedir(), ".quadwork", `telegram-${projectId}.toml`);
+      if (replaceInFile(tomlPath, oldDisplayName, newName)) changes.push("config.toml");
+
+      // Propagate to CLAUDE.md in working directory
+      if (workDir) {
+        const claudeMd = path.join(workDir, "CLAUDE.md");
+        if (replaceInFile(claudeMd, oldDisplayName, newName)) changes.push("CLAUDE.md");
+      }
+
+      // Propagate to AGENTS.md files in agent worktree cwds
+      if (agent.cwd) {
+        const agentsMd = path.join(agent.cwd, "AGENTS.md");
+        if (replaceInFile(agentsMd, oldDisplayName, newName)) changes.push("AGENTS.md");
       }
     }
   }

--- a/src/app/api/rename/route.ts
+++ b/src/app/api/rename/route.ts
@@ -60,7 +60,9 @@ export async function POST(req: NextRequest) {
   if (type === "agent" && agentId) {
     const agent = project.agents?.[agentId];
     if (agent) {
-      const oldDisplayName = agent.display_name || agentId.toUpperCase();
+      // Use the oldName from the request, not from current config
+      // (config may have already been updated by a Save before debounce fires)
+      const oldDisplayName = oldName || agent.display_name || agentId.toUpperCase();
       agent.display_name = newName;
       changes.push("config.json");
 

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -42,7 +42,7 @@ export default function HomeDashboard() {
         return r.json();
       })
       .then((data) => {
-        if (data.projects && Array.isArray(data.projects)) setProjects(data.projects);
+        if (data.projects && Array.isArray(data.projects)) setProjects(data.projects.filter((p: Project & { archived?: boolean }) => !p.archived));
         if (data.recentEvents && Array.isArray(data.recentEvents)) setActivity(data.recentEvents);
       })
       .catch(() => {});

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 
 interface AgentConfig {
@@ -204,36 +204,68 @@ export default function SettingsPage() {
     setExpanded({ ...expanded, [id]: true });
   };
 
+  // Track original names for debounced rename propagation
+  const originalNames = useRef<Record<string, string>>({});
+  const renameTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
   const renameProject = (idx: number, newName: string) => {
     if (!config) return;
     const project = config.projects[idx];
-    const oldName = project.name;
-    if (oldName === newName) return;
+    const key = `project:${project.id}`;
 
-    // Propagate rename via API, then reload config to get server-side changes
-    fetch("/api/rename", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ type: "project", projectId: project.id, oldName, newName }),
-    })
-      .then(() => load())
-      .catch(() => {});
+    // Store the original name on first edit
+    if (!(key in originalNames.current)) {
+      originalNames.current[key] = project.name;
+    }
+
+    // Update local state immediately for responsive UI
+    updateProject(idx, { name: newName });
+
+    // Debounce the API propagation (800ms after last keystroke)
+    if (renameTimers.current[key]) clearTimeout(renameTimers.current[key]);
+    renameTimers.current[key] = setTimeout(() => {
+      const oldName = originalNames.current[key];
+      if (oldName && oldName !== newName) {
+        fetch("/api/rename", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "project", projectId: project.id, oldName, newName }),
+        })
+          .then(() => load())
+          .catch(() => {});
+      }
+      delete originalNames.current[key];
+      delete renameTimers.current[key];
+    }, 800);
   };
 
   const renameAgent = (projectIdx: number, agentId: string, newName: string) => {
     if (!config) return;
     const project = config.projects[projectIdx];
     const agent = project.agents?.[agentId];
-    const oldName = agent?.display_name || agentId.toUpperCase();
-    if (oldName === newName) return;
+    const key = `agent:${project.id}:${agentId}`;
 
-    fetch("/api/rename", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ type: "agent", projectId: project.id, agentId, oldName, newName }),
-    })
-      .then(() => load())
-      .catch(() => {});
+    if (!(key in originalNames.current)) {
+      originalNames.current[key] = agent?.display_name || agentId.toUpperCase();
+    }
+
+    updateAgent(projectIdx, agentId, { display_name: newName });
+
+    if (renameTimers.current[key]) clearTimeout(renameTimers.current[key]);
+    renameTimers.current[key] = setTimeout(() => {
+      const oldName = originalNames.current[key];
+      if (oldName && oldName !== newName) {
+        fetch("/api/rename", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "agent", projectId: project.id, agentId, oldName, newName }),
+        })
+          .then(() => load())
+          .catch(() => {});
+      }
+      delete originalNames.current[key];
+      delete renameTimers.current[key];
+    }, 800);
   };
 
   const archiveProject = (idx: number) => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -210,14 +210,14 @@ export default function SettingsPage() {
     const oldName = project.name;
     if (oldName === newName) return;
 
-    // Propagate rename via API
+    // Propagate rename via API, then reload config to get server-side changes
     fetch("/api/rename", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "project", projectId: project.id, oldName, newName }),
-    }).catch(() => {});
-
-    updateProject(idx, { name: newName });
+    })
+      .then(() => load())
+      .catch(() => {});
   };
 
   const renameAgent = (projectIdx: number, agentId: string, newName: string) => {
@@ -231,9 +231,9 @@ export default function SettingsPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "agent", projectId: project.id, agentId, oldName, newName }),
-    }).catch(() => {});
-
-    updateAgent(projectIdx, agentId, { display_name: newName });
+    })
+      .then(() => load())
+      .catch(() => {});
   };
 
   const archiveProject = (idx: number) => {
@@ -297,9 +297,10 @@ export default function SettingsPage() {
 
       {/* Per-project settings */}
       <section className="mb-6">
-        <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">Projects</h2>
+        <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">Active Projects</h2>
 
-        {config.projects.map((project, idx) => {
+        {config.projects.filter((p) => !p.archived).map((project) => {
+          const idx = config.projects.indexOf(project);
           const isExpanded = expanded[project.id] ?? false;
           const telegram = project.telegram || { enabled: false, bot_token: "", chat_id: "" };
 
@@ -596,6 +597,44 @@ export default function SettingsPage() {
         >
           + Add Project
         </button>
+
+        {/* Archived projects */}
+        {config.projects.some((p) => p.archived) && (
+          <>
+            <hr className="border-border my-4" />
+            <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">Archived</h2>
+            {config.projects.filter((p) => p.archived).map((project) => {
+              const idx = config.projects.indexOf(project);
+              return (
+                <div key={project.id} className="border border-border mb-3 opacity-60">
+                  <div className="flex items-center justify-between px-3 py-2">
+                    <span className="text-[12px] text-text-muted">{project.name}</span>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => restoreProject(idx)}
+                        className="text-[11px] text-accent hover:underline"
+                      >
+                        Restore
+                      </button>
+                      <button
+                        onClick={() => {
+                          if (confirmDelete === project.id) {
+                            removeProject(idx);
+                          } else {
+                            setConfirmDelete(project.id);
+                          }
+                        }}
+                        className="text-[11px] text-error hover:underline"
+                      >
+                        {confirmDelete === project.id ? "Confirm Remove" : "Remove"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </>
+        )}
       </section>
 
       {/* Bottom save */}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -28,6 +28,7 @@ interface ProjectConfig {
   trigger_enabled?: boolean;
   trigger_interval?: number;
   trigger_message?: string;
+  archived?: boolean;
 }
 
 interface Config {
@@ -203,6 +204,48 @@ export default function SettingsPage() {
     setExpanded({ ...expanded, [id]: true });
   };
 
+  const renameProject = (idx: number, newName: string) => {
+    if (!config) return;
+    const project = config.projects[idx];
+    const oldName = project.name;
+    if (oldName === newName) return;
+
+    // Propagate rename via API
+    fetch("/api/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "project", projectId: project.id, oldName, newName }),
+    }).catch(() => {});
+
+    updateProject(idx, { name: newName });
+  };
+
+  const renameAgent = (projectIdx: number, agentId: string, newName: string) => {
+    if (!config) return;
+    const project = config.projects[projectIdx];
+    const agent = project.agents?.[agentId];
+    const oldName = agent?.display_name || agentId.toUpperCase();
+    if (oldName === newName) return;
+
+    fetch("/api/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "agent", projectId: project.id, agentId, oldName, newName }),
+    }).catch(() => {});
+
+    updateAgent(projectIdx, agentId, { display_name: newName });
+  };
+
+  const archiveProject = (idx: number) => {
+    if (!config) return;
+    updateProject(idx, { archived: true });
+  };
+
+  const restoreProject = (idx: number) => {
+    if (!config) return;
+    updateProject(idx, { archived: false });
+  };
+
   const removeProject = (idx: number) => {
     if (!config) return;
     const projects = config.projects.filter((_, i) => i !== idx);
@@ -278,7 +321,7 @@ export default function SettingsPage() {
                     <Input
                       label="Project Name"
                       value={project.name}
-                      onChange={(v) => updateProject(idx, { name: v })}
+                      onChange={(v) => renameProject(idx, v)}
                     />
                     <Input
                       label="GitHub Repo"
@@ -308,11 +351,16 @@ export default function SettingsPage() {
                       {Object.entries(project.agents || {}).map(([agentId, agent]) => (
                         <div key={agentId} className="border-b border-border/50 last:border-b-0">
                           <div className="grid grid-cols-5 gap-0 px-2 py-1">
-                            <input
-                              value={agent.display_name || agentId.toUpperCase()}
-                              onChange={(e) => updateAgent(idx, agentId, { display_name: e.target.value })}
-                              className="bg-transparent text-[11px] text-text font-semibold outline-none border border-border px-1 py-0.5 focus:border-accent"
-                            />
+                            <div className="flex flex-col gap-0.5">
+                              <input
+                                value={agent.display_name || agentId.toUpperCase()}
+                                onChange={(e) => renameAgent(idx, agentId, e.target.value)}
+                                className="bg-transparent text-[11px] text-text font-semibold outline-none border border-border px-1 py-0.5 focus:border-accent"
+                              />
+                              <span className="text-[9px] text-text-muted px-1">
+                                {agentId === "t1" ? "Owner" : agentId.startsWith("t2") ? "Reviewer" : "Builder"}
+                              </span>
+                            </div>
                             <select
                               value={agent.command || "claude"}
                               onChange={(e) => updateAgent(idx, agentId, { command: e.target.value })}
@@ -494,10 +542,25 @@ export default function SettingsPage() {
                   </div>
 
                   {/* Remove project */}
-                  <div className="mt-4 flex justify-end">
+                  <div className="mt-4 flex justify-end gap-3">
+                    {project.archived ? (
+                      <button
+                        onClick={() => restoreProject(idx)}
+                        className="text-[11px] text-accent hover:underline"
+                      >
+                        Restore Project
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => archiveProject(idx)}
+                        className="text-[11px] text-text-muted hover:text-text transition-colors"
+                      >
+                        Archive
+                      </button>
+                    )}
                     {confirmDelete === project.id ? (
                       <div className="flex items-center gap-2">
-                        <span className="text-[11px] text-error">Remove this project?</span>
+                        <span className="text-[11px] text-error">Remove?</span>
                         <button
                           onClick={() => removeProject(idx)}
                           className="px-2 py-1 text-[11px] bg-error text-bg font-semibold"
@@ -516,7 +579,7 @@ export default function SettingsPage() {
                         onClick={() => setConfirmDelete(project.id)}
                         className="text-[11px] text-error hover:text-text transition-colors"
                       >
-                        Remove Project
+                        Remove
                       </button>
                     )}
                   </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -108,7 +108,7 @@ export default function Sidebar() {
         if (!r.ok) throw new Error(`Config fetch failed: ${r.status}`);
         return r.json();
       })
-      .then((cfg) => setProjects(cfg.projects || []))
+      .then((cfg) => setProjects((cfg.projects || []).filter((p: Project & { archived?: boolean }) => !p.archived)))
       .catch((err) => console.error(err.message));
   }, []);
 


### PR DESCRIPTION
## Summary
- `POST /api/rename`: propagates project/agent renames across config, AGENTS.md seeds, trigger message templates, and @mentions
- **Project rename**: settings name change triggers auto-propagation to config + trigger messages
- **Agent rename**: display name change propagates to config, AGENTS.md seed, trigger message @mentions
- Agent table shows role label (Owner/Reviewer/Builder) under editable display name
- **Archive/restore**: archive hides project from sidebar + home, keeps config. Restore brings it back. Both visible in settings.
- Sidebar + HomeDashboard filter out archived projects
- `npm run build` passes clean

Fixes #17

## Test plan
- [ ] Renaming project updates config and sidebar/home
- [ ] Renaming agent display name propagates to config and trigger template
- [ ] Agent table shows role labels
- [ ] Archive hides project from sidebar and home
- [ ] Restore brings archived project back
- [ ] Remove with confirmation deletes project
- [ ] Archived section visible in settings
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)