### PR TITLE
[#91] Improve terminal font and spacing

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -48,8 +48,10 @@ export default function TerminalPanel({
 
     const term = new Terminal({
       scrollback: 1000,
-      fontSize: 13,
-      fontFamily: "var(--font-geist-mono), ui-monospace, monospace",
+      fontSize: 12,
+      fontFamily: '"Geist Mono", "JetBrains Mono", "Fira Code", "Cascadia Code", monospace',
+      lineHeight: 1.4,
+      letterSpacing: 0.5,
       cursorBlink: false,
       cursorStyle: "block",
       theme: {


### PR DESCRIPTION
## Summary
- Updated xterm.js Terminal config in `TerminalPanel.tsx`: fontFamily to `"Geist Mono", "JetBrains Mono", "Fira Code", "Cascadia Code", monospace`, fontSize 12, lineHeight 1.4, letterSpacing 0.5
- Matches dashboard's mono font stack for visual consistency
- Improves readability with more breathing room between lines and characters

Fixes #91

## Test plan
- [ ] Open any project dashboard — terminal panels render with the new font stack
- [ ] Text is readable at 12px with comfortable line spacing
- [ ] Verify font fallback works (if Geist Mono unavailable, falls through to JetBrains Mono, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)