### PR TITLE
[#50] Fix backend dropdown: store 'claude' not 'claude-code'

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -46,7 +46,10 @@ const DEFAULT_AGENTS: Record<string, AgentConfig> = {
   t3: { display_name: "T3", command: "claude", cwd: "", model: "sonnet", agents_md: "" },
 };
 
-const BACKENDS = ["claude-code", "codex"];
+const BACKENDS: { value: string; label: string }[] = [
+  { value: "claude", label: "Claude Code" },
+  { value: "codex", label: "Codex" },
+];
 const MODELS = ["opus", "sonnet", "haiku"];
 
 function Input({ label, value, onChange, type = "text", placeholder }: {
@@ -74,7 +77,7 @@ function Select({ label, value, onChange, options }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
-  options: string[];
+  options: { value: string; label: string }[];
 }) {
   return (
     <div className="flex flex-col gap-1">
@@ -85,7 +88,7 @@ function Select({ label, value, onChange, options }: {
         className="bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent cursor-pointer"
       >
         {options.map((o) => (
-          <option key={o} value={o} className="bg-bg-surface">{o}</option>
+          <option key={o.value} value={o.value} className="bg-bg-surface">{o.label}</option>
         ))}
       </select>
     </div>
@@ -112,7 +115,7 @@ export default function SettingsPage() {
         port: data.port || 8400,
         agentchattr_url: data.agentchattr_url || "http://127.0.0.1:8300",
         agentchattr_token: data.agentchattr_token || "",
-        default_backend: data.default_backend || "claude-code",
+        default_backend: data.default_backend || "claude",
         projects: data.projects || [],
       }))
       .catch(() => {});
@@ -414,7 +417,7 @@ export default function SettingsPage() {
                               className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
                             >
                               {BACKENDS.map((b) => (
-                                <option key={b} value={b} className="bg-bg-surface">{b}</option>
+                                <option key={b.value} value={b.value} className="bg-bg-surface">{b.label}</option>
                               ))}
                             </select>
                             <select

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -25,7 +25,10 @@ const INITIAL_STEPS: Step[] = [
   { id: "config", label: "Save Config", status: "pending" },
 ];
 
-const BACKENDS = ["claude-code", "codex"];
+const BACKENDS: { value: string; label: string }[] = [
+  { value: "claude", label: "Claude Code" },
+  { value: "codex", label: "Codex" },
+];
 
 export default function SetupWizard() {
   const router = useRouter();
@@ -36,7 +39,7 @@ export default function SetupWizard() {
   const [projectName, setProjectName] = useState("");
   const [repo, setRepo] = useState("");
   const [backends, setBackends] = useState<Record<string, string>>({
-    t1: "claude-code", t2a: "claude-code", t2b: "claude-code", t3: "claude-code",
+    t1: "claude", t2a: "claude", t2b: "claude", t3: "claude",
   });
   const [workingDir, setWorkingDir] = useState("");
   const [loading, setLoading] = useState(false);
@@ -231,7 +234,7 @@ export default function SetupWizard() {
                       onChange={(e) => setBackends({ ...backends, [agent]: e.target.value })}
                       className="bg-transparent border border-border px-2 py-0.5 text-[11px] text-text outline-none focus:border-accent cursor-pointer"
                     >
-                      {BACKENDS.map((b) => <option key={b} value={b} className="bg-bg-surface">{b}</option>)}
+                      {BACKENDS.map((b) => <option key={b.value} value={b.value} className="bg-bg-surface">{b.label}</option>)}
                     </select>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- Fix SetupWizard and SettingsPage backend dropdowns to store `"claude"` (correct binary name) instead of `"claude-code"` (non-existent binary)
- Display labels remain user-friendly: "Claude Code" and "Codex"
- Updated `Select` component to accept `{value, label}` option objects

## Test plan
- [ ] Web setup wizard stores `"claude"` in config when selecting Claude Code
- [ ] Settings page agent command dropdown shows "Claude Code" but stores `"claude"`
- [ ] Agent spawn uses the correct `claude` binary name

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)