### PR TITLE
[#18] Add-project setup wizard

### DIFF
--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+const REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+
+function exec(cmd: string, args: string[], opts?: { cwd?: string }): { ok: boolean; output: string } {
+  try {
+    const out = execFileSync(cmd, args, { encoding: "utf-8", timeout: 30000, ...opts });
+    return { ok: true, output: out.trim() };
+  } catch (err) {
+    return { ok: false, output: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// POST /api/setup?step=verify-repo|create-worktrees|seed-files|add-config
+export async function POST(req: NextRequest) {
+  const step = req.nextUrl.searchParams.get("step");
+  const body = await req.json().catch(() => ({}));
+
+  switch (step) {
+    case "verify-repo":
+      return verifyRepo(body.repo);
+    case "create-worktrees":
+      return createWorktrees(body.workingDir, body.repo);
+    case "seed-files":
+      return seedFiles(body.workingDir, body.projectName, body.repo);
+    case "add-config":
+      return addConfig(body);
+    default:
+      return NextResponse.json({ error: "Unknown step" }, { status: 400 });
+  }
+}
+
+function verifyRepo(repo: string) {
+  if (!repo || !REPO_RE.test(repo)) {
+    return NextResponse.json({ ok: false, error: "Invalid repo format (use owner/repo)" });
+  }
+  const result = exec("gh", ["repo", "view", repo, "--json", "name,owner"]);
+  return NextResponse.json({ ok: result.ok, error: result.ok ? undefined : "Cannot access repo. Check gh auth and repo permissions." });
+}
+
+function createWorktrees(workingDir: string, repo: string) {
+  if (!workingDir) return NextResponse.json({ ok: false, error: "Missing working directory" });
+
+  // Clone if not a git repo
+  if (!fs.existsSync(path.join(workingDir, ".git"))) {
+    if (!fs.existsSync(workingDir)) {
+      fs.mkdirSync(workingDir, { recursive: true });
+    }
+    if (!REPO_RE.test(repo)) return NextResponse.json({ ok: false, error: "Invalid repo" });
+    const clone = exec("gh", ["repo", "clone", repo, workingDir]);
+    if (!clone.ok) return NextResponse.json({ ok: false, error: `Clone failed: ${clone.output}` });
+  }
+
+  const agents = ["t1", "t2a", "t2b", "t3"];
+  const created: string[] = [];
+  const errors: string[] = [];
+
+  for (const agent of agents) {
+    const wtDir = path.join(workingDir, agent);
+    if (fs.existsSync(wtDir)) {
+      created.push(`${agent} (exists)`);
+      continue;
+    }
+    const result = exec("git", ["worktree", "add", wtDir, "main"], { cwd: workingDir });
+    if (result.ok) {
+      created.push(agent);
+    } else {
+      errors.push(`${agent}: ${result.output}`);
+    }
+  }
+
+  return NextResponse.json({ ok: errors.length === 0, created, errors });
+}
+
+function seedFiles(workingDir: string, projectName: string, repo: string) {
+  if (!workingDir) return NextResponse.json({ ok: false, error: "Missing working directory" });
+
+  const agents = ["t1", "t2a", "t2b", "t3"];
+  const seeded: string[] = [];
+
+  for (const agent of agents) {
+    const wtDir = path.join(workingDir, agent);
+    if (!fs.existsSync(wtDir)) continue;
+
+    // AGENTS.md
+    const agentsMd = path.join(wtDir, "AGENTS.md");
+    if (!fs.existsSync(agentsMd)) {
+      fs.writeFileSync(agentsMd, `# ${projectName} — ${agent.toUpperCase()} Agent\n\nRepo: ${repo}\nRole: ${agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}\n`);
+      seeded.push(`${agent}/AGENTS.md`);
+    }
+
+    // CLAUDE.md
+    const claudeMd = path.join(wtDir, "CLAUDE.md");
+    if (!fs.existsSync(claudeMd)) {
+      fs.writeFileSync(claudeMd, `# ${projectName}\n\nBranch: task/<issue>-<slug>\nCommit: [#<issue>] Short description\nNever push to main.\n`);
+      seeded.push(`${agent}/CLAUDE.md`);
+    }
+  }
+
+  return NextResponse.json({ ok: true, seeded });
+}
+
+function addConfig(body: { id: string; name: string; repo: string; workingDir: string; backend: string }) {
+  const { id, name, repo, workingDir, backend } = body;
+
+  let cfg;
+  try {
+    cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+  } catch {
+    cfg = { port: 3001, agentchattr_url: "http://127.0.0.1:8300", projects: [] };
+  }
+
+  // Check if project already exists
+  if (cfg.projects.some((p: { id: string }) => p.id === id)) {
+    return NextResponse.json({ ok: true, message: "Project already in config" });
+  }
+
+  const agents: Record<string, { display_name: string; command: string; cwd: string; model: string; agents_md: string }> = {};
+  for (const [agentId, role] of [["t1", "opus"], ["t2a", "sonnet"], ["t2b", "sonnet"], ["t3", "sonnet"]]) {
+    agents[agentId] = {
+      display_name: agentId.toUpperCase(),
+      command: backend || "claude",
+      cwd: path.join(workingDir, agentId),
+      model: role,
+      agents_md: "",
+    };
+  }
+
+  cfg.projects.push({ id, name, repo, working_dir: workingDir, agents });
+
+  const dir = path.dirname(CONFIG_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     case "seed-files":
       return seedFiles(body.workingDir, body.projectName, body.repo);
     case "agentchattr-config":
-      return updateAgentChattr(body.workingDir, body.projectName, body.backend);
+      return updateAgentChattr(body.workingDir, body.projectName, body.backends);
     case "add-config":
       return addConfig(body);
     default:
@@ -108,7 +108,7 @@ function seedFiles(workingDir: string, projectName: string, repo: string) {
   return NextResponse.json({ ok: true, seeded });
 }
 
-function updateAgentChattr(workingDir: string, projectName: string, backend?: string) {
+function updateAgentChattr(workingDir: string, projectName: string, backends?: Record<string, string>) {
   if (!workingDir) return NextResponse.json({ ok: false, error: "Missing working directory" });
 
   // Find AgentChattr config.toml
@@ -132,7 +132,7 @@ function updateAgentChattr(workingDir: string, projectName: string, backend?: st
     let content = `[meta]\nname = "${projectName}"\n\n`;
 
     agents.forEach((agent, i) => {
-      content += `[agents.${agent}]\ncommand = "${backend || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
+      content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
     });
 
     fs.writeFileSync(tomlPath, content);
@@ -145,7 +145,7 @@ function updateAgentChattr(workingDir: string, projectName: string, backend?: st
 
     agents.forEach((agent, i) => {
       if (!content.includes(`[agents.${agent}]`)) {
-        content += `\n[agents.${agent}]\ncommand = "${backend || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
+        content += `\n[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
       }
     });
 
@@ -162,8 +162,8 @@ function updateAgentChattr(workingDir: string, projectName: string, backend?: st
   return NextResponse.json({ ok: true, path: tomlPath });
 }
 
-function addConfig(body: { id: string; name: string; repo: string; workingDir: string; backend: string }) {
-  const { id, name, repo, workingDir, backend } = body;
+function addConfig(body: { id: string; name: string; repo: string; workingDir: string; backends?: Record<string, string> }) {
+  const { id, name, repo, workingDir, backends } = body;
 
   let cfg;
   try {
@@ -181,7 +181,7 @@ function addConfig(body: { id: string; name: string; repo: string; workingDir: s
   for (const [agentId, role] of [["t1", "opus"], ["t2a", "sonnet"], ["t2b", "sonnet"], ["t3", "sonnet"]]) {
     agents[agentId] = {
       display_name: agentId.toUpperCase(),
-      command: backend || "claude",
+      command: (backends && backends[agentId]) || "claude",
       cwd: path.join(workingDir, agentId),
       model: role,
       agents_md: "",

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     case "seed-files":
       return seedFiles(body.workingDir, body.projectName, body.repo);
     case "agentchattr-config":
-      return updateAgentChattr(body.workingDir, body.projectName);
+      return updateAgentChattr(body.workingDir, body.projectName, body.backend);
     case "add-config":
       return addConfig(body);
     default:
@@ -108,7 +108,7 @@ function seedFiles(workingDir: string, projectName: string, repo: string) {
   return NextResponse.json({ ok: true, seeded });
 }
 
-function updateAgentChattr(workingDir: string, projectName: string) {
+function updateAgentChattr(workingDir: string, projectName: string, backend?: string) {
   if (!workingDir) return NextResponse.json({ ok: false, error: "Missing working directory" });
 
   // Find AgentChattr config.toml
@@ -132,7 +132,7 @@ function updateAgentChattr(workingDir: string, projectName: string) {
     let content = `[meta]\nname = "${projectName}"\n\n`;
 
     agents.forEach((agent, i) => {
-      content += `[agents.${agent}]\ncommand = "claude"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
+      content += `[agents.${agent}]\ncommand = "${backend || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
     });
 
     fs.writeFileSync(tomlPath, content);
@@ -145,7 +145,7 @@ function updateAgentChattr(workingDir: string, projectName: string) {
 
     agents.forEach((agent, i) => {
       if (!content.includes(`[agents.${agent}]`)) {
-        content += `\n[agents.${agent}]\ncommand = "claude"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
+        content += `\n[agents.${agent}]\ncommand = "${backend || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
       }
     });
 

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -28,6 +28,8 @@ export async function POST(req: NextRequest) {
       return createWorktrees(body.workingDir, body.repo);
     case "seed-files":
       return seedFiles(body.workingDir, body.projectName, body.repo);
+    case "agentchattr-config":
+      return updateAgentChattr(body.workingDir, body.projectName);
     case "add-config":
       return addConfig(body);
     default:
@@ -66,7 +68,8 @@ function createWorktrees(workingDir: string, repo: string) {
       created.push(`${agent} (exists)`);
       continue;
     }
-    const result = exec("git", ["worktree", "add", wtDir, "main"], { cwd: workingDir });
+    // Use -b to create a new branch per agent (avoids "main already used" error)
+    const result = exec("git", ["worktree", "add", "-b", `worktree/${agent}`, wtDir, "HEAD"], { cwd: workingDir });
     if (result.ok) {
       created.push(agent);
     } else {
@@ -103,6 +106,60 @@ function seedFiles(workingDir: string, projectName: string, repo: string) {
   }
 
   return NextResponse.json({ ok: true, seeded });
+}
+
+function updateAgentChattr(workingDir: string, projectName: string) {
+  if (!workingDir) return NextResponse.json({ ok: false, error: "Missing working directory" });
+
+  // Find AgentChattr config.toml
+  const tomlPaths = [
+    path.join(workingDir, "agentchattr", "config.toml"),
+    path.join(workingDir, "..", "agentchattr", "config.toml"),
+    path.join(os.homedir(), ".agentchattr", "config.toml"),
+  ];
+
+  let tomlPath = tomlPaths.find((p) => fs.existsSync(p));
+
+  if (!tomlPath) {
+    // Create a default config.toml
+    const dir = path.join(workingDir, "agentchattr");
+    fs.mkdirSync(dir, { recursive: true });
+    tomlPath = path.join(dir, "config.toml");
+
+    const agents = ["t1", "t2a", "t2b", "t3"];
+    const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
+    const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
+    let content = `[meta]\nname = "${projectName}"\n\n`;
+
+    agents.forEach((agent, i) => {
+      content += `[agents.${agent}]\ncommand = "claude"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
+    });
+
+    fs.writeFileSync(tomlPath, content);
+  } else {
+    // Append missing agents to existing config
+    let content = fs.readFileSync(tomlPath, "utf-8");
+    const agents = ["t1", "t2a", "t2b", "t3"];
+    const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
+    const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
+
+    agents.forEach((agent, i) => {
+      if (!content.includes(`[agents.${agent}]`)) {
+        content += `\n[agents.${agent}]\ncommand = "claude"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
+      }
+    });
+
+    fs.writeFileSync(tomlPath, content);
+  }
+
+  // Try to restart AgentChattr if running
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const port = cfg.port || 3001;
+    fetch(`http://127.0.0.1:${port}/api/agentchattr/restart`, { method: "POST" }).catch(() => {});
+  } catch {}
+
+  return NextResponse.json({ ok: true, path: tomlPath });
 }
 
 function addConfig(body: { id: string; name: string; repo: string; workingDir: string; backend: string }) {

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,0 +1,5 @@
+import SetupWizard from "@/components/SetupWizard";
+
+export default function SetupPage() {
+  return <SetupWizard />;
+}

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -108,7 +108,7 @@ export default function HomeDashboard() {
 
         {/* + New Project */}
         <Link
-          href="/settings?add=true"
+          href="/setup"
           className="border border-dashed border-border p-4 flex items-center justify-center text-text-muted hover:text-text hover:border-text-muted transition-colors min-h-[88px]"
         >
           <span className="text-sm">+ New Project</span>

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -35,7 +35,9 @@ export default function SetupWizard() {
   // Form state
   const [projectName, setProjectName] = useState("");
   const [repo, setRepo] = useState("");
-  const [backend, setBackend] = useState("claude-code");
+  const [backends, setBackends] = useState<Record<string, string>>({
+    t1: "claude-code", t2a: "claude-code", t2b: "claude-code", t3: "claude-code",
+  });
   const [workingDir, setWorkingDir] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -104,7 +106,7 @@ export default function SetupWizard() {
 
   const saveConfig = async () => {
     const id = projectName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
-    const result = await apiCall("add-config", { id, name: projectName, repo, workingDir, backend });
+    const result = await apiCall("add-config", { id, name: projectName, repo, workingDir, backends });
     if (result.ok) {
       updateStep(currentStep, { status: "done" });
       setTimeout(() => router.push(`/project/${id}`), 500);
@@ -197,6 +199,13 @@ export default function SetupWizard() {
                   </div>
                   <p className="text-text mt-1">→ Add rule for &quot;main&quot; → Require 1 approval → Save</p>
                 </div>
+                <div>
+                  <p className="text-text-muted mb-1">Add reviewer as collaborator (replace USERNAME):</p>
+                  <div className="flex items-center gap-2">
+                    <code className="text-accent flex-1 select-all">{`gh api repos/${repo}/collaborators/USERNAME -X PUT -f permission=push`}</code>
+                    <button onClick={() => navigator.clipboard.writeText(`gh api repos/${repo}/collaborators/USERNAME -X PUT -f permission=push`)} className="text-[10px] text-text-muted hover:text-accent shrink-0">copy</button>
+                  </div>
+                </div>
               </div>
               <div className="flex gap-2">
                 <button onClick={goNext} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors">
@@ -211,14 +220,22 @@ export default function SetupWizard() {
 
           {step?.id === "backend" && (
             <div>
-              <h2 className="text-sm font-semibold text-text mb-3">CLI Backend</h2>
-              <select
-                value={backend}
-                onChange={(e) => setBackend(e.target.value)}
-                className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent mb-3 cursor-pointer"
-              >
-                {BACKENDS.map((b) => <option key={b} value={b} className="bg-bg-surface">{b}</option>)}
-              </select>
+              <h2 className="text-sm font-semibold text-text mb-3">CLI Backend per Agent</h2>
+              <div className="border border-border mb-3">
+                {["t1", "t2a", "t2b", "t3"].map((agent) => (
+                  <div key={agent} className="flex items-center justify-between px-3 py-1.5 border-b border-border/50 last:border-b-0">
+                    <span className="text-[11px] text-text font-semibold w-10">{agent.toUpperCase()}</span>
+                    <span className="text-[10px] text-text-muted w-16">{agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}</span>
+                    <select
+                      value={backends[agent]}
+                      onChange={(e) => setBackends({ ...backends, [agent]: e.target.value })}
+                      className="bg-transparent border border-border px-2 py-0.5 text-[11px] text-text outline-none focus:border-accent cursor-pointer"
+                    >
+                      {BACKENDS.map((b) => <option key={b} value={b} className="bg-bg-surface">{b}</option>)}
+                    </select>
+                  </div>
+                ))}
+              </div>
               <button onClick={goNext} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors">
                 Next
               </button>
@@ -280,7 +297,7 @@ export default function SetupWizard() {
               <div className="flex gap-2">
                 <button
                   onClick={async () => {
-                    const result = await apiCall("agentchattr-config", { workingDir, projectName, repo, backend });
+                    const result = await apiCall("agentchattr-config", { workingDir, projectName, repo, backends });
                     if (result.ok) goNext();
                     else updateStep(currentStep, { status: "error", error: result.error });
                   }}
@@ -302,7 +319,7 @@ export default function SetupWizard() {
               <div className="border border-border bg-bg-surface p-3 mb-3 text-[11px] text-text space-y-1">
                 <p><strong>Name:</strong> {projectName}</p>
                 <p><strong>Repo:</strong> {repo}</p>
-                <p><strong>Backend:</strong> {backend}</p>
+                <p><strong>Backends:</strong> {Object.entries(backends).map(([a, b]) => `${a.toUpperCase()}=${b}`).join(", ")}</p>
                 <p><strong>Directory:</strong> {workingDir}</p>
                 <p><strong>Agents:</strong> T1, T2a, T2b, T3</p>
               </div>

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -180,12 +180,23 @@ export default function SetupWizard() {
           {step?.id === "protection" && (
             <div>
               <h2 className="text-sm font-semibold text-text mb-3">Branch Protection</h2>
-              <p className="text-[11px] text-text-muted mb-3">Ensure branch protection is configured on <code className="text-accent">main</code>:</p>
-              <div className="border border-border bg-bg-surface p-3 mb-3 text-[11px] text-text space-y-1">
-                <p>1. Go to GitHub → Settings → Branches → Add rule for <code className="text-accent">main</code></p>
-                <p>2. Enable &quot;Require pull request reviews before merging&quot;</p>
-                <p>3. Set required approvals to 1</p>
-                <p>4. Add reviewer account as collaborator with write access</p>
+              <p className="text-[11px] text-text-muted mb-3">Configure branch protection on <code className="text-accent">main</code>. Run these commands or configure via GitHub UI:</p>
+              <div className="border border-border bg-bg-surface p-3 mb-3 text-[11px] space-y-2">
+                <div>
+                  <p className="text-text-muted mb-1">Enable branch protection via gh CLI:</p>
+                  <div className="flex items-center gap-2">
+                    <code className="text-accent flex-1 select-all">{`gh api repos/${repo}/branches/main/protection -X PUT -f "required_pull_request_reviews[required_approving_review_count]=1" -f "enforce_admins=false" -f "required_status_checks=null" -f "restrictions=null"`}</code>
+                    <button onClick={() => navigator.clipboard.writeText(`gh api repos/${repo}/branches/main/protection -X PUT -f "required_pull_request_reviews[required_approving_review_count]=1" -f "enforce_admins=false" -f "required_status_checks=null" -f "restrictions=null"`)} className="text-[10px] text-text-muted hover:text-accent shrink-0">copy</button>
+                  </div>
+                </div>
+                <div>
+                  <p className="text-text-muted mb-1">Or manually in GitHub UI:</p>
+                  <div className="flex items-center gap-2">
+                    <code className="text-accent flex-1 select-all">{`https://github.com/${repo}/settings/branches`}</code>
+                    <button onClick={() => navigator.clipboard.writeText(`https://github.com/${repo}/settings/branches`)} className="text-[10px] text-text-muted hover:text-accent shrink-0">copy</button>
+                  </div>
+                  <p className="text-text mt-1">→ Add rule for &quot;main&quot; → Require 1 approval → Save</p>
+                </div>
               </div>
               <div className="flex gap-2">
                 <button onClick={goNext} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors">
@@ -269,7 +280,7 @@ export default function SetupWizard() {
               <div className="flex gap-2">
                 <button
                   onClick={async () => {
-                    const result = await apiCall("agentchattr-config", { workingDir, projectName, repo });
+                    const result = await apiCall("agentchattr-config", { workingDir, projectName, repo, backend });
                     if (result.ok) goNext();
                     else updateStep(currentStep, { status: "error", error: result.error });
                   }}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type StepStatus = "pending" | "active" | "done" | "error" | "skipped";
+
+interface Step {
+  id: string;
+  label: string;
+  status: StepStatus;
+  error?: string;
+  optional?: boolean;
+}
+
+const INITIAL_STEPS: Step[] = [
+  { id: "name", label: "Project Name", status: "active" },
+  { id: "repo", label: "GitHub Repo", status: "pending" },
+  { id: "protection", label: "Branch Protection", status: "pending", optional: true },
+  { id: "backend", label: "CLI Backend", status: "pending" },
+  { id: "workdir", label: "Working Directory", status: "pending" },
+  { id: "worktrees", label: "Worktree Setup", status: "pending" },
+  { id: "seeds", label: "Seed Files", status: "pending" },
+  { id: "config", label: "Save Config", status: "pending" },
+];
+
+const BACKENDS = ["claude-code", "codex"];
+
+export default function SetupWizard() {
+  const router = useRouter();
+  const [steps, setSteps] = useState<Step[]>(INITIAL_STEPS);
+  const [currentStep, setCurrentStep] = useState(0);
+
+  // Form state
+  const [projectName, setProjectName] = useState("");
+  const [repo, setRepo] = useState("");
+  const [backend, setBackend] = useState("claude-code");
+  const [workingDir, setWorkingDir] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const updateStep = (idx: number, updates: Partial<Step>) => {
+    setSteps((prev) => prev.map((s, i) => (i === idx ? { ...s, ...updates } : s)));
+  };
+
+  const goNext = () => {
+    updateStep(currentStep, { status: "done" });
+    const next = currentStep + 1;
+    if (next < steps.length) {
+      updateStep(next, { status: "active" });
+      setCurrentStep(next);
+    }
+  };
+
+  const skipStep = () => {
+    updateStep(currentStep, { status: "skipped" });
+    const next = currentStep + 1;
+    if (next < steps.length) {
+      updateStep(next, { status: "active" });
+      setCurrentStep(next);
+    }
+  };
+
+  const apiCall = async (step: string, body: Record<string, string>) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/setup?step=${step}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      setLoading(false);
+      return data;
+    } catch {
+      setLoading(false);
+      return { ok: false, error: "Request failed" };
+    }
+  };
+
+  const verifyRepo = async () => {
+    const result = await apiCall("verify-repo", { repo });
+    if (result.ok) {
+      goNext();
+    } else {
+      updateStep(currentStep, { status: "error", error: result.error });
+    }
+  };
+
+  const createWorktrees = async () => {
+    const result = await apiCall("create-worktrees", { workingDir, repo });
+    if (result.ok) {
+      goNext();
+    } else {
+      updateStep(currentStep, { status: "error", error: result.errors?.join(", ") || result.error });
+    }
+  };
+
+  const seedFiles = async () => {
+    const result = await apiCall("seed-files", { workingDir, projectName, repo });
+    if (result.ok) goNext();
+    else updateStep(currentStep, { status: "error", error: result.error });
+  };
+
+  const saveConfig = async () => {
+    const id = projectName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    const result = await apiCall("add-config", { id, name: projectName, repo, workingDir, backend });
+    if (result.ok) {
+      updateStep(currentStep, { status: "done" });
+      setTimeout(() => router.push(`/project/${id}`), 500);
+    } else {
+      updateStep(currentStep, { status: "error", error: result.error });
+    }
+  };
+
+  const step = steps[currentStep];
+
+  return (
+    <div className="h-full overflow-y-auto p-6 max-w-4xl">
+      <h1 className="text-lg font-semibold text-text tracking-tight mb-6">New Project Setup</h1>
+
+      <div className="flex gap-8">
+        {/* Step indicator */}
+        <div className="w-48 shrink-0">
+          {steps.map((s, i) => (
+            <div key={s.id} className="flex items-center gap-2 py-1.5">
+              <span className={`w-5 h-5 flex items-center justify-center text-[10px] border ${
+                s.status === "done" ? "border-accent text-accent" :
+                s.status === "error" ? "border-error text-error" :
+                s.status === "active" ? "border-accent text-accent bg-accent/10" :
+                s.status === "skipped" ? "border-border text-text-muted line-through" :
+                "border-border text-text-muted"
+              }`}>
+                {s.status === "done" ? "✓" : s.status === "error" ? "!" : s.status === "skipped" ? "—" : i + 1}
+              </span>
+              <span className={`text-[11px] ${
+                s.status === "active" ? "text-text font-semibold" :
+                s.status === "done" ? "text-accent" :
+                "text-text-muted"
+              }`}>
+                {s.label}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Step content */}
+        <div className="flex-1 border border-border p-4">
+          {step?.id === "name" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">Project Name</h2>
+              <input
+                value={projectName}
+                onChange={(e) => setProjectName(e.target.value)}
+                placeholder="My Project"
+                className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent mb-3"
+              />
+              <button onClick={goNext} disabled={!projectName} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+                Next
+              </button>
+            </div>
+          )}
+
+          {step?.id === "repo" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">GitHub Repository</h2>
+              <input
+                value={repo}
+                onChange={(e) => setRepo(e.target.value)}
+                placeholder="owner/repo"
+                className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent mb-3"
+              />
+              {step.error && <p className="text-[11px] text-error mb-2">{step.error}</p>}
+              <button onClick={verifyRepo} disabled={!repo || loading} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+                {loading ? "Verifying..." : "Verify & Continue"}
+              </button>
+            </div>
+          )}
+
+          {step?.id === "protection" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">Branch Protection</h2>
+              <p className="text-[11px] text-text-muted mb-3">Ensure branch protection is configured on <code className="text-accent">main</code>:</p>
+              <div className="border border-border bg-bg-surface p-3 mb-3 text-[11px] text-text space-y-1">
+                <p>1. Go to GitHub → Settings → Branches → Add rule for <code className="text-accent">main</code></p>
+                <p>2. Enable &quot;Require pull request reviews before merging&quot;</p>
+                <p>3. Set required approvals to 1</p>
+                <p>4. Add reviewer account as collaborator with write access</p>
+              </div>
+              <div className="flex gap-2">
+                <button onClick={goNext} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors">
+                  Done
+                </button>
+                <button onClick={skipStep} className="px-3 py-1.5 text-[12px] text-text-muted border border-border hover:text-text transition-colors">
+                  Skip
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step?.id === "backend" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">CLI Backend</h2>
+              <select
+                value={backend}
+                onChange={(e) => setBackend(e.target.value)}
+                className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent mb-3 cursor-pointer"
+              >
+                {BACKENDS.map((b) => <option key={b} value={b} className="bg-bg-surface">{b}</option>)}
+              </select>
+              <button onClick={goNext} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors">
+                Next
+              </button>
+            </div>
+          )}
+
+          {step?.id === "workdir" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">Working Directory</h2>
+              <input
+                value={workingDir}
+                onChange={(e) => setWorkingDir(e.target.value)}
+                placeholder="/path/to/project"
+                className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent mb-3"
+              />
+              <button onClick={goNext} disabled={!workingDir} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+                Next
+              </button>
+            </div>
+          )}
+
+          {step?.id === "worktrees" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">Create Worktrees</h2>
+              <p className="text-[11px] text-text-muted mb-3">Creates 4 git worktrees: t1/, t2a/, t2b/, t3/ in <code className="text-accent">{workingDir}</code></p>
+              {step.error && <p className="text-[11px] text-error mb-2">{step.error}</p>}
+              <div className="flex gap-2">
+                <button onClick={createWorktrees} disabled={loading} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+                  {loading ? "Creating..." : "Create Worktrees"}
+                </button>
+                <button onClick={skipStep} className="px-3 py-1.5 text-[12px] text-text-muted border border-border hover:text-text transition-colors">
+                  Skip
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step?.id === "seeds" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">Seed Files</h2>
+              <p className="text-[11px] text-text-muted mb-3">Creates default AGENTS.md + CLAUDE.md in each worktree</p>
+              {step.error && <p className="text-[11px] text-error mb-2">{step.error}</p>}
+              <div className="flex gap-2">
+                <button onClick={seedFiles} disabled={loading} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+                  {loading ? "Creating..." : "Create Seed Files"}
+                </button>
+                <button onClick={skipStep} className="px-3 py-1.5 text-[12px] text-text-muted border border-border hover:text-text transition-colors">
+                  Skip
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step?.id === "config" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">Save Configuration</h2>
+              <div className="border border-border bg-bg-surface p-3 mb-3 text-[11px] text-text space-y-1">
+                <p><strong>Name:</strong> {projectName}</p>
+                <p><strong>Repo:</strong> {repo}</p>
+                <p><strong>Backend:</strong> {backend}</p>
+                <p><strong>Directory:</strong> {workingDir}</p>
+                <p><strong>Agents:</strong> T1, T2a, T2b, T3</p>
+              </div>
+              {step.error && <p className="text-[11px] text-error mb-2">{step.error}</p>}
+              <button onClick={saveConfig} disabled={loading} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+                {loading ? "Saving..." : "Save & Open Project"}
+              </button>
+            </div>
+          )}
+
+          {currentStep >= steps.length && (
+            <div className="text-center py-8">
+              <p className="text-accent text-sm font-semibold">Setup complete!</p>
+              <p className="text-[11px] text-text-muted mt-2">Redirecting to project dashboard...</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -21,6 +21,7 @@ const INITIAL_STEPS: Step[] = [
   { id: "workdir", label: "Working Directory", status: "pending" },
   { id: "worktrees", label: "Worktree Setup", status: "pending" },
   { id: "seeds", label: "Seed Files", status: "pending" },
+  { id: "agentchattr", label: "AgentChattr Config", status: "pending", optional: true },
   { id: "config", label: "Save Config", status: "pending" },
 ];
 
@@ -252,6 +253,30 @@ export default function SetupWizard() {
               <div className="flex gap-2">
                 <button onClick={seedFiles} disabled={loading} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
                   {loading ? "Creating..." : "Create Seed Files"}
+                </button>
+                <button onClick={skipStep} className="px-3 py-1.5 text-[12px] text-text-muted border border-border hover:text-text transition-colors">
+                  Skip
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step?.id === "agentchattr" && (
+            <div>
+              <h2 className="text-sm font-semibold text-text mb-3">AgentChattr Configuration</h2>
+              <p className="text-[11px] text-text-muted mb-3">Add agents to AgentChattr config.toml and restart the server.</p>
+              {step.error && <p className="text-[11px] text-error mb-2">{step.error}</p>}
+              <div className="flex gap-2">
+                <button
+                  onClick={async () => {
+                    const result = await apiCall("agentchattr-config", { workingDir, projectName, repo });
+                    if (result.ok) goNext();
+                    else updateStep(currentStep, { status: "error", error: result.error });
+                  }}
+                  disabled={loading}
+                  className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50"
+                >
+                  {loading ? "Updating..." : "Update AgentChattr Config"}
                 </button>
                 <button onClick={skipStep} className="px-3 py-1.5 text-[12px] text-text-muted border border-border hover:text-text transition-colors">
                   Skip

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -63,7 +63,7 @@ export default function SetupWizard() {
     }
   };
 
-  const apiCall = async (step: string, body: Record<string, string>) => {
+  const apiCall = async (step: string, body: Record<string, unknown>) => {
     setLoading(true);
     try {
       const res = await fetch(`/api/setup?step=${step}`, {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -151,7 +151,7 @@ export default function Sidebar() {
 
         {/* Add project */}
         <Link
-          href="/settings?add=true"
+          href="/setup"
           className="w-10 h-10 flex items-center justify-center rounded-full border border-dashed border-border text-text-muted hover:text-text hover:bg-[#1a1a1a] transition-colors"
           title="Add project"
         >


### PR DESCRIPTION
## Summary
- `/setup` page with 8-step wizard for creating new projects from scratch
- **Steps**: project name → repo verification (gh check) → branch protection guide → CLI backend selection → working directory → worktree creation (git worktree add for t1/t2a/t2b/t3) → seed files (AGENTS.md + CLAUDE.md) → config save
- `POST /api/setup` endpoint with `verify-repo`, `create-worktrees`, `seed-files`, `add-config` actions
- Vertical step indicator: green checkmark (done), accent highlight (active), muted (pending), red (error), strikethrough (skipped)
- Skip support for optional steps (branch protection, worktrees, seeds)
- Clear instructions for manual steps with copyable commands
- Redirects to project dashboard on completion
- Sidebar + Home `+` buttons now link to `/setup`
- `npm run build` passes clean

Fixes #18

## Test plan
- [ ] Wizard renders at `/setup` with 8 steps
- [ ] Project name step accepts input, advances
- [ ] Repo step verifies via `gh repo view`, shows error on failure
- [ ] Branch protection shows manual instructions with Done/Skip
- [ ] Backend selection works
- [ ] Working directory accepts path
- [ ] Worktree creation runs `git worktree add` for 4 agents
- [ ] Seed files creates AGENTS.md + CLAUDE.md per worktree
- [ ] Config save adds project to `~/.quadwork/config.json`
- [ ] Redirects to project dashboard on completion
- [ ] Sidebar and Home `+` link to `/setup`
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)