### PR TITLE
[#71] Init wizard: improve prompt clarity and default hints

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -35,7 +35,7 @@ function which(cmd) {
 
 function ask(rl, question, defaultVal) {
   return new Promise((resolve) => {
-    const suffix = defaultVal ? ` (${defaultVal})` : "";
+    const suffix = defaultVal ? ` [${defaultVal}]` : "";
     rl.question(`  ${question}${suffix}: `, (answer) => {
       resolve(answer.trim() || defaultVal || "");
     });
@@ -173,7 +173,8 @@ async function setupAgents(rl, repo) {
     }
   }
 
-  log("Path to your local clone of the repo. Worktrees will be created as sibling directories.");
+  log("Path to your local clone of the repo. Four worktrees will be created next to it");
+  log("(e.g., project-t1/, project-t2a/, project-t2b/, project-t3/).");
   const projectDir = await ask(rl, "Project directory", process.cwd());
   const absDir = path.resolve(projectDir);
 
@@ -517,6 +518,7 @@ function writeQuadWorkConfig(setup) {
 
 async function cmdInit() {
   console.log("\n  QuadWork Init — 4-agent coding team setup\n");
+  console.log("  Tip: Press Enter to accept defaults shown in [brackets].\n");
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 


### PR DESCRIPTION
## Summary
- Show defaults in `[brackets]` instead of `(parentheses)` in `ask()` helper
- Add one-time hint at wizard start: "Press Enter to accept defaults shown in [brackets]"
- Improve project directory helper text: explains four worktrees created next to the clone

## Test plan
- [ ] Defaults show in [brackets] format
- [ ] One-time hint appears at wizard start
- [ ] Project directory description mentions worktree names
- [ ] All prompts still accept user input and defaults correctly

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)