### PR TITLE
[#83] Fix project page blank on direct URL by using usePathname

### DIFF
--- a/src/app/project/[id]/ProjectPageClient.tsx
+++ b/src/app/project/[id]/ProjectPageClient.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import ProjectDashboard from "@/components/ProjectDashboard";
 
 export default function ProjectPageClient() {
-  const { id } = useParams<{ id: string }>();
+  const pathname = usePathname();
+  // Extract project ID from URL path: /project/<id>
+  const segments = pathname.split("/");
+  const id = segments[2] || "";
 
-  // Static export pre-renders with placeholder "_". Wait for hydration
-  // to resolve the real project ID before rendering child components
-  // that issue API/WebSocket requests.
   if (!id || id === "_") {
     return null;
   }

--- a/src/app/project/[id]/memory/MemoryPageClient.tsx
+++ b/src/app/project/[id]/memory/MemoryPageClient.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import MemoryDashboard from "@/components/MemoryDashboard";
 
 export default function MemoryPageClient() {
-  const { id } = useParams<{ id: string }>();
+  const pathname = usePathname();
+  const segments = pathname.split("/");
+  const id = segments[2] || "";
 
   if (!id || id === "_") {
     return null;

--- a/src/app/project/[id]/queue/QueuePageClient.tsx
+++ b/src/app/project/[id]/queue/QueuePageClient.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import QueueManager from "@/components/QueueManager";
 
 export default function QueuePageClient() {
-  const { id } = useParams<{ id: string }>();
+  const pathname = usePathname();
+  const segments = pathname.split("/");
+  const id = segments[2] || "";
 
   if (!id || id === "_") {
     return null;


### PR DESCRIPTION
## Summary
- Root cause: `useParams()` returns the pre-rendered `"_"` from static export RSC payload and never re-resolves to the real URL segment
- Fix: switch all 3 client page components to `usePathname()` which reads the actual browser URL
- Verified with Playwright: all panels load correctly on direct URL access

## Verified
- [x] T1, T2a, T2b, T3 terminals spawn correctly
- [x] GitHub panel shows real issues
- [x] Chat panel loads messages from AgentChattr
- [x] Memory and Queue pages also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)