### PR TITLE
[#83] Fix placeholder ID on direct URL load

### DIFF
--- a/src/app/project/[id]/ProjectPageClient.tsx
+++ b/src/app/project/[id]/ProjectPageClient.tsx
@@ -6,6 +6,13 @@ import ProjectDashboard from "@/components/ProjectDashboard";
 export default function ProjectPageClient() {
   const { id } = useParams<{ id: string }>();
 
+  // Static export pre-renders with placeholder "_". Wait for hydration
+  // to resolve the real project ID before rendering child components
+  // that issue API/WebSocket requests.
+  if (!id || id === "_") {
+    return null;
+  }
+
   return (
     <div className="w-full h-full">
       <ProjectDashboard projectId={id} />

--- a/src/app/project/[id]/memory/MemoryPageClient.tsx
+++ b/src/app/project/[id]/memory/MemoryPageClient.tsx
@@ -5,5 +5,10 @@ import MemoryDashboard from "@/components/MemoryDashboard";
 
 export default function MemoryPageClient() {
   const { id } = useParams<{ id: string }>();
+
+  if (!id || id === "_") {
+    return null;
+  }
+
   return <MemoryDashboard projectId={id} />;
 }

--- a/src/app/project/[id]/queue/QueuePageClient.tsx
+++ b/src/app/project/[id]/queue/QueuePageClient.tsx
@@ -5,5 +5,10 @@ import QueueManager from "@/components/QueueManager";
 
 export default function QueuePageClient() {
   const { id } = useParams<{ id: string }>();
+
+  if (!id || id === "_") {
+    return null;
+  }
+
   return <QueueManager projectId={id} />;
 }


### PR DESCRIPTION
## Summary
- Direct URL loads served the SSG template with placeholder `id="_"`, causing child components to fire API/WebSocket requests with `project=_` before hydration
- This caused GitHub panel 400 errors and terminal `pty-spawn-failed` errors
- Added guards in all three client page wrappers (`ProjectPageClient`, `MemoryPageClient`, `QueuePageClient`) to return `null` until `useParams()` resolves the real project ID

Fixes #83

## Test plan
- [ ] Open `http://127.0.0.1:8400/project/quadwork` directly — dashboard loads with correct project, no `project=_` requests in network tab
- [ ] GitHub panel loads issues/PRs for `realproject7/quadwork`
- [ ] Terminal panels connect without `pty-spawn-failed`
- [ ] `/project/quadwork/memory` and `/project/quadwork/queue` also work on direct load
- [ ] Client-side navigation from home still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)