### PR TITLE
[#65] Init wizard: make reviewer credentials optional

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -228,8 +228,15 @@ async function setupAgents(rl, repo) {
     const seedDst = path.join(wtDir, "AGENTS.md");
     if (fs.existsSync(seedSrc)) {
       let seedContent = fs.readFileSync(seedSrc, "utf-8");
-      seedContent = seedContent.replace(/\{\{reviewer_github_user\}\}/g, reviewerUser);
-      seedContent = seedContent.replace(/\{\{reviewer_token_path\}\}/g, reviewerTokenPath);
+      if (reviewerUser) {
+        seedContent = seedContent.replace(/\{\{reviewer_github_user\}\}/g, reviewerUser);
+        seedContent = seedContent.replace(/\{\{reviewer_token_path\}\}/g, reviewerTokenPath);
+      } else {
+        // No reviewer configured — remove the GitHub Authentication section
+        seedContent = seedContent.replace(/## GitHub Authentication[\s\S]*?## Forbidden Actions/, "## Forbidden Actions");
+        seedContent = seedContent.replace(/\{\{reviewer_github_user\}\}/g, "");
+        seedContent = seedContent.replace(/\{\{reviewer_token_path\}\}/g, "");
+      }
       fs.writeFileSync(seedDst, seedContent);
       log(`  Copied ${agent}.AGENTS.md`);
     }

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -190,12 +190,12 @@ async function setupAgents(rl, repo) {
   log("A separate reviewer account lets T2a/T2b approve PRs independently. You can set this up later in Settings.");
   const wantReviewer = await askYN(rl, "Use a separate GitHub account for reviewers (T2a/T2b)?", false);
   let reviewerUser = "";
-  let reviewerTokenPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
+  let reviewerTokenPath = "";
   if (wantReviewer) {
     log("GitHub username for the reviewer account (used in T2a/T2b seed files for PR reviews).");
     reviewerUser = await ask(rl, "Reviewer GitHub username", "");
     log("Path to a file containing a GitHub PAT for the reviewer account.");
-    reviewerTokenPath = await ask(rl, "Reviewer token file path", reviewerTokenPath);
+    reviewerTokenPath = await ask(rl, "Reviewer token file path", path.join(os.homedir(), ".quadwork", "reviewer-token"));
   }
 
   const projectName = path.basename(absDir);

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -186,11 +186,17 @@ async function setupAgents(rl, repo) {
     return null;
   }
 
-  // Prompt for reviewer credentials (used in T2a/T2b seed templates)
-  log("GitHub username for the reviewer account (used in T2a/T2b seed files for PR reviews).");
-  const reviewerUser = await ask(rl, "Reviewer GitHub username (for T2a/T2b)", "");
-  log("Path to a file containing a GitHub PAT for the reviewer account.");
-  const reviewerTokenPath = await ask(rl, "Reviewer token file path (for T2a/T2b)", path.join(os.homedir(), ".quadwork", "reviewer-token"));
+  // Prompt for reviewer credentials (optional)
+  log("A separate reviewer account lets T2a/T2b approve PRs independently. You can set this up later in Settings.");
+  const wantReviewer = await askYN(rl, "Use a separate GitHub account for reviewers (T2a/T2b)?", false);
+  let reviewerUser = "";
+  let reviewerTokenPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
+  if (wantReviewer) {
+    log("GitHub username for the reviewer account (used in T2a/T2b seed files for PR reviews).");
+    reviewerUser = await ask(rl, "Reviewer GitHub username", "");
+    log("Path to a file containing a GitHub PAT for the reviewer account.");
+    reviewerTokenPath = await ask(rl, "Reviewer token file path", reviewerTokenPath);
+  }
 
   const projectName = path.basename(absDir);
   log(`Project: ${projectName}`);


### PR DESCRIPTION
## Summary
- Ask "Use a separate GitHub account for reviewers (T2a/T2b)? [y/N]" after backend selection
- Default N: skip reviewer prompts, leave placeholders empty in seed files
- Yes: prompt for reviewer username and token path (previous behavior)
- Helper text: "A separate reviewer account lets T2a/T2b approve PRs independently. You can set this up later in Settings."

## Test plan
- [ ] Default "N" skips reviewer prompts entirely
- [ ] Answering "y" shows reviewer username and token path prompts
- [ ] Seed files work with empty reviewer placeholders
- [ ] Wizard completes successfully in both paths

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)