### PR TITLE
[#84] Fix chat panel 403 auth by passing token as query param

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -92,6 +92,7 @@ router.get("/api/chat", async (req, res) => {
   for (const [k, v] of Object.entries(req.query)) {
     if (k !== "path") fwd.set(k, String(v));
   }
+  if (token) fwd.set("token", token);
 
   const url = `${base}${apiPath}?${fwd.toString()}`;
   try {
@@ -105,8 +106,9 @@ router.get("/api/chat", async (req, res) => {
 
 router.post("/api/chat", async (req, res) => {
   const { url: base, token } = getChattrConfig();
+  const tokenParam = token ? `?token=${encodeURIComponent(token)}` : "";
   try {
-    const r = await fetch(`${base}/api/send`, {
+    const r = await fetch(`${base}/api/send${tokenParam}`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...chatAuthHeaders(token) },
       body: JSON.stringify(req.body),

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -33,15 +33,19 @@ function senderColor(sender: string): string {
 export default function ChatPanel() {
   const [mode, setMode] = useState<"iframe" | "api" | "loading">("loading");
   const [chattrUrl, setChattrUrl] = useState("");
+  const [chattrToken, setChattrToken] = useState("");
 
-  // Resolve AgentChattr URL from config
+  // Resolve AgentChattr URL and token from config
   useEffect(() => {
     fetch("/api/config")
       .then((r) => {
         if (!r.ok) throw new Error("config fetch failed");
         return r.json();
       })
-      .then((cfg) => setChattrUrl(cfg.agentchattr_url || "http://127.0.0.1:8300"))
+      .then((cfg) => {
+        setChattrUrl(cfg.agentchattr_url || "http://127.0.0.1:8300");
+        setChattrToken(cfg.agentchattr_token || "");
+      })
       .catch(() => setChattrUrl("http://127.0.0.1:8300"));
   }, []);
 
@@ -80,7 +84,7 @@ export default function ChatPanel() {
             };
             el.onerror = () => setMode("api");
           }}
-          src={chattrUrl}
+          src={chattrToken ? `${chattrUrl}?token=${encodeURIComponent(chattrToken)}` : chattrUrl}
           className="w-full h-full border-0"
           style={{ display: mode === "loading" ? "none" : "block" }}
           sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
@@ -105,6 +109,7 @@ function ChatPanelAPI() {
   const [input, setInput] = useState("");
   const [showMentions, setShowMentions] = useState(false);
   const [mentionFilter, setMentionFilter] = useState("");
+  const [authError, setAuthError] = useState<string | null>(null);
   const cursorRef = useRef(0);
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -114,10 +119,15 @@ function ChatPanelAPI() {
   useEffect(() => {
     fetch("/api/chat?path=/api/channels")
       .then((r) => {
+        if (r.status === 403) {
+          setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
+          throw new Error("auth failed");
+        }
         if (!r.ok) throw new Error("channels fetch failed");
         return r.json();
       })
       .then((data) => {
+        setAuthError(null);
         const list = Array.isArray(data) ? data : data.channels || [];
         setChannels(list.map((c: string | { name: string }) => (typeof c === "string" ? c : c.name)));
       })
@@ -134,10 +144,15 @@ function ChatPanelAPI() {
   const fetchMessages = useCallback(() => {
     fetch(`/api/chat?path=/api/messages&channel=${encodeURIComponent(channel)}&cursor=${cursorRef.current}`)
       .then((r) => {
+        if (r.status === 403) {
+          setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
+          throw new Error("auth failed");
+        }
         if (!r.ok) throw new Error(`Poll failed: ${r.status}`);
         return r.json();
       })
       .then((data) => {
+        setAuthError(null);
         const msgs: Message[] = Array.isArray(data) ? data : data.messages || [];
         if (msgs.length > 0) {
           setMessages((prev) => {
@@ -213,6 +228,12 @@ function ChatPanelAPI() {
 
   return (
     <div className="flex flex-col h-full bg-bg">
+      {/* Auth error banner */}
+      {authError && (
+        <div className="px-3 py-2 bg-red-900/30 border-b border-red-700/50 text-[11px] text-red-400">
+          {authError}
+        </div>
+      )}
       {/* Channel selector */}
       <div className="flex items-center gap-2 px-3 h-7 shrink-0 border-b border-border">
         <span className="text-[11px] text-text-muted">#</span>


### PR DESCRIPTION
## Summary
- Chat proxy routes only sent `agentchattr_token` as `x-session-token` header, but AgentChattr also validates via `?token=` query parameter — added both (matching existing trigger code pattern)
- iframe mode now passes token in the URL so direct embeds authenticate
- ChatPanelAPI now shows a clear red error banner on 403 instead of silently failing with "No messages"

Fixes #84

## Test plan
- [ ] Open `http://127.0.0.1:8400/project/quadwork` directly — chat panel loads messages without 403
- [ ] No 403 errors in browser console network tab
- [ ] If token is missing/wrong, red banner appears: "Chat authentication failed (403)..."
- [ ] Sending messages works through the chat panel
- [ ] iframe mode authenticates when AgentChattr allows embedding

🤖 Generated with [Claude Code](https://claude.com/claude-code)