### PR TITLE
[#81] Fix SPA fallback for direct URL navigation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -359,11 +359,31 @@ if (fs.existsSync(outDir)) {
   app.use(express.static(outDir));
 }
 
-// SPA fallback: serve index.html for all non-API, non-WS routes
+// SPA fallback: serve the correct pre-rendered HTML for dynamic routes.
+// Static export only generates templates for placeholder params (e.g. /project/_),
+// so we map real dynamic segments back to those template files.
 app.use((req, res, next) => {
   if (req.method !== "GET" || req.path.startsWith("/api/")) {
     return next();
   }
+
+  // Map dynamic routes to their pre-rendered template HTML
+  const dynamicRoutes = [
+    { pattern: /^\/project\/[^/]+\/memory\/?$/, template: "project/_/memory.html" },
+    { pattern: /^\/project\/[^/]+\/queue\/?$/, template: "project/_/queue.html" },
+    { pattern: /^\/project\/[^/]+\/?$/, template: "project/_.html" },
+  ];
+
+  for (const route of dynamicRoutes) {
+    if (route.pattern.test(req.path)) {
+      const templatePath = path.join(outDir, route.template);
+      if (fs.existsSync(templatePath)) {
+        return res.sendFile(templatePath);
+      }
+    }
+  }
+
+  // Default fallback to index.html
   const indexPath = path.join(outDir, "index.html");
   if (fs.existsSync(indexPath)) {
     res.sendFile(indexPath);


### PR DESCRIPTION
## Summary
- Direct URL navigation to `/project/<id>`, `/project/<id>/memory`, and `/project/<id>/queue` returned 404 because the static export only pre-renders HTML for placeholder param `_`
- Updated the SPA fallback middleware in `server/index.js` to map dynamic route patterns (`/project/[id]/*`) to their pre-rendered template HTML files before falling back to `index.html`
- Client-side hydration reads the actual URL via `useParams()`, so the correct project ID is used at runtime

Fixes #81

## Test plan
- [ ] Navigate directly to `http://127.0.0.1:8400/project/quadwork` — should render project dashboard
- [ ] Navigate directly to `http://127.0.0.1:8400/project/quadwork/memory` — should render memory page
- [ ] Navigate directly to `http://127.0.0.1:8400/project/quadwork/queue` — should render queue page
- [ ] Verify client-side navigation from home still works
- [ ] Verify API routes (`/api/*`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)