### PR TITLE
[#19] Shared memory dashboard

### DIFF
--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -18,9 +18,9 @@ function getProject(projectId: string) {
 function getMemoryPaths(project: { working_dir: string; memory_cards_dir?: string; shared_memory_path?: string; butler_scripts_dir?: string }) {
   const workDir = project.working_dir || "";
   return {
-    cardsDir: project.memory_cards_dir || path.join(workDir, "..", "agent-memory", "cards"),
-    sharedMemoryPath: project.shared_memory_path || path.join(workDir, "..", "agent-memory", "shared-memory.md"),
-    butlerDir: project.butler_scripts_dir || path.join(workDir, "..", "agent-memory", "bin"),
+    cardsDir: project.memory_cards_dir || path.join(workDir, "..", "agent-memory", "archive", "v2", "cards"),
+    sharedMemoryPath: project.shared_memory_path || path.join(workDir, "..", "agent-memory", "central", "short-term", "agent-os.md"),
+    butlerDir: project.butler_scripts_dir || path.join(workDir, "..", "agent-memory", "scripts"),
   };
 }
 

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -24,7 +24,7 @@ function getMemoryPaths(project: { working_dir: string; memory_cards_dir?: strin
   };
 }
 
-// GET /api/memory?project=X&action=cards|status|shared-memory
+// GET /api/memory?project=X&action=cards|status|shared-memory|settings
 export async function GET(req: NextRequest) {
   const projectId = req.nextUrl.searchParams.get("project") || "";
   const action = req.nextUrl.searchParams.get("action") || "cards";
@@ -42,10 +42,17 @@ export async function GET(req: NextRequest) {
   if (action === "shared-memory") {
     return readSharedMemory(paths.sharedMemoryPath);
   }
+  if (action === "settings") {
+    return NextResponse.json({
+      memory_cards_dir: project.memory_cards_dir || "",
+      shared_memory_path: project.shared_memory_path || "",
+      butler_scripts_dir: project.butler_scripts_dir || "",
+    });
+  }
   return NextResponse.json({ error: "Unknown action" }, { status: 400 });
 }
 
-// POST /api/memory?project=X&action=butler|save-memory
+// POST /api/memory?project=X&action=butler|save-memory|save-settings
 export async function POST(req: NextRequest) {
   const projectId = req.nextUrl.searchParams.get("project") || "";
   const action = req.nextUrl.searchParams.get("action") || "";
@@ -61,6 +68,10 @@ export async function POST(req: NextRequest) {
   if (action === "save-memory") {
     const body = await req.json();
     return saveSharedMemory(paths.sharedMemoryPath, body.content);
+  }
+  if (action === "save-settings") {
+    const body = await req.json();
+    return saveSettings(projectId, body);
   }
   return NextResponse.json({ error: "Unknown action" }, { status: 400 });
 }
@@ -127,6 +138,21 @@ function saveSharedMemory(sharedMemoryPath: string, content: string) {
     const dir = path.dirname(sharedMemoryPath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(sharedMemoryPath, content);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+function saveSettings(projectId: string, settings: { memory_cards_dir?: string; shared_memory_path?: string; butler_scripts_dir?: string }) {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const project = cfg.projects?.find((p: { id: string }) => p.id === projectId);
+    if (!project) return NextResponse.json({ ok: false, error: "Project not found" });
+    if (settings.memory_cards_dir !== undefined) project.memory_cards_dir = settings.memory_cards_dir || undefined;
+    if (settings.shared_memory_path !== undefined) project.shared_memory_path = settings.shared_memory_path || undefined;
+    if (settings.butler_scripts_dir !== undefined) project.butler_scripts_dir = settings.butler_scripts_dir || undefined;
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
     return NextResponse.json({ ok: true });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : String(err) });

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -76,26 +76,59 @@ export async function POST(req: NextRequest) {
   return NextResponse.json({ error: "Unknown action" }, { status: 400 });
 }
 
+function findMdFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findMdFiles(full));
+    } else if (entry.name.endsWith(".md")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function parseFrontmatter(content: string): Record<string, string> {
+  const fm: Record<string, string> = {};
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return fm;
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx > 0) {
+      const key = line.slice(0, idx).trim();
+      let val = line.slice(idx + 1).trim();
+      // Strip YAML array brackets for tags
+      if (val.startsWith("[") && val.endsWith("]")) val = val.slice(1, -1).trim();
+      fm[key] = val;
+    }
+  }
+  return fm;
+}
+
 function listCards(cardsDir: string, search: string) {
   try {
-    if (!fs.existsSync(cardsDir)) return NextResponse.json([]);
-    const files = fs.readdirSync(cardsDir).filter((f) => f.endsWith(".md"));
-    const cards = files.map((f) => {
-      const content = fs.readFileSync(path.join(cardsDir, f), "utf-8");
-      const lines = content.split("\n");
-      const title = lines.find((l) => l.startsWith("# "))?.replace("# ", "") || f;
-      const dateLine = lines.find((l) => /date:|created:/i.test(l));
-      const agentLine = lines.find((l) => /agent:|source:/i.test(l));
-      const tagLine = lines.find((l) => /tags:/i.test(l));
+    const files = findMdFiles(cardsDir);
+    const cards = files.map((fullPath) => {
+      const content = fs.readFileSync(fullPath, "utf-8");
+      const fm = parseFrontmatter(content);
+      const relPath = path.relative(cardsDir, fullPath);
+      // Body is everything after the frontmatter
+      const body = content.replace(/^---\n[\s\S]*?\n---\n?/, "").trim();
+      // Title: first line of body, or id from frontmatter, or filename
+      const firstLine = body.split("\n")[0]?.replace(/^#\s*/, "").trim();
       return {
-        file: f,
-        title,
-        date: dateLine?.split(":").slice(1).join(":").trim() || "",
-        agent: agentLine?.split(":").slice(1).join(":").trim() || "",
-        tags: tagLine?.split(":").slice(1).join(":").trim() || "",
-        content,
+        file: relPath,
+        title: firstLine || fm.id || path.basename(fullPath, ".md"),
+        date: fm.at || "",
+        agent: fm.by || "",
+        tags: fm.tags || "",
+        content: body,
       };
     });
+    // Sort by date descending
+    cards.sort((a, b) => b.date.localeCompare(a.date));
     if (search) {
       const q = search.toLowerCase();
       return NextResponse.json(cards.filter((c) =>

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+function getProject(projectId: string) {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    return cfg.projects?.find((p: { id: string }) => p.id === projectId) || null;
+  } catch {
+    return null;
+  }
+}
+
+function getMemoryPaths(project: { working_dir: string; memory_cards_dir?: string; shared_memory_path?: string; butler_scripts_dir?: string }) {
+  const workDir = project.working_dir || "";
+  return {
+    cardsDir: project.memory_cards_dir || path.join(workDir, "..", "agent-memory", "cards"),
+    sharedMemoryPath: project.shared_memory_path || path.join(workDir, "..", "agent-memory", "shared-memory.md"),
+    butlerDir: project.butler_scripts_dir || path.join(workDir, "..", "agent-memory", "bin"),
+  };
+}
+
+// GET /api/memory?project=X&action=cards|status|shared-memory
+export async function GET(req: NextRequest) {
+  const projectId = req.nextUrl.searchParams.get("project") || "";
+  const action = req.nextUrl.searchParams.get("action") || "cards";
+  const project = getProject(projectId);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+
+  const paths = getMemoryPaths(project);
+
+  if (action === "cards") {
+    return listCards(paths.cardsDir, req.nextUrl.searchParams.get("search") || "");
+  }
+  if (action === "status") {
+    return injectionStatus(project, paths.sharedMemoryPath);
+  }
+  if (action === "shared-memory") {
+    return readSharedMemory(paths.sharedMemoryPath);
+  }
+  return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+}
+
+// POST /api/memory?project=X&action=butler|save-memory
+export async function POST(req: NextRequest) {
+  const projectId = req.nextUrl.searchParams.get("project") || "";
+  const action = req.nextUrl.searchParams.get("action") || "";
+  const project = getProject(projectId);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+
+  const paths = getMemoryPaths(project);
+
+  if (action === "butler") {
+    const body = await req.json();
+    return runButler(paths.butlerDir, body.command);
+  }
+  if (action === "save-memory") {
+    const body = await req.json();
+    return saveSharedMemory(paths.sharedMemoryPath, body.content);
+  }
+  return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+}
+
+function listCards(cardsDir: string, search: string) {
+  try {
+    if (!fs.existsSync(cardsDir)) return NextResponse.json([]);
+    const files = fs.readdirSync(cardsDir).filter((f) => f.endsWith(".md"));
+    const cards = files.map((f) => {
+      const content = fs.readFileSync(path.join(cardsDir, f), "utf-8");
+      const lines = content.split("\n");
+      const title = lines.find((l) => l.startsWith("# "))?.replace("# ", "") || f;
+      const dateLine = lines.find((l) => /date:|created:/i.test(l));
+      const agentLine = lines.find((l) => /agent:|source:/i.test(l));
+      const tagLine = lines.find((l) => /tags:/i.test(l));
+      return {
+        file: f,
+        title,
+        date: dateLine?.split(":").slice(1).join(":").trim() || "",
+        agent: agentLine?.split(":").slice(1).join(":").trim() || "",
+        tags: tagLine?.split(":").slice(1).join(":").trim() || "",
+        content,
+      };
+    });
+    if (search) {
+      const q = search.toLowerCase();
+      return NextResponse.json(cards.filter((c) =>
+        c.title.toLowerCase().includes(q) || c.agent.toLowerCase().includes(q) || c.tags.toLowerCase().includes(q) || c.content.toLowerCase().includes(q)
+      ));
+    }
+    return NextResponse.json(cards);
+  } catch {
+    return NextResponse.json([]);
+  }
+}
+
+function injectionStatus(project: { agents?: Record<string, { cwd: string }> }, sharedMemoryPath: string) {
+  const agents = project.agents || {};
+  const status: Record<string, { injected: boolean; lastModified: string | null }> = {};
+  for (const [id, agent] of Object.entries(agents)) {
+    const targetPath = path.join(agent.cwd || "", "shared-memory.md");
+    if (fs.existsSync(targetPath)) {
+      const stat = fs.statSync(targetPath);
+      status[id] = { injected: true, lastModified: stat.mtime.toISOString() };
+    } else {
+      status[id] = { injected: false, lastModified: null };
+    }
+  }
+  const sourceExists = fs.existsSync(sharedMemoryPath);
+  return NextResponse.json({ agents: status, sourceExists });
+}
+
+function readSharedMemory(sharedMemoryPath: string) {
+  try {
+    const content = fs.readFileSync(sharedMemoryPath, "utf-8");
+    return NextResponse.json({ content, path: sharedMemoryPath });
+  } catch {
+    return NextResponse.json({ content: "", path: sharedMemoryPath });
+  }
+}
+
+function saveSharedMemory(sharedMemoryPath: string, content: string) {
+  try {
+    const dir = path.dirname(sharedMemoryPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(sharedMemoryPath, content);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+function runButler(butlerDir: string, command: string) {
+  const allowed = ["butler-scan.sh", "butler-consolidate.sh", "inject.sh"];
+  if (!allowed.includes(command)) {
+    return NextResponse.json({ ok: false, error: `Unknown command: ${command}` });
+  }
+  const scriptPath = path.join(butlerDir, command);
+  if (!fs.existsSync(scriptPath)) {
+    return NextResponse.json({ ok: false, error: `Script not found: ${scriptPath}` });
+  }
+  try {
+    const output = execFileSync("bash", [scriptPath], {
+      encoding: "utf-8",
+      timeout: 30000,
+      cwd: path.dirname(butlerDir),
+    });
+    return NextResponse.json({ ok: true, output });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+}

--- a/src/app/project/[id]/memory/page.tsx
+++ b/src/app/project/[id]/memory/page.tsx
@@ -1,0 +1,10 @@
+import MemoryDashboard from "@/components/MemoryDashboard";
+
+interface MemoryPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function MemoryPage({ params }: MemoryPageProps) {
+  const { id } = await params;
+  return <MemoryDashboard projectId={id} />;
+}

--- a/src/components/MemoryDashboard.tsx
+++ b/src/components/MemoryDashboard.tsx
@@ -30,7 +30,10 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
   const [butlerRunning, setButlerRunning] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
-  const [tab, setTab] = useState<"cards" | "editor">("cards");
+  const [tab, setTab] = useState<"cards" | "editor" | "settings">("cards");
+  const [settings, setSettings] = useState({ memory_cards_dir: "", shared_memory_path: "", butler_scripts_dir: "" });
+  const [settingsSaving, setSettingsSaving] = useState(false);
+  const [settingsSaved, setSettingsSaved] = useState(false);
 
   const fetchCards = useCallback(() => {
     fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=cards&search=${encodeURIComponent(search)}`)
@@ -52,6 +55,13 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
     fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=shared-memory`)
       .then((r) => r.ok ? r.json() : { content: "" })
       .then((d) => setSharedMemory(d.content))
+      .catch(() => {});
+  }, [projectId]);
+
+  useEffect(() => {
+    fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=settings`)
+      .then((r) => r.ok ? r.json() : {})
+      .then((d: { memory_cards_dir?: string; shared_memory_path?: string; butler_scripts_dir?: string }) => setSettings({ memory_cards_dir: d.memory_cards_dir || "", shared_memory_path: d.shared_memory_path || "", butler_scripts_dir: d.butler_scripts_dir || "" }))
       .catch(() => {});
   }, [projectId]);
 
@@ -81,6 +91,19 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
       .finally(() => setButlerRunning(false));
   };
 
+  const saveSettings = () => {
+    setSettingsSaving(true);
+    fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=save-settings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(settings),
+    })
+      .then((r) => r.json())
+      .then((d) => { if (d.ok) { setSettingsSaved(true); setTimeout(() => setSettingsSaved(false), 2000); } })
+      .catch(() => {})
+      .finally(() => setSettingsSaving(false));
+  };
+
   const saveMemory = () => {
     setSaving(true);
     fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=save-memory`, {
@@ -101,6 +124,7 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
         <div className="flex items-center gap-1 border border-border">
           <button onClick={() => setTab("cards")} className={`px-3 py-1 text-[11px] ${tab === "cards" ? "bg-accent text-bg" : "text-text-muted hover:text-text"}`}>Cards</button>
           <button onClick={() => setTab("editor")} className={`px-3 py-1 text-[11px] ${tab === "editor" ? "bg-accent text-bg" : "text-text-muted hover:text-text"}`}>Editor</button>
+          <button onClick={() => setTab("settings")} className={`px-3 py-1 text-[11px] ${tab === "settings" ? "bg-accent text-bg" : "text-text-muted hover:text-text"}`}>Settings</button>
         </div>
       </div>
 
@@ -179,6 +203,45 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
             onChange={(e) => setSharedMemory(e.target.value)}
             className="flex-1 bg-bg-surface border border-border p-3 text-[12px] text-text outline-none focus:border-accent resize-none"
           />
+        </div>
+      )}
+
+      {/* Settings tab */}
+      {tab === "settings" && (
+        <div className="flex-1 min-h-0 flex flex-col gap-4">
+          <p className="text-[11px] text-text-muted">Override default paths for this project. Leave blank to use defaults.</p>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-text-muted">Memory Cards Directory</span>
+            <input
+              value={settings.memory_cards_dir}
+              onChange={(e) => setSettings({ ...settings, memory_cards_dir: e.target.value })}
+              placeholder="../agent-memory/cards"
+              className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-text-muted">Shared Memory Path</span>
+            <input
+              value={settings.shared_memory_path}
+              onChange={(e) => setSettings({ ...settings, shared_memory_path: e.target.value })}
+              placeholder="../agent-memory/shared-memory.md"
+              className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-text-muted">Butler Scripts Directory</span>
+            <input
+              value={settings.butler_scripts_dir}
+              onChange={(e) => setSettings({ ...settings, butler_scripts_dir: e.target.value })}
+              placeholder="../agent-memory/bin"
+              className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
+            />
+          </label>
+          <div>
+            <button onClick={saveSettings} disabled={settingsSaving} className="px-4 py-1 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+              {settingsSaving ? "Saving..." : settingsSaved ? "Saved" : "Save Settings"}
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/MemoryDashboard.tsx
+++ b/src/components/MemoryDashboard.tsx
@@ -215,7 +215,7 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
             <input
               value={settings.memory_cards_dir}
               onChange={(e) => setSettings({ ...settings, memory_cards_dir: e.target.value })}
-              placeholder="../agent-memory/cards"
+              placeholder="../agent-memory/archive/v2/cards"
               className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
             />
           </label>
@@ -224,7 +224,7 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
             <input
               value={settings.shared_memory_path}
               onChange={(e) => setSettings({ ...settings, shared_memory_path: e.target.value })}
-              placeholder="../agent-memory/shared-memory.md"
+              placeholder="../agent-memory/central/short-term/agent-os.md"
               className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
             />
           </label>
@@ -233,7 +233,7 @@ export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
             <input
               value={settings.butler_scripts_dir}
               onChange={(e) => setSettings({ ...settings, butler_scripts_dir: e.target.value })}
-              placeholder="../agent-memory/bin"
+              placeholder="../agent-memory/scripts"
               className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
             />
           </label>

--- a/src/components/MemoryDashboard.tsx
+++ b/src/components/MemoryDashboard.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Card {
+  file: string;
+  title: string;
+  date: string;
+  agent: string;
+  tags: string;
+  content: string;
+}
+
+interface AgentStatus {
+  injected: boolean;
+  lastModified: string | null;
+}
+
+interface MemoryDashboardProps {
+  projectId: string;
+}
+
+export default function MemoryDashboard({ projectId }: MemoryDashboardProps) {
+  const [cards, setCards] = useState<Card[]>([]);
+  const [search, setSearch] = useState("");
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [status, setStatus] = useState<Record<string, AgentStatus>>({});
+  const [sharedMemory, setSharedMemory] = useState("");
+  const [butlerLog, setButlerLog] = useState("");
+  const [butlerRunning, setButlerRunning] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [tab, setTab] = useState<"cards" | "editor">("cards");
+
+  const fetchCards = useCallback(() => {
+    fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=cards&search=${encodeURIComponent(search)}`)
+      .then((r) => r.ok ? r.json() : [])
+      .then(setCards)
+      .catch(() => {});
+  }, [projectId, search]);
+
+  useEffect(() => { fetchCards(); }, [fetchCards]);
+
+  useEffect(() => {
+    fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=status`)
+      .then((r) => r.ok ? r.json() : { agents: {} })
+      .then((d: { agents?: Record<string, AgentStatus> }) => setStatus(d.agents || {}))
+      .catch(() => {});
+  }, [projectId]);
+
+  useEffect(() => {
+    fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=shared-memory`)
+      .then((r) => r.ok ? r.json() : { content: "" })
+      .then((d) => setSharedMemory(d.content))
+      .catch(() => {});
+  }, [projectId]);
+
+  const runButler = (command: string) => {
+    setButlerRunning(true);
+    setButlerLog((prev) => prev + `\n> ${command}\n`);
+    fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=butler`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command }),
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        setButlerLog((prev) => prev + (d.ok ? d.output : `Error: ${d.error}`) + "\n");
+        if (command === "inject.sh") {
+          // Refresh injection status
+          fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=status`)
+            .then((r) => r.ok ? r.json() : { agents: {} })
+            .then((s: { agents?: Record<string, AgentStatus> }) => setStatus(s.agents || {}))
+            .catch(() => {});
+        }
+        if (command === "butler-scan.sh" || command === "butler-consolidate.sh") {
+          fetchCards();
+        }
+      })
+      .catch((err) => setButlerLog((prev) => prev + `Error: ${err.message}\n`))
+      .finally(() => setButlerRunning(false));
+  };
+
+  const saveMemory = () => {
+    setSaving(true);
+    fetch(`/api/memory?project=${encodeURIComponent(projectId)}&action=save-memory`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: sharedMemory }),
+    })
+      .then((r) => r.json())
+      .then((d) => { if (d.ok) { setSaved(true); setTimeout(() => setSaved(false), 2000); } })
+      .catch(() => {})
+      .finally(() => setSaving(false));
+  };
+
+  return (
+    <div className="h-full flex flex-col p-6 max-w-5xl">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-semibold text-text tracking-tight">Shared Memory</h1>
+        <div className="flex items-center gap-1 border border-border">
+          <button onClick={() => setTab("cards")} className={`px-3 py-1 text-[11px] ${tab === "cards" ? "bg-accent text-bg" : "text-text-muted hover:text-text"}`}>Cards</button>
+          <button onClick={() => setTab("editor")} className={`px-3 py-1 text-[11px] ${tab === "editor" ? "bg-accent text-bg" : "text-text-muted hover:text-text"}`}>Editor</button>
+        </div>
+      </div>
+
+      {/* Injection status */}
+      <div className="flex items-center gap-4 mb-4 text-[11px]">
+        {Object.entries(status).map(([agent, s]) => (
+          <div key={agent} className="flex items-center gap-1.5">
+            <span className={`w-1.5 h-1.5 rounded-full ${s.injected ? "bg-accent" : "bg-text-muted"}`} />
+            <span className="text-text-muted">{agent.toUpperCase()}</span>
+            {s.lastModified && <span className="text-text-muted text-[10px]">{new Date(s.lastModified).toLocaleTimeString()}</span>}
+          </div>
+        ))}
+      </div>
+
+      {/* Butler controls */}
+      <div className="flex items-center gap-2 mb-4">
+        <button onClick={() => runButler("butler-scan.sh")} disabled={butlerRunning} className="px-3 py-1 text-[11px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors disabled:opacity-50">Scan</button>
+        <button onClick={() => runButler("butler-consolidate.sh")} disabled={butlerRunning} className="px-3 py-1 text-[11px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors disabled:opacity-50">Consolidate</button>
+        <button onClick={() => runButler("inject.sh")} disabled={butlerRunning} className="px-3 py-1 text-[11px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors disabled:opacity-50">Inject</button>
+        {butlerRunning && <span className="text-[10px] text-text-muted">Running...</span>}
+      </div>
+
+      {/* Butler log */}
+      {butlerLog && (
+        <div className="mb-4 border border-border bg-bg-surface max-h-32 overflow-y-auto">
+          <pre className="p-2 text-[10px] text-text-muted whitespace-pre-wrap">{butlerLog.trim()}</pre>
+        </div>
+      )}
+
+      {/* Cards tab */}
+      {tab === "cards" && (
+        <div className="flex-1 min-h-0 flex flex-col">
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search cards..."
+            className="mb-3 bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
+          />
+          <div className="flex-1 overflow-y-auto border border-border">
+            {cards.length === 0 && (
+              <div className="p-3 text-[11px] text-text-muted">No memory cards found</div>
+            )}
+            {cards.map((card) => (
+              <div key={card.file} className="border-b border-border/50 last:border-b-0">
+                <button
+                  onClick={() => setExpanded(expanded === card.file ? null : card.file)}
+                  className="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-[#1a1a1a] transition-colors text-left"
+                >
+                  <span className="text-[11px] text-text flex-1 truncate">{card.title}</span>
+                  <span className="text-[10px] text-text-muted shrink-0">{card.agent}</span>
+                  <span className="text-[10px] text-text-muted shrink-0">{card.date}</span>
+                  {card.tags && <span className="text-[10px] text-accent shrink-0">{card.tags}</span>}
+                </button>
+                {expanded === card.file && (
+                  <div className="px-3 pb-2 bg-bg-surface">
+                    <pre className="text-[11px] text-text whitespace-pre-wrap">{card.content}</pre>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Editor tab */}
+      {tab === "editor" && (
+        <div className="flex-1 min-h-0 flex flex-col">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-[11px] text-text-muted">shared-memory.md</span>
+            <button onClick={saveMemory} disabled={saving} className="px-4 py-1 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">
+              {saving ? "Saving..." : saved ? "Saved" : "Save"}
+            </button>
+          </div>
+          <textarea
+            value={sharedMemory}
+            onChange={(e) => setSharedMemory(e.target.value)}
+            className="flex-1 bg-bg-surface border border-border p-3 text-[12px] text-text outline-none focus:border-accent resize-none"
+          />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `/project/[id]/memory` page with cards browser and markdown editor tabs
- **Cards browser**: lists memory cards with title, date, agent, tags; click to expand full content; search/filter
- **Injection status**: green/gray dots per agent showing shared-memory.md presence + last modified time
- **Butler controls**: Scan/Consolidate/Inject buttons that shell out to whitelisted butler scripts; command output in log area
- **Editor**: full-width markdown editor for shared-memory.md with Save button
- `GET /api/memory`: cards listing, injection status, shared-memory read
- `POST /api/memory`: butler command execution, shared-memory save
- Configurable paths via project config (memory_cards_dir, shared_memory_path, butler_scripts_dir)
- `npm run build` passes clean

Fixes #19

## Test plan
- [ ] Memory page renders at `/project/[id]/memory`
- [ ] Cards tab lists memory cards with metadata
- [ ] Search filters cards by keyword
- [ ] Click to expand shows full card content
- [ ] Injection status shows per-agent dots
- [ ] Butler Scan/Consolidate/Inject buttons execute scripts
- [ ] Butler log shows command output
- [ ] Editor tab loads shared-memory.md content
- [ ] Save persists changes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)