### PR TITLE
[#39] Fix backend to use agent command from config

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -47,4 +47,17 @@ function resolveAgentCwd(projectId, agentId) {
   return agent.cwd;
 }
 
-module.exports = { readConfig, resolveAgentCwd, CONFIG_PATH };
+/**
+ * Resolve the configured command for a project/agent pair.
+ * Returns null if not found (caller should fall back to default shell).
+ */
+function resolveAgentCommand(projectId, agentId) {
+  const config = readConfig();
+  const project = config.projects.find((p) => p.id === projectId);
+  if (!project) return null;
+  const agent = project.agents && project.agents[agentId];
+  if (!agent || !agent.command) return null;
+  return agent.command;
+}
+
+module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, CONFIG_PATH };

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ const http = require("http");
 const { WebSocketServer } = require("ws");
 const pty = require("node-pty");
 const { spawn } = require("child_process");
-const { readConfig, resolveAgentCwd } = require("./config");
+const { readConfig, resolveAgentCwd, resolveAgentCommand } = require("./config");
 
 const config = readConfig();
 const PORT = config.port || 3001;
@@ -357,7 +357,7 @@ wss.on("connection", (ws, req) => {
   const params = new URL(req.url, `http://localhost:${PORT}`).searchParams;
   const projectId = params.get("project");
   const agentId = params.get("agent");
-  const shell = process.env.SHELL || "/bin/zsh";
+  const defaultShell = process.env.SHELL || "/bin/zsh";
 
   if (!projectId || !agentId) {
     ws.close(1008, "missing project or agent query params");
@@ -370,11 +370,12 @@ wss.on("connection", (ws, req) => {
     return;
   }
 
+  const command = resolveAgentCommand(projectId, agentId) || defaultShell;
   const sessionKey = `${projectId}/${agentId}`;
 
   let term;
   try {
-    term = pty.spawn(shell, [], {
+    term = pty.spawn(command, [], {
       name: "xterm-256color",
       cols: 120,
       rows: 30,


### PR DESCRIPTION
## Summary
Fixes #39

- Added `resolveAgentCommand()` to `server/config.js` to read `agent.command` from project config
- Updated PTY spawn in `server/index.js` to use configured command, falling back to `process.env.SHELL`
- Previously all terminal panels showed a plain shell instead of the configured agent CLI (claude, codex)

## Test plan
- [ ] Set `agents.t3.command = "claude"` in config, connect to T3 terminal — should spawn claude, not zsh
- [ ] Remove `command` field from an agent config — should fall back to default shell
- [ ] Verify other agents with different commands spawn correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)