### PR TITLE
[#49] Unify setup paths — web wizard matches CLI structure

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -13,6 +13,7 @@ const router = express.Router();
 const CONFIG_DIR = path.join(os.homedir(), ".quadwork");
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 const ENV_PATH = path.join(CONFIG_DIR, ".env");
+const TEMPLATES_DIR = path.join(__dirname, "..", "templates");
 const REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 
 const DEFAULT_CONFIG = {
@@ -473,34 +474,70 @@ router.post("/api/setup", (req, res) => {
         const clone = exec("gh", ["repo", "clone", body.repo, workingDir]);
         if (!clone.ok) return res.json({ ok: false, error: `Clone failed: ${clone.output}` });
       }
+      // Sibling dirs: ../projectName-t1/, ../projectName-t2a/, etc. (matches CLI wizard)
+      const projectName = path.basename(workingDir);
+      const parentDir = path.dirname(workingDir);
       const agents = ["t1", "t2a", "t2b", "t3"];
       const created = [];
       const errors = [];
       for (const agent of agents) {
-        const wtDir = path.join(workingDir, agent);
+        const wtDir = path.join(parentDir, `${projectName}-${agent}`);
         if (fs.existsSync(wtDir)) { created.push(`${agent} (exists)`); continue; }
-        const result = exec("git", ["worktree", "add", "-b", `worktree/${agent}`, wtDir, "HEAD"], { cwd: workingDir });
-        if (result.ok) created.push(agent);
-        else errors.push(`${agent}: ${result.output}`);
+        const branchName = `worktree-${agent}`;
+        exec("git", ["branch", branchName, "HEAD"], { cwd: workingDir });
+        const result = exec("git", ["worktree", "add", wtDir, branchName], { cwd: workingDir });
+        if (result.ok) {
+          created.push(agent);
+        } else {
+          // Fallback: detached worktree
+          const result2 = exec("git", ["worktree", "add", "--detach", wtDir, "HEAD"], { cwd: workingDir });
+          if (result2.ok) created.push(`${agent} (detached)`);
+          else errors.push(`${agent}: ${result.output}`);
+        }
       }
       return res.json({ ok: errors.length === 0, created, errors });
     }
     case "seed-files": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
+      const projectName = body.projectName || path.basename(workingDir);
+      const parentDir = path.dirname(workingDir);
+      const reviewerUser = body.reviewerUser || "";
+      const reviewerTokenPath = body.reviewerTokenPath || path.join(os.homedir(), ".quadwork", "reviewer-token");
       const agents = ["t1", "t2a", "t2b", "t3"];
       const seeded = [];
       for (const agent of agents) {
-        const wtDir = path.join(workingDir, agent);
+        // Sibling dir layout (matches CLI wizard)
+        const wtDir = path.join(parentDir, `${projectName}-${agent}`);
         if (!fs.existsSync(wtDir)) continue;
+
+        // AGENTS.md — use template with placeholder substitution (matches CLI)
         const agentsMd = path.join(wtDir, "AGENTS.md");
         if (!fs.existsSync(agentsMd)) {
-          fs.writeFileSync(agentsMd, `# ${body.projectName} — ${agent.toUpperCase()} Agent\n\nRepo: ${body.repo}\nRole: ${agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}\n`);
+          const seedSrc = path.join(TEMPLATES_DIR, "seeds", `${agent}.AGENTS.md`);
+          if (fs.existsSync(seedSrc)) {
+            let content = fs.readFileSync(seedSrc, "utf-8");
+            content = content.replace(/\{\{reviewer_github_user\}\}/g, reviewerUser);
+            content = content.replace(/\{\{reviewer_token_path\}\}/g, reviewerTokenPath);
+            fs.writeFileSync(agentsMd, content);
+          } else {
+            // Fallback stub if template missing
+            fs.writeFileSync(agentsMd, `# ${projectName} — ${agent.toUpperCase()} Agent\n\nRepo: ${body.repo}\nRole: ${agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}\n`);
+          }
           seeded.push(`${agent}/AGENTS.md`);
         }
+
+        // CLAUDE.md — use template with placeholder substitution (matches CLI)
         const claudeMd = path.join(wtDir, "CLAUDE.md");
         if (!fs.existsSync(claudeMd)) {
-          fs.writeFileSync(claudeMd, `# ${body.projectName}\n\nBranch: task/<issue>-<slug>\nCommit: [#<issue>] Short description\nNever push to main.\n`);
+          const claudeSrc = path.join(TEMPLATES_DIR, "CLAUDE.md");
+          if (fs.existsSync(claudeSrc)) {
+            let content = fs.readFileSync(claudeSrc, "utf-8");
+            content = content.replace(/\{\{project_name\}\}/g, projectName);
+            fs.writeFileSync(claudeMd, content);
+          } else {
+            fs.writeFileSync(claudeMd, `# ${projectName}\n\nBranch: task/<issue>-<slug>\nCommit: [#<issue>] Short description\nNever push to main.\n`);
+          }
           seeded.push(`${agent}/CLAUDE.md`);
         }
       }
@@ -509,9 +546,11 @@ router.post("/api/setup", (req, res) => {
     case "agentchattr-config": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
+      const projectName = body.projectName || path.basename(workingDir);
+      const parentDir = path.dirname(workingDir);
       const tomlPaths = [
         path.join(workingDir, "agentchattr", "config.toml"),
-        path.join(workingDir, "..", "agentchattr", "config.toml"),
+        path.join(parentDir, "agentchattr", "config.toml"),
         path.join(os.homedir(), ".agentchattr", "config.toml"),
       ];
       let tomlPath = tomlPaths.find((p) => fs.existsSync(p));
@@ -523,9 +562,10 @@ router.post("/api/setup", (req, res) => {
         const agents = ["t1", "t2a", "t2b", "t3"];
         const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
         const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
-        let content = `[meta]\nname = "${body.projectName}"\n\n`;
+        let content = `[meta]\nname = "${projectName}"\n\n`;
         agents.forEach((agent, i) => {
-          content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
+          const wtDir = path.join(parentDir, `${projectName}-${agent}`);
+          content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
         });
         fs.writeFileSync(tomlPath, content);
       } else {
@@ -535,7 +575,8 @@ router.post("/api/setup", (req, res) => {
         const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
         agents.forEach((agent, i) => {
           if (!content.includes(`[agents.${agent}]`)) {
-            content += `\n[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${path.join(workingDir, agent)}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
+            const wtDir = path.join(parentDir, `${projectName}-${agent}`);
+            content += `\n[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
           }
         });
         fs.writeFileSync(tomlPath, content);
@@ -550,6 +591,8 @@ router.post("/api/setup", (req, res) => {
     }
     case "add-config": {
       const { id, name, repo, workingDir, backends } = body;
+      const projectName = path.basename(workingDir);
+      const parentDir = path.dirname(workingDir);
       let cfg;
       try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); }
       catch { cfg = { port: 8400, agentchattr_url: "http://127.0.0.1:8300", projects: [] }; }
@@ -559,7 +602,7 @@ router.post("/api/setup", (req, res) => {
         agents[agentId] = {
           display_name: agentId.toUpperCase(),
           command: (backends && backends[agentId]) || "claude",
-          cwd: path.join(workingDir, agentId),
+          cwd: path.join(parentDir, `${projectName}-${agentId}`),
           model: role,
           agents_md: "",
         };

--- a/server/routes.js
+++ b/server/routes.js
@@ -500,8 +500,9 @@ router.post("/api/setup", (req, res) => {
     case "seed-files": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
-      // Use directory basename for sibling paths (matches CLI wizard)
+      // Use directory basename for sibling paths, display name for content
       const dirName = path.basename(workingDir);
+      const displayName = body.projectName || dirName;
       const parentDir = path.dirname(workingDir);
       const reviewerUser = body.reviewerUser || "";
       const reviewerTokenPath = body.reviewerTokenPath || path.join(os.homedir(), ".quadwork", "reviewer-token");
@@ -523,7 +524,7 @@ router.post("/api/setup", (req, res) => {
             fs.writeFileSync(agentsMd, content);
           } else {
             // Fallback stub if template missing
-            fs.writeFileSync(agentsMd, `# ${projectName} — ${agent.toUpperCase()} Agent\n\nRepo: ${body.repo}\nRole: ${agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}\n`);
+            fs.writeFileSync(agentsMd, `# ${displayName} — ${agent.toUpperCase()} Agent\n\nRepo: ${body.repo}\nRole: ${agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}\n`);
           }
           seeded.push(`${agent}/AGENTS.md`);
         }
@@ -534,10 +535,10 @@ router.post("/api/setup", (req, res) => {
           const claudeSrc = path.join(TEMPLATES_DIR, "CLAUDE.md");
           if (fs.existsSync(claudeSrc)) {
             let content = fs.readFileSync(claudeSrc, "utf-8");
-            content = content.replace(/\{\{project_name\}\}/g, projectName);
+            content = content.replace(/\{\{project_name\}\}/g, displayName);
             fs.writeFileSync(claudeMd, content);
           } else {
-            fs.writeFileSync(claudeMd, `# ${projectName}\n\nBranch: task/<issue>-<slug>\nCommit: [#<issue>] Short description\nNever push to main.\n`);
+            fs.writeFileSync(claudeMd, `# ${displayName}\n\nBranch: task/<issue>-<slug>\nCommit: [#<issue>] Short description\nNever push to main.\n`);
           }
           seeded.push(`${agent}/CLAUDE.md`);
         }

--- a/server/routes.js
+++ b/server/routes.js
@@ -500,9 +500,8 @@ router.post("/api/setup", (req, res) => {
     case "seed-files": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
-      // Use directory basename for sibling paths, display name for content
+      // Use directory basename for sibling paths and template substitution (matches CLI)
       const dirName = path.basename(workingDir);
-      const displayName = body.projectName || dirName;
       const parentDir = path.dirname(workingDir);
       const reviewerUser = body.reviewerUser || "";
       const reviewerTokenPath = body.reviewerTokenPath || path.join(os.homedir(), ".quadwork", "reviewer-token");
@@ -524,7 +523,7 @@ router.post("/api/setup", (req, res) => {
             fs.writeFileSync(agentsMd, content);
           } else {
             // Fallback stub if template missing
-            fs.writeFileSync(agentsMd, `# ${displayName} — ${agent.toUpperCase()} Agent\n\nRepo: ${body.repo}\nRole: ${agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}\n`);
+            fs.writeFileSync(agentsMd, `# ${dirName} — ${agent.toUpperCase()} Agent\n\nRepo: ${body.repo}\nRole: ${agent === "t1" ? "Owner" : agent.startsWith("t2") ? "Reviewer" : "Builder"}\n`);
           }
           seeded.push(`${agent}/AGENTS.md`);
         }
@@ -535,10 +534,11 @@ router.post("/api/setup", (req, res) => {
           const claudeSrc = path.join(TEMPLATES_DIR, "CLAUDE.md");
           if (fs.existsSync(claudeSrc)) {
             let content = fs.readFileSync(claudeSrc, "utf-8");
-            content = content.replace(/\{\{project_name\}\}/g, displayName);
+            // CLI uses path.basename(workingDir) for {{project_name}}
+            content = content.replace(/\{\{project_name\}\}/g, dirName);
             fs.writeFileSync(claudeMd, content);
           } else {
-            fs.writeFileSync(claudeMd, `# ${displayName}\n\nBranch: task/<issue>-<slug>\nCommit: [#<issue>] Short description\nNever push to main.\n`);
+            fs.writeFileSync(claudeMd, `# ${dirName}\n\nBranch: task/<issue>-<slug>\nCommit: [#<issue>] Short description\nNever push to main.\n`);
           }
           seeded.push(`${agent}/CLAUDE.md`);
         }

--- a/server/routes.js
+++ b/server/routes.js
@@ -500,7 +500,8 @@ router.post("/api/setup", (req, res) => {
     case "seed-files": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
-      const projectName = body.projectName || path.basename(workingDir);
+      // Use directory basename for sibling paths (matches CLI wizard)
+      const dirName = path.basename(workingDir);
       const parentDir = path.dirname(workingDir);
       const reviewerUser = body.reviewerUser || "";
       const reviewerTokenPath = body.reviewerTokenPath || path.join(os.homedir(), ".quadwork", "reviewer-token");
@@ -508,7 +509,7 @@ router.post("/api/setup", (req, res) => {
       const seeded = [];
       for (const agent of agents) {
         // Sibling dir layout (matches CLI wizard)
-        const wtDir = path.join(parentDir, `${projectName}-${agent}`);
+        const wtDir = path.join(parentDir, `${dirName}-${agent}`);
         if (!fs.existsSync(wtDir)) continue;
 
         // AGENTS.md — use template with placeholder substitution (matches CLI)
@@ -546,7 +547,9 @@ router.post("/api/setup", (req, res) => {
     case "agentchattr-config": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
-      const projectName = body.projectName || path.basename(workingDir);
+      // Use directory basename for sibling paths, display name for metadata
+      const dirName = path.basename(workingDir);
+      const displayName = body.projectName || dirName;
       const parentDir = path.dirname(workingDir);
       const tomlPaths = [
         path.join(workingDir, "agentchattr", "config.toml"),
@@ -562,9 +565,9 @@ router.post("/api/setup", (req, res) => {
         const agents = ["t1", "t2a", "t2b", "t3"];
         const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
         const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
-        let content = `[meta]\nname = "${projectName}"\n\n`;
+        let content = `[meta]\nname = "${displayName}"\n\n`;
         agents.forEach((agent, i) => {
-          const wtDir = path.join(parentDir, `${projectName}-${agent}`);
+          const wtDir = path.join(parentDir, `${dirName}-${agent}`);
           content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
         });
         fs.writeFileSync(tomlPath, content);
@@ -575,7 +578,7 @@ router.post("/api/setup", (req, res) => {
         const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
         agents.forEach((agent, i) => {
           if (!content.includes(`[agents.${agent}]`)) {
-            const wtDir = path.join(parentDir, `${projectName}-${agent}`);
+            const wtDir = path.join(parentDir, `${dirName}-${agent}`);
             content += `\n[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.toUpperCase()} ${labels[i]}"\nmcp_inject = "flag"\n`;
           }
         });
@@ -591,20 +594,19 @@ router.post("/api/setup", (req, res) => {
     }
     case "add-config": {
       const { id, name, repo, workingDir, backends } = body;
-      const projectName = path.basename(workingDir);
+      // Use directory basename for sibling paths (matches CLI wizard)
+      const dirName = path.basename(workingDir);
       const parentDir = path.dirname(workingDir);
       let cfg;
       try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); }
       catch { cfg = { port: 8400, agentchattr_url: "http://127.0.0.1:8300", projects: [] }; }
       if (cfg.projects.some((p) => p.id === id)) return res.json({ ok: true, message: "Project already in config" });
+      // Match CLI wizard agent structure: { cwd, command }
       const agents = {};
-      for (const [agentId, role] of [["t1", "opus"], ["t2a", "sonnet"], ["t2b", "sonnet"], ["t3", "sonnet"]]) {
+      for (const agentId of ["t1", "t2a", "t2b", "t3"]) {
         agents[agentId] = {
-          display_name: agentId.toUpperCase(),
+          cwd: path.join(parentDir, `${dirName}-${agentId}`),
           command: (backends && backends[agentId]) || "claude",
-          cwd: path.join(parentDir, `${projectName}-${agentId}`),
-          model: role,
-          agents_md: "",
         };
       }
       cfg.projects.push({ id, name, repo, working_dir: workingDir, agents });

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -110,7 +110,8 @@ export default function SetupWizard() {
   };
 
   const saveConfig = async () => {
-    const id = projectName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    // Use directory basename as project ID (matches CLI wizard)
+    const id = workingDir.split("/").pop() || projectName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
     const result = await apiCall("add-config", { id, name: projectName, repo, workingDir, backends });
     if (result.ok) {
       updateStep(currentStep, { status: "done" });

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -42,6 +42,8 @@ export default function SetupWizard() {
     t1: "claude", t2a: "claude", t2b: "claude", t3: "claude",
   });
   const [workingDir, setWorkingDir] = useState("");
+  const [reviewerUser, setReviewerUser] = useState("");
+  const [reviewerTokenPath, setReviewerTokenPath] = useState("");
   const [loading, setLoading] = useState(false);
 
   const updateStep = (idx: number, updates: Partial<Step>) => {
@@ -102,7 +104,7 @@ export default function SetupWizard() {
   };
 
   const seedFiles = async () => {
-    const result = await apiCall("seed-files", { workingDir, projectName, repo });
+    const result = await apiCall("seed-files", { workingDir, projectName, repo, reviewerUser, reviewerTokenPath });
     if (result.ok) goNext();
     else updateStep(currentStep, { status: "error", error: result.error });
   };
@@ -239,6 +241,20 @@ export default function SetupWizard() {
                   </div>
                 ))}
               </div>
+              <h2 className="text-sm font-semibold text-text mb-2 mt-4">Reviewer Credentials</h2>
+              <p className="text-[11px] text-text-muted mb-2">Used by T2a/T2b to post GitHub reviews</p>
+              <input
+                value={reviewerUser}
+                onChange={(e) => setReviewerUser(e.target.value)}
+                placeholder="Reviewer GitHub username"
+                className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent mb-2"
+              />
+              <input
+                value={reviewerTokenPath}
+                onChange={(e) => setReviewerTokenPath(e.target.value)}
+                placeholder="Token file path (default: ~/.quadwork/reviewer-token)"
+                className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent mb-3"
+              />
               <button onClick={goNext} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors">
                 Next
               </button>
@@ -263,7 +279,7 @@ export default function SetupWizard() {
           {step?.id === "worktrees" && (
             <div>
               <h2 className="text-sm font-semibold text-text mb-3">Create Worktrees</h2>
-              <p className="text-[11px] text-text-muted mb-3">Creates 4 git worktrees: t1/, t2a/, t2b/, t3/ in <code className="text-accent">{workingDir}</code></p>
+              <p className="text-[11px] text-text-muted mb-3">Creates 4 git worktrees as sibling directories: <code className="text-accent">{workingDir ? `${workingDir.split("/").pop()}-t1/` : "project-t1/"}</code>, etc.</p>
               {step.error && <p className="text-[11px] text-error mb-2">{step.error}</p>}
               <div className="flex gap-2">
                 <button onClick={createWorktrees} disabled={loading} className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50">


### PR DESCRIPTION
## Summary
- Align web setup wizard with CLI wizard directory structure: worktrees as sibling dirs (`../project-t1/`) instead of subdirs (`project/t1/`)
- Seed files now use `templates/seeds/*.AGENTS.md` and `templates/CLAUDE.md` with placeholder substitution (reviewer username, token path, project name) instead of 4-line stubs
- Added reviewer credential fields to web wizard (GitHub username + token path)
- AgentChattr config and `config.json` agent CWDs now use sibling dir layout

## Test plan
- [ ] Web wizard creates worktrees as sibling dirs matching CLI output
- [ ] Seed AGENTS.md files match template content with substituted placeholders
- [ ] Seed CLAUDE.md files match template content with project name
- [ ] Config JSON from web wizard is interchangeable with CLI wizard output
- [ ] Reviewer fields populate T2a/T2b AGENTS.md templates
- [ ] Build passes

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)