### PR TITLE
[#72] Init wizard: add Telegram setup guidance

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -356,8 +356,15 @@ async function setupAddons(rl, setup, configTomlPath) {
         ok("Installed Telegram Bridge dependencies");
       }
 
+      log("Create a bot via @BotFather on Telegram (https://t.me/BotFather), then copy the token.");
       const botToken = await ask(rl, "Telegram bot token", "");
+      log("To find your chat ID:");
+      log("  1. Open your bot on Telegram and send it any message (e.g., 'hi')");
+      log("  2. Run: curl https://api.telegram.org/bot<TOKEN>/getUpdates");
+      log("  3. Look for \"chat\":{\"id\":123456789,...} — the number is your chat ID");
+      log("  Note: Returns empty if no messages have been sent to the bot yet.");
       const chatId = await ask(rl, "Telegram chat ID", "");
+      log("Need help? See https://github.com/realproject7/agentchattr-telegram#readme");
 
       if (botToken && chatId) {
         // Write bot token to ~/.quadwork/.env (never stored in config files)


### PR DESCRIPTION
## Summary
- Add BotFather link and instructions before bot token prompt
- Add multi-step chat ID guide (send message, curl getUpdates, find ID)
- Add help link to agentchattr-telegram README

## Test plan
- [ ] Bot token prompt shows BotFather guidance
- [ ] Chat ID prompt shows step-by-step guide
- [ ] Help link appears after chat ID prompt
- [ ] Wizard flow unchanged

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)