### PR TITLE
[#88] Per-project AgentChattr instances

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -678,15 +678,15 @@ async function cmdInit() {
     const setup = await setupAgents(rl, repo);
     if (!setup) { rl.close(); process.exit(1); }
 
-    // Step 4: AgentChattr config (skip install if prereqs already flagged it missing)
-    const configTomlPath = path.join(setup.absDir, "config.toml");
+    // Write QuadWork config first (assigns per-project ports)
+    writeQuadWorkConfig(setup);
+
+    // Step 4: AgentChattr config (reads assigned ports from saved config)
+    const configTomlPath = path.join(setup.absDir, "agentchattr", "config.toml");
     writeAgentChattrConfig(setup, configTomlPath, { skipInstall: !agentChattrFound });
 
     // Step 5: Optional add-ons
     await setupAddons(rl, setup, configTomlPath);
-
-    // Write QuadWork config
-    writeQuadWorkConfig(setup);
 
     // Done
     header("Setup Complete");
@@ -753,11 +753,12 @@ function cmdStart() {
   const pidFile = path.join(CONFIG_DIR, "server.pid");
   fs.writeFileSync(pidFile, String(server.pid));
 
-  // Start AgentChattr if installed and config.toml exists for first project
-  const firstProject = config.projects[0];
-  if (firstProject && which("agentchattr")) {
-    const configToml = path.join(firstProject.working_dir, "config.toml");
-    if (fs.existsSync(configToml)) {
+  // Start AgentChattr for each project that has a config.toml
+  if (which("agentchattr")) {
+    for (const project of config.projects) {
+      if (!project.working_dir) continue;
+      const configToml = path.join(project.working_dir, "agentchattr", "config.toml");
+      if (!fs.existsSync(configToml)) continue;
       const acProc = spawn("agentchattr", ["--config", configToml], {
         stdio: "ignore",
         detached: true,
@@ -765,8 +766,8 @@ function cmdStart() {
       acProc.on("error", () => {});
       acProc.unref();
       if (acProc.pid) {
-        ok(`AgentChattr started (PID: ${acProc.pid})`);
-        fs.writeFileSync(path.join(CONFIG_DIR, "agentchattr.pid"), String(acProc.pid));
+        ok(`AgentChattr started for ${project.id} (PID: ${acProc.pid})`);
+        fs.writeFileSync(path.join(CONFIG_DIR, `agentchattr-${project.id}.pid`), String(acProc.pid));
       }
     }
   }
@@ -827,10 +828,10 @@ async function cmdAddProject() {
     const setup = await setupAgents(rl, repo);
     if (!setup) { rl.close(); process.exit(1); }
 
-    const configTomlPath = path.join(setup.absDir, "config.toml");
-    writeAgentChattrConfig(setup, configTomlPath);
-
     writeQuadWorkConfig(setup);
+
+    const configTomlPath = path.join(setup.absDir, "agentchattr", "config.toml");
+    writeAgentChattrConfig(setup, configTomlPath);
 
     header("Project Added");
     log(`Project:      ${setup.projectName}`);

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -610,9 +610,16 @@ function writeQuadWorkConfig(setup) {
     };
   }
 
+  // Auto-assign per-project AgentChattr and MCP ports
+  const existingIdx = config.projects.findIndex((p) => p.id === setup.projectName);
+  const projectIdx = existingIdx >= 0 ? existingIdx : config.projects.length;
+  const chattrPort = 8300 + projectIdx;
+  project.agentchattr_url = `http://127.0.0.1:${chattrPort}`;
+  project.mcp_http_port = 8200 + (projectIdx * 2);
+  project.mcp_sse_port = 8201 + (projectIdx * 2);
+
   // Upsert project
-  const idx = config.projects.findIndex((p) => p.id === setup.projectName);
-  if (idx >= 0) config.projects[idx] = project;
+  if (existingIdx >= 0) config.projects[existingIdx] = project;
   else config.projects.push(project);
 
   writeConfig(config);

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -393,6 +393,11 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
   const mcpSse = existingProject?.mcp_sse_port || 8201;
   tomlContent = tomlContent.replace(/^port = \d+/m, `port = ${chattrPort}`);
   tomlContent = tomlContent.replace(/^data_dir = .+/m, `data_dir = "${dataDir}"`);
+  // Add session_token to [server] section if project has one
+  const sessionToken = existingProject?.agentchattr_token || "";
+  if (sessionToken) {
+    tomlContent = tomlContent.replace(/^(data_dir = .+)$/m, `$1\nsession_token = "${sessionToken}"`);
+  }
   tomlContent = tomlContent.replace(/^http_port = \d+/m, `http_port = ${mcpHttp}`);
   tomlContent = tomlContent.replace(/^sse_port = \d+/m, `sse_port = ${mcpSse}`);
 

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -505,12 +505,17 @@ async function setupAddons(rl, setup, configTomlPath) {
           bridge_dir: telegramDir,
         };
 
+        // Resolve per-project AgentChattr URL
+        const projectCfg = readConfig();
+        const projectEntry = projectCfg.projects?.find((p) => p.id === setup.projectName);
+        const projectChattrUrl = projectEntry?.agentchattr_url || "http://127.0.0.1:8300";
+
         // Append telegram section to config.toml (token read from env at runtime)
         const telegramSection = `
 [telegram]
 bot_token = "env:${envKey}"
 chat_id = "${chatId}"
-agentchattr_url = "http://127.0.0.1:8300"
+agentchattr_url = "${projectChattrUrl}"
 poll_interval = 2
 bridge_sender = "telegram-bridge"
 `;
@@ -522,7 +527,7 @@ bridge_sender = "telegram-bridge"
         if (fs.existsSync(bridgeScript)) {
           log("Starting Telegram bridge...");
           const bridgeToml = path.join(CONFIG_DIR, `telegram-${setup.projectName}.toml`);
-          const bridgeTomlContent = `[telegram]\nbot_token = "${botToken}"\nchat_id = "${chatId}"\n\n[agentchattr]\nurl = "http://127.0.0.1:8300"\n`;
+          const bridgeTomlContent = `[telegram]\nbot_token = "${botToken}"\nchat_id = "${chatId}"\n\n[agentchattr]\nurl = "${projectChattrUrl}"\n`;
           fs.writeFileSync(bridgeToml, bridgeTomlContent, { mode: 0o600 });
           fs.chmodSync(bridgeToml, 0o600);
           const bridgeProc = spawn("python3", [bridgeScript, "--config", bridgeToml], {
@@ -640,6 +645,7 @@ function writeQuadWorkConfig(setup) {
   let mcp_sse = mcp_http + 1;
   while (usedMcpPorts.has(mcp_sse)) mcp_sse++;
   project.agentchattr_url = `http://127.0.0.1:${chattrPort}`;
+  project.agentchattr_token = require("crypto").randomBytes(16).toString("hex");
   project.mcp_http_port = mcp_http;
   project.mcp_sse_port = mcp_sse;
 

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -380,6 +380,22 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
     );
   }
 
+  // Per-project: isolated data dir and port
+  const dataDir = path.join(path.dirname(configTomlPath), "data");
+  if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+  // Read assigned port from config (set by writeQuadWorkConfig)
+  const existingConfig = readConfig();
+  const existingProject = existingConfig.projects?.find((p) => p.id === setup.projectName);
+  const chattrPort = existingProject?.agentchattr_url
+    ? new URL(existingProject.agentchattr_url).port
+    : "8300";
+  const mcpHttp = existingProject?.mcp_http_port || 8200;
+  const mcpSse = existingProject?.mcp_sse_port || 8201;
+  tomlContent = tomlContent.replace(/^port = \d+/m, `port = ${chattrPort}`);
+  tomlContent = tomlContent.replace(/^data_dir = .+/m, `data_dir = "${dataDir}"`);
+  tomlContent = tomlContent.replace(/^http_port = \d+/m, `http_port = ${mcpHttp}`);
+  tomlContent = tomlContent.replace(/^sse_port = \d+/m, `sse_port = ${mcpSse}`);
+
   // Write config.toml
   const configDir = path.dirname(configTomlPath);
   if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
@@ -610,13 +626,21 @@ function writeQuadWorkConfig(setup) {
     };
   }
 
-  // Auto-assign per-project AgentChattr and MCP ports
+  // Auto-assign per-project AgentChattr and MCP ports (scan existing to avoid collisions)
   const existingIdx = config.projects.findIndex((p) => p.id === setup.projectName);
-  const projectIdx = existingIdx >= 0 ? existingIdx : config.projects.length;
-  const chattrPort = 8300 + projectIdx;
+  const usedChattrPorts = new Set(config.projects.map((p) => {
+    try { return parseInt(new URL(p.agentchattr_url).port, 10); } catch { return 0; }
+  }).filter(Boolean));
+  const usedMcpPorts = new Set(config.projects.flatMap((p) => [p.mcp_http_port, p.mcp_sse_port]).filter(Boolean));
+  let chattrPort = 8300;
+  while (usedChattrPorts.has(chattrPort)) chattrPort++;
+  let mcp_http = 8200;
+  while (usedMcpPorts.has(mcp_http)) mcp_http++;
+  let mcp_sse = mcp_http + 1;
+  while (usedMcpPorts.has(mcp_sse)) mcp_sse++;
   project.agentchattr_url = `http://127.0.0.1:${chattrPort}`;
-  project.mcp_http_port = 8200 + (projectIdx * 2);
-  project.mcp_sse_port = 8201 + (projectIdx * 2);
+  project.mcp_http_port = mcp_http;
+  project.mcp_sse_port = mcp_sse;
 
   // Upsert project
   if (existingIdx >= 0) config.projects[existingIdx] = project;

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -430,8 +430,9 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
     acProc.unref();
     if (acProc.pid) {
       ok(`AgentChattr started (PID: ${acProc.pid})`);
-      const pidFile = path.join(CONFIG_DIR, "agentchattr.pid");
+      // Per-project PID file
       if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true });
+      const pidFile = path.join(CONFIG_DIR, `agentchattr-${setup.projectName}.pid`);
       fs.writeFileSync(pidFile, String(acProc.pid));
     } else {
       warn("Could not start AgentChattr — start manually: agentchattr --config " + configTomlPath);
@@ -806,7 +807,15 @@ function cmdStop() {
 
   let stopped = 0;
   if (stopPid("Telegram bridge", "telegram-bridge.pid")) stopped++;
+
+  // Stop per-project AgentChattr instances
+  const config = readConfig();
+  for (const project of (config.projects || [])) {
+    if (stopPid(`AgentChattr (${project.id})`, `agentchattr-${project.id}.pid`)) stopped++;
+  }
+  // Also stop legacy single-instance PID if present
   if (stopPid("AgentChattr", "agentchattr.pid")) stopped++;
+
   if (stopPid("Server", "server.pid")) stopped++;
 
   if (stopped === 0) warn("No running processes found");

--- a/server/config.js
+++ b/server/config.js
@@ -86,4 +86,18 @@ function resolveAgentCommand(projectId, agentId) {
   return agent.command;
 }
 
-module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, CONFIG_PATH };
+/**
+ * Resolve AgentChattr connection for a project (per-project → global fallback).
+ */
+function resolveProjectChattr(projectId) {
+  const config = readConfig();
+  const project = projectId ? config.projects?.find((p) => p.id === projectId) : null;
+  return {
+    url: project?.agentchattr_url || config.agentchattr_url || "http://127.0.0.1:8300",
+    token: project?.agentchattr_token || config.agentchattr_token || null,
+    mcp_http_port: project?.mcp_http_port || null,
+    mcp_sse_port: project?.mcp_sse_port || null,
+  };
+}
+
+module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, CONFIG_PATH };

--- a/server/index.js
+++ b/server/index.js
@@ -122,6 +122,13 @@ app.post("/api/agentchattr/:projectOrAction/:action?", (req, res) => {
   const { url: chattrUrl } = resolveProjectChattr(projectId);
   const chattrPort = new URL(chattrUrl).port || "8300";
 
+  // Find per-project config.toml (prefer project working_dir/agentchattr/config.toml)
+  const cfg = readConfig();
+  const project = cfg.projects?.find((p) => p.id === projectId);
+  const projectConfigToml = project?.working_dir
+    ? path.join(project.working_dir, "agentchattr", "config.toml")
+    : null;
+
   function getProc() {
     return chattrProcesses.get(projectId) || { process: null, state: "stopped", error: null };
   }
@@ -130,7 +137,11 @@ app.post("/api/agentchattr/:projectOrAction/:action?", (req, res) => {
   }
 
   function spawnChattr() {
-    const child = spawn("agentchattr", ["--port", chattrPort], {
+    // Use project config.toml if available (isolated data dir + ports), otherwise fall back to --port
+    const args = (projectConfigToml && fs.existsSync(projectConfigToml))
+      ? ["--config", projectConfigToml]
+      : ["--port", chattrPort];
+    const child = spawn("agentchattr", args, {
       env: process.env,
       stdio: "ignore",
       detached: true,

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ const fs = require("fs");
 const { WebSocketServer } = require("ws");
 const pty = require("node-pty");
 const { spawn } = require("child_process");
-const { readConfig, resolveAgentCwd, resolveAgentCommand } = require("./config");
+const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr } = require("./config");
 const routes = require("./routes");
 
 const config = readConfig();
@@ -30,8 +30,8 @@ app.get("/api/health", (_req, res) => {
 // PTY (term) is the source of truth for "running". WS is optional (attaches to view terminal).
 const agentSessions = new Map();
 
-// AgentChattr server process (separate — not a PTY agent)
-let chattrProcess = { process: null, state: "stopped", error: null };
+// AgentChattr server processes — per-project (key = projectId)
+const chattrProcesses = new Map();
 
 // Helper: spawn a PTY for a project/agent and register in agentSessions
 function spawnAgentPty(project, agent) {
@@ -99,72 +99,87 @@ app.get("/api/agents", (_req, res) => {
   for (const [key, session] of agentSessions) {
     agents[key] = { state: session.state, error: session.error || null };
   }
-  agents["_agentchattr"] = { state: chattrProcess.state, error: chattrProcess.error };
+  for (const [pid, proc] of chattrProcesses) {
+    agents[`_agentchattr/${pid}`] = { state: proc.state, error: proc.error };
+  }
   res.json(agents);
 });
 
-app.post("/api/agentchattr/:action", (req, res) => {
-  const { action } = req.params;
-  const cfg = readConfig();
-  const chattrUrl = cfg.agentchattr_url || "http://127.0.0.1:8300";
+// Per-project AgentChattr lifecycle: /api/agentchattr/:project/:action
+// Backward compat: /api/agentchattr/:action uses first project
+app.post("/api/agentchattr/:projectOrAction/:action?", (req, res) => {
+  let projectId, action;
+  if (req.params.action) {
+    projectId = req.params.projectOrAction;
+    action = req.params.action;
+  } else {
+    // Backward compat: single-param = action, use first project
+    action = req.params.projectOrAction;
+    const cfg = readConfig();
+    projectId = cfg.projects?.[0]?.id || "_default";
+  }
+
+  const { url: chattrUrl } = resolveProjectChattr(projectId);
   const chattrPort = new URL(chattrUrl).port || "8300";
 
+  function getProc() {
+    return chattrProcesses.get(projectId) || { process: null, state: "stopped", error: null };
+  }
+  function setProc(val) {
+    chattrProcesses.set(projectId, val);
+  }
+
+  function spawnChattr() {
+    const child = spawn("agentchattr", ["--port", chattrPort], {
+      env: process.env,
+      stdio: "ignore",
+      detached: true,
+    });
+    child.unref();
+    child.on("error", (err) => {
+      setProc({ process: null, state: "error", error: err.message });
+    });
+    child.on("exit", (code) => {
+      const cur = getProc();
+      if (cur.process === child) {
+        setProc({ process: null, state: "stopped", error: code ? `exit:${code}` : null });
+      }
+    });
+    setProc({ process: child, state: "running", error: null });
+    return child;
+  }
+
   if (action === "start") {
-    if (chattrProcess.state === "running" && chattrProcess.process) {
+    const proc = getProc();
+    if (proc.state === "running" && proc.process) {
       return res.json({ ok: true, state: "running", message: "Already running" });
     }
     try {
-      const child = spawn("agentchattr", ["--port", chattrPort], {
-        env: process.env,
-        stdio: "ignore",
-        detached: true,
-      });
-      child.unref();
-      child.on("error", (err) => {
-        chattrProcess = { process: null, state: "error", error: err.message };
-      });
-      child.on("exit", (code) => {
-        if (chattrProcess.process === child) {
-          chattrProcess = { process: null, state: "stopped", error: code ? `exit:${code}` : null };
-        }
-      });
-      chattrProcess = { process: child, state: "running", error: null };
+      const child = spawnChattr();
       res.json({ ok: true, state: "running", pid: child.pid });
     } catch (err) {
-      chattrProcess = { process: null, state: "error", error: err.message };
+      setProc({ process: null, state: "error", error: err.message });
       res.status(500).json({ ok: false, state: "error", error: err.message });
     }
   } else if (action === "stop") {
-    if (chattrProcess.process) {
-      try { chattrProcess.process.kill("SIGTERM"); } catch {}
+    const proc = getProc();
+    if (proc.process) {
+      try { proc.process.kill("SIGTERM"); } catch {}
     }
-    chattrProcess = { process: null, state: "stopped", error: null };
+    setProc({ process: null, state: "stopped", error: null });
     res.json({ ok: true, state: "stopped" });
   } else if (action === "restart") {
-    if (chattrProcess.process) {
-      try { chattrProcess.process.kill("SIGTERM"); } catch {}
+    const proc = getProc();
+    if (proc.process) {
+      try { proc.process.kill("SIGTERM"); } catch {}
     }
-    chattrProcess = { process: null, state: "stopped", error: null };
+    setProc({ process: null, state: "stopped", error: null });
     setTimeout(() => {
       try {
-        const child = spawn("agentchattr", ["--port", chattrPort], {
-          env: process.env,
-          stdio: "ignore",
-          detached: true,
-        });
-        child.unref();
-        child.on("error", (err) => {
-          chattrProcess = { process: null, state: "error", error: err.message };
-        });
-        child.on("exit", (code) => {
-          if (chattrProcess.process === child) {
-            chattrProcess = { process: null, state: "stopped", error: code ? `exit:${code}` : null };
-          }
-        });
-        chattrProcess = { process: child, state: "running", error: null };
+        const child = spawnChattr();
         res.json({ ok: true, state: "running", pid: child.pid });
       } catch (err) {
-        chattrProcess = { process: null, state: "error", error: err.message };
+        setProc({ process: null, state: "error", error: err.message });
         res.status(500).json({ ok: false, state: "error", error: err.message });
       }
     }, 500);
@@ -271,8 +286,8 @@ ALL: Communicate via this chat by tagging agents. Your terminal is NOT visible.`
 async function sendTriggerMessage(projectId) {
   const cfg = readConfig();
   const project = cfg.projects && cfg.projects.find((p) => p.id === projectId);
-  const chattrUrl = cfg.agentchattr_url || "http://127.0.0.1:8300";
-  const token = cfg.agentchattr_token || "";
+  const { url: chattrUrl, token: chattrToken } = resolveProjectChattr(projectId);
+  const token = chattrToken || "";
   const message = (project && project.trigger_message) || DEFAULT_MESSAGE;
   const headers = { "Content-Type": "application/json" };
   if (token) headers["x-session-token"] = token;

--- a/server/routes.js
+++ b/server/routes.js
@@ -143,7 +143,6 @@ router.get("/api/projects", async (req, res) => {
     const { url: chattrUrl, token: chattrToken } = getChattrConfig(p.id);
     try {
       const headers = chattrToken ? { "x-session-token": chattrToken } : {};
-      if (chattrToken) headers["x-session-token"] = chattrToken;
       const tokenParam = chattrToken ? `&token=${encodeURIComponent(chattrToken)}` : "";
       const r = await fetch(`${chattrUrl}/api/messages?channel=general&limit=30${tokenParam}`, { headers });
       if (r.ok) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -562,12 +562,19 @@ router.post("/api/setup", (req, res) => {
       fs.mkdirSync(dataDir, { recursive: true });
       const tomlPath = path.join(projectConfigDir, "config.toml");
 
-      // Resolve per-project port from config (if already assigned)
-      const { resolveProjectChattr: rpc } = require("./config");
-      const projectChattr = rpc(dirName);
-      const chattrPort = new URL(projectChattr.url).port || "8300";
-      const mcp_http = projectChattr.mcp_http_port || 8200;
-      const mcp_sse = projectChattr.mcp_sse_port || 8201;
+      // Resolve per-project ports: prefer explicit body params (from setup wizard),
+      // then fall back to saved config, then defaults
+      let chattrPort, mcp_http, mcp_sse;
+      if (body.agentchattr_port) {
+        chattrPort = String(body.agentchattr_port);
+        mcp_http = body.mcp_http_port || 8200;
+        mcp_sse = body.mcp_sse_port || 8201;
+      } else {
+        const projectChattr = resolveProjectChattr(dirName);
+        chattrPort = new URL(projectChattr.url).port || "8300";
+        mcp_http = projectChattr.mcp_http_port || 8200;
+        mcp_sse = projectChattr.mcp_sse_port || 8201;
+      }
 
       const agents = ["head", "reviewer1", "reviewer2", "dev"];
       const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];

--- a/server/routes.js
+++ b/server/routes.js
@@ -580,8 +580,15 @@ router.post("/api/setup", (req, res) => {
       const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
       const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
 
+      // Read saved token for this project (if available)
+      const savedCfg = readConfigFile();
+      const savedProject = savedCfg.projects?.find((p) => p.id === dirName);
+      const sessionToken = body.agentchattr_token || savedProject?.agentchattr_token || "";
+
       let content = `[meta]\nname = "${displayName}"\n\n`;
-      content += `[server]\nport = ${chattrPort}\nhost = "127.0.0.1"\ndata_dir = "${dataDir}"\n\n`;
+      content += `[server]\nport = ${chattrPort}\nhost = "127.0.0.1"\ndata_dir = "${dataDir}"\n`;
+      if (sessionToken) content += `session_token = "${sessionToken}"\n`;
+      content += `\n`;
       agents.forEach((agent, i) => {
         const wtDir = path.join(parentDir, `${dirName}-${agent}`);
         content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.charAt(0).toUpperCase() + agent.slice(1)} ${labels[i]}"\nmcp_inject = "flag"\n\n`;

--- a/server/routes.js
+++ b/server/routes.js
@@ -67,16 +67,11 @@ router.put("/api/config", (req, res) => {
 
 // ─── Chat (AgentChattr proxy) ──────────────────────────────────────────────
 
-function getChattrConfig() {
-  try {
-    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
-    return {
-      url: cfg.agentchattr_url || "http://127.0.0.1:8300",
-      token: cfg.agentchattr_token || null,
-    };
-  } catch {
-    return { url: "http://127.0.0.1:8300", token: null };
-  }
+const { resolveProjectChattr } = require("./config");
+
+function getChattrConfig(projectId) {
+  const resolved = resolveProjectChattr(projectId);
+  return { url: resolved.url, token: resolved.token };
 }
 
 function chatAuthHeaders(token) {
@@ -86,7 +81,7 @@ function chatAuthHeaders(token) {
 
 router.get("/api/chat", async (req, res) => {
   const apiPath = req.query.path || "/api/messages";
-  const { url: base, token } = getChattrConfig();
+  const { url: base, token } = getChattrConfig(req.query.project);
 
   const fwd = new URLSearchParams();
   for (const [k, v] of Object.entries(req.query)) {
@@ -105,7 +100,7 @@ router.get("/api/chat", async (req, res) => {
 });
 
 router.post("/api/chat", async (req, res) => {
-  const { url: base, token } = getChattrConfig();
+  const { url: base, token } = getChattrConfig(req.query.project || req.body.project);
   const tokenParam = token ? `?token=${encodeURIComponent(token)}` : "";
   try {
     const r = await fetch(`${base}/api/send${tokenParam}`, {
@@ -134,8 +129,6 @@ function ghJson(args) {
 
 router.get("/api/projects", async (req, res) => {
   const cfg = readConfigFile();
-  const chattrUrl = cfg.agentchattr_url || "http://127.0.0.1:8300";
-  const chattrToken = cfg.agentchattr_token;
 
   // Fetch active sessions from our own in-memory state (only running PTYs)
   const activeSessions = req.app.get("activeSessions") || new Map();
@@ -144,16 +137,24 @@ router.get("/api/projects", async (req, res) => {
     if (info.projectId && info.state === "running") activeProjectIds.add(info.projectId);
   }
 
-  // Fetch chat messages
-  let chatMsgs = [];
-  try {
-    const headers = chattrToken ? { "x-session-token": chattrToken } : {};
-    const r = await fetch(`${chattrUrl}/api/messages?channel=general&limit=30`, { headers });
-    if (r.ok) {
-      const data = await r.json();
-      chatMsgs = Array.isArray(data) ? data : data.messages || [];
-    }
-  } catch {}
+  // Fetch chat messages from all projects (per-project AgentChattr instances)
+  const chatMsgsByProject = {};
+  const chatFetches = (cfg.projects || []).map(async (p) => {
+    const { url: chattrUrl, token: chattrToken } = getChattrConfig(p.id);
+    try {
+      const headers = chattrToken ? { "x-session-token": chattrToken } : {};
+      if (chattrToken) headers["x-session-token"] = chattrToken;
+      const tokenParam = chattrToken ? `&token=${encodeURIComponent(chattrToken)}` : "";
+      const r = await fetch(`${chattrUrl}/api/messages?channel=general&limit=30${tokenParam}`, { headers });
+      if (r.ok) {
+        const data = await r.json();
+        chatMsgsByProject[p.id] = Array.isArray(data) ? data : data.messages || [];
+      }
+    } catch {}
+  });
+  await Promise.allSettled(chatFetches);
+  // Aggregate all project chat messages for the activity feed
+  let chatMsgs = Object.values(chatMsgsByProject).flat();
 
   const eventKeywords = /\b(PR|merged|pushed|approved|opened|closed|review|commit)\b/i;
   const workflowMsgs = chatMsgs
@@ -612,7 +613,17 @@ router.post("/api/setup", (req, res) => {
           command: (backends && backends[agentId]) || "claude",
         };
       }
-      cfg.projects.push({ id, name, repo, working_dir: workingDir, agents });
+      // Auto-assign per-project AgentChattr and MCP ports
+      const idx = cfg.projects.length;
+      const chattrPort = 8300 + idx;
+      const mcp_http_port = 8200 + (idx * 2);
+      const mcp_sse_port = 8201 + (idx * 2);
+      cfg.projects.push({
+        id, name, repo, working_dir: workingDir, agents,
+        agentchattr_url: `http://127.0.0.1:${chattrPort}`,
+        mcp_http_port,
+        mcp_sse_port,
+      });
       const dir = path.dirname(CONFIG_PATH);
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));

--- a/server/routes.js
+++ b/server/routes.js
@@ -625,9 +625,13 @@ router.post("/api/setup", (req, res) => {
       while (usedMcpPorts.has(mcp_http_port)) mcp_http_port++;
       let mcp_sse_port = mcp_http_port + 1;
       while (usedMcpPorts.has(mcp_sse_port)) mcp_sse_port++;
+      // Auto-generate per-project session token
+      const crypto = require("crypto");
+      const agentchattr_token = crypto.randomBytes(16).toString("hex");
       cfg.projects.push({
         id, name, repo, working_dir: workingDir, agents,
         agentchattr_url: `http://127.0.0.1:${chattrPort}`,
+        agentchattr_token,
         mcp_http_port,
         mcp_sse_port,
       });

--- a/server/routes.js
+++ b/server/routes.js
@@ -550,48 +550,43 @@ router.post("/api/setup", (req, res) => {
     case "agentchattr-config": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
-      // Use directory basename for sibling paths, display name for metadata
       const dirName = path.basename(workingDir);
       const displayName = body.projectName || dirName;
       const parentDir = path.dirname(workingDir);
-      const tomlPaths = [
-        path.join(workingDir, "agentchattr", "config.toml"),
-        path.join(parentDir, "agentchattr", "config.toml"),
-        path.join(os.homedir(), ".agentchattr", "config.toml"),
-      ];
-      let tomlPath = tomlPaths.find((p) => fs.existsSync(p));
       const backends = body.backends;
-      if (!tomlPath) {
-        const dir = path.join(workingDir, "agentchattr");
-        fs.mkdirSync(dir, { recursive: true });
-        tomlPath = path.join(dir, "config.toml");
-        const agents = ["head", "reviewer1", "reviewer2", "dev"];
-        const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
-        const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
-        let content = `[meta]\nname = "${displayName}"\n\n`;
-        agents.forEach((agent, i) => {
-          const wtDir = path.join(parentDir, `${dirName}-${agent}`);
-          content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.charAt(0).toUpperCase() + agent.slice(1)} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
-        });
-        fs.writeFileSync(tomlPath, content);
-      } else {
-        let content = fs.readFileSync(tomlPath, "utf-8");
-        const agents = ["head", "reviewer1", "reviewer2", "dev"];
-        const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
-        const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
-        agents.forEach((agent, i) => {
-          if (!content.includes(`[agents.${agent}]`)) {
-            const wtDir = path.join(parentDir, `${dirName}-${agent}`);
-            content += `\n[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.charAt(0).toUpperCase() + agent.slice(1)} ${labels[i]}"\nmcp_inject = "flag"\n`;
-          }
-        });
-        fs.writeFileSync(tomlPath, content);
-      }
-      // Restart AgentChattr so config changes take effect
+
+      // Per-project: isolated config dir + data dir
+      const projectConfigDir = path.join(workingDir, "agentchattr");
+      fs.mkdirSync(projectConfigDir, { recursive: true });
+      const dataDir = path.join(projectConfigDir, "data");
+      fs.mkdirSync(dataDir, { recursive: true });
+      const tomlPath = path.join(projectConfigDir, "config.toml");
+
+      // Resolve per-project port from config (if already assigned)
+      const { resolveProjectChattr: rpc } = require("./config");
+      const projectChattr = rpc(dirName);
+      const chattrPort = new URL(projectChattr.url).port || "8300";
+      const mcp_http = projectChattr.mcp_http_port || 8200;
+      const mcp_sse = projectChattr.mcp_sse_port || 8201;
+
+      const agents = ["head", "reviewer1", "reviewer2", "dev"];
+      const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
+      const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
+
+      let content = `[meta]\nname = "${displayName}"\n\n`;
+      content += `[server]\nport = ${chattrPort}\nhost = "127.0.0.1"\ndata_dir = "${dataDir}"\n\n`;
+      agents.forEach((agent, i) => {
+        const wtDir = path.join(parentDir, `${dirName}-${agent}`);
+        content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.charAt(0).toUpperCase() + agent.slice(1)} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
+      });
+      content += `[mcp]\nhttp_port = ${mcp_http}\nsse_port = ${mcp_sse}\n`;
+      fs.writeFileSync(tomlPath, content);
+
+      // Restart this project's AgentChattr instance (not global)
       try {
         const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
-        const port = cfg.port || 8400;
-        fetch(`http://127.0.0.1:${port}/api/agentchattr/restart`, { method: "POST" }).catch(() => {});
+        const qwPort = cfg.port || 8400;
+        fetch(`http://127.0.0.1:${qwPort}/api/agentchattr/${encodeURIComponent(dirName)}/restart`, { method: "POST" }).catch(() => {});
       } catch {}
       return res.json({ ok: true, path: tomlPath });
     }
@@ -612,11 +607,17 @@ router.post("/api/setup", (req, res) => {
           command: (backends && backends[agentId]) || "claude",
         };
       }
-      // Auto-assign per-project AgentChattr and MCP ports
-      const idx = cfg.projects.length;
-      const chattrPort = 8300 + idx;
-      const mcp_http_port = 8200 + (idx * 2);
-      const mcp_sse_port = 8201 + (idx * 2);
+      // Auto-assign per-project AgentChattr and MCP ports (scan existing to avoid collisions)
+      const usedChattrPorts = new Set(cfg.projects.map((p) => {
+        try { return parseInt(new URL(p.agentchattr_url).port, 10); } catch { return 0; }
+      }).filter(Boolean));
+      const usedMcpPorts = new Set(cfg.projects.flatMap((p) => [p.mcp_http_port, p.mcp_sse_port]).filter(Boolean));
+      let chattrPort = 8300;
+      while (usedChattrPorts.has(chattrPort)) chattrPort++;
+      let mcp_http_port = 8200;
+      while (usedMcpPorts.has(mcp_http_port)) mcp_http_port++;
+      let mcp_sse_port = mcp_http_port + 1;
+      while (usedMcpPorts.has(mcp_sse_port)) mcp_sse_port++;
       cfg.projects.push({
         id, name, repo, working_dir: workingDir, agents,
         agentchattr_url: `http://127.0.0.1:${chattrPort}`,

--- a/server/routes.js
+++ b/server/routes.js
@@ -580,10 +580,11 @@ router.post("/api/setup", (req, res) => {
       const colors = ["#10a37f", "#22c55e", "#f59e0b", "#da7756"];
       const labels = ["Owner", "Reviewer", "Reviewer", "Builder"];
 
-      // Read saved token for this project (if available)
+      // Read or generate token for this project
+      const crypto = require("crypto");
       const savedCfg = readConfigFile();
       const savedProject = savedCfg.projects?.find((p) => p.id === dirName);
-      const sessionToken = body.agentchattr_token || savedProject?.agentchattr_token || "";
+      const sessionToken = body.agentchattr_token || savedProject?.agentchattr_token || crypto.randomBytes(16).toString("hex");
 
       let content = `[meta]\nname = "${displayName}"\n\n`;
       content += `[server]\nport = ${chattrPort}\nhost = "127.0.0.1"\ndata_dir = "${dataDir}"\n`;
@@ -602,7 +603,7 @@ router.post("/api/setup", (req, res) => {
         const qwPort = cfg.port || 8400;
         fetch(`http://127.0.0.1:${qwPort}/api/agentchattr/${encodeURIComponent(dirName)}/restart`, { method: "POST" }).catch(() => {});
       } catch {}
-      return res.json({ ok: true, path: tomlPath });
+      return res.json({ ok: true, path: tomlPath, agentchattr_token: sessionToken, agentchattr_port: chattrPort, mcp_http_port: mcp_http, mcp_sse_port: mcp_sse });
     }
     case "add-config": {
       const { id, name, repo, workingDir, backends } = body;
@@ -621,20 +622,26 @@ router.post("/api/setup", (req, res) => {
           command: (backends && backends[agentId]) || "claude",
         };
       }
-      // Auto-assign per-project AgentChattr and MCP ports (scan existing to avoid collisions)
-      const usedChattrPorts = new Set(cfg.projects.map((p) => {
-        try { return parseInt(new URL(p.agentchattr_url).port, 10); } catch { return 0; }
-      }).filter(Boolean));
-      const usedMcpPorts = new Set(cfg.projects.flatMap((p) => [p.mcp_http_port, p.mcp_sse_port]).filter(Boolean));
-      let chattrPort = 8300;
-      while (usedChattrPorts.has(chattrPort)) chattrPort++;
-      let mcp_http_port = 8200;
-      while (usedMcpPorts.has(mcp_http_port)) mcp_http_port++;
-      let mcp_sse_port = mcp_http_port + 1;
-      while (usedMcpPorts.has(mcp_sse_port)) mcp_sse_port++;
-      // Auto-generate per-project session token
+      // Use pre-assigned ports/token from agentchattr-config step if provided,
+      // otherwise auto-assign (direct add-config without prior agentchattr-config)
       const crypto = require("crypto");
-      const agentchattr_token = crypto.randomBytes(16).toString("hex");
+      let chattrPort = body.agentchattr_port;
+      let mcp_http_port = body.mcp_http_port;
+      let mcp_sse_port = body.mcp_sse_port;
+      let agentchattr_token = body.agentchattr_token;
+      if (!chattrPort) {
+        const usedChattrPorts = new Set(cfg.projects.map((p) => {
+          try { return parseInt(new URL(p.agentchattr_url).port, 10); } catch { return 0; }
+        }).filter(Boolean));
+        const usedMcpPorts = new Set(cfg.projects.flatMap((p) => [p.mcp_http_port, p.mcp_sse_port]).filter(Boolean));
+        chattrPort = 8300;
+        while (usedChattrPorts.has(chattrPort)) chattrPort++;
+        mcp_http_port = 8200;
+        while (usedMcpPorts.has(mcp_http_port)) mcp_http_port++;
+        mcp_sse_port = mcp_http_port + 1;
+        while (usedMcpPorts.has(mcp_sse_port)) mcp_sse_port++;
+      }
+      if (!agentchattr_token) agentchattr_token = crypto.randomBytes(16).toString("hex");
       cfg.projects.push({
         id, name, repo, working_dir: workingDir, agents,
         agentchattr_url: `http://127.0.0.1:${chattrPort}`,

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -30,12 +30,16 @@ function senderColor(sender: string): string {
  * Tries iframe first (uses AgentChattr's own session auth).
  * Falls back to API polling if iframe fails to load.
  */
-export default function ChatPanel() {
+interface ChatPanelProps {
+  projectId?: string;
+}
+
+export default function ChatPanel({ projectId }: ChatPanelProps) {
   const [mode, setMode] = useState<"iframe" | "api" | "loading">("loading");
   const [chattrUrl, setChattrUrl] = useState("");
   const [chattrToken, setChattrToken] = useState("");
 
-  // Resolve AgentChattr URL and token from config
+  // Resolve AgentChattr URL and token from per-project config (fallback to global)
   useEffect(() => {
     fetch("/api/config")
       .then((r) => {
@@ -43,11 +47,12 @@ export default function ChatPanel() {
         return r.json();
       })
       .then((cfg) => {
-        setChattrUrl(cfg.agentchattr_url || "http://127.0.0.1:8300");
-        setChattrToken(cfg.agentchattr_token || "");
+        const project = projectId ? cfg.projects?.find((p: { id: string }) => p.id === projectId) : null;
+        setChattrUrl(project?.agentchattr_url || cfg.agentchattr_url || "http://127.0.0.1:8300");
+        setChattrToken(project?.agentchattr_token || cfg.agentchattr_token || "");
       })
       .catch(() => setChattrUrl("http://127.0.0.1:8300"));
-  }, []);
+  }, [projectId]);
 
   // Timeout fallback: if iframe hasn't loaded within 3s, switch to API mode
   // (onError doesn't fire for CSP/X-Frame-Options blocks)
@@ -98,11 +103,11 @@ export default function ChatPanel() {
     );
   }
 
-  return <ChatPanelAPI />;
+  return <ChatPanelAPI projectId={projectId} />;
 }
 
 /** API-driven fallback when iframe is blocked */
-function ChatPanelAPI() {
+function ChatPanelAPI({ projectId }: { projectId?: string }) {
   const [channels, setChannels] = useState<string[]>(["general"]);
   const [channel, setChannel] = useState("general");
   const [messages, setMessages] = useState<Message[]>([]);
@@ -117,7 +122,7 @@ function ChatPanelAPI() {
 
   // Fetch channels via proxy
   useEffect(() => {
-    fetch("/api/chat?path=/api/channels")
+    fetch(`/api/chat?path=/api/channels${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`)
       .then((r) => {
         if (r.status === 403) {
           setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
@@ -138,11 +143,11 @@ function ChatPanelAPI() {
   useEffect(() => {
     cursorRef.current = 0;
     setMessages([]);
-  }, [channel]);
+  }, [channel, projectId]);
 
   // Poll messages via proxy
   const fetchMessages = useCallback(() => {
-    fetch(`/api/chat?path=/api/messages&channel=${encodeURIComponent(channel)}&cursor=${cursorRef.current}`)
+    fetch(`/api/chat?path=/api/messages&channel=${encodeURIComponent(channel)}&cursor=${cursorRef.current}${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`)
       .then((r) => {
         if (r.status === 403) {
           setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
@@ -165,7 +170,7 @@ function ChatPanelAPI() {
         }
       })
       .catch(() => {});
-  }, [channel]);
+  }, [channel, projectId]);
 
   useEffect(() => {
     fetchMessages();
@@ -190,7 +195,7 @@ function ChatPanelAPI() {
   const send = () => {
     const text = input.trim();
     if (!text) return;
-    fetch("/api/chat", {
+    fetch(`/api/chat${projectId ? `?project=${encodeURIComponent(projectId)}` : ""}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text, channel, sender: "user" }),

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -158,7 +158,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
       <div className="flex flex-col overflow-hidden">
         <PanelHeader label="Chat" />
         <div className="flex-1 min-h-0">
-          <ChatPanel />
+          <ChatPanel projectId={projectId} />
         </div>
         <TriggerWidget projectId={projectId} />
       </div>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -24,6 +24,10 @@ interface ProjectConfig {
   repo: string;
   working_dir: string;
   agents: Record<string, AgentConfig>;
+  agentchattr_url?: string;
+  agentchattr_token?: string;
+  mcp_http_port?: number;
+  mcp_sse_port?: number;
   telegram?: TelegramConfig;
   trigger_enabled?: boolean;
   trigger_interval?: number;
@@ -455,6 +459,41 @@ export default function SettingsPage() {
                           )}
                         </div>
                       ))}
+                    </div>
+                  </div>
+
+                  {/* AgentChattr (per-project) */}
+                  <div className="mt-4">
+                    <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">AgentChattr</h3>
+                    <div className="border border-border p-3">
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <Input
+                          label="AgentChattr URL"
+                          value={project.agentchattr_url || ""}
+                          onChange={(v) => updateProject(idx, { agentchattr_url: v } as Partial<ProjectConfig>)}
+                          placeholder="http://127.0.0.1:8300"
+                        />
+                        <Input
+                          label="Session Token"
+                          value={project.agentchattr_token || ""}
+                          onChange={(v) => updateProject(idx, { agentchattr_token: v } as Partial<ProjectConfig>)}
+                          placeholder="(optional)"
+                        />
+                        <Input
+                          label="MCP HTTP Port"
+                          value={String(project.mcp_http_port || "")}
+                          onChange={(v) => updateProject(idx, { mcp_http_port: parseInt(v, 10) || undefined } as Partial<ProjectConfig>)}
+                          type="number"
+                          placeholder="8200"
+                        />
+                        <Input
+                          label="MCP SSE Port"
+                          value={String(project.mcp_sse_port || "")}
+                          onChange={(v) => updateProject(idx, { mcp_sse_port: parseInt(v, 10) || undefined } as Partial<ProjectConfig>)}
+                          type="number"
+                          placeholder="8201"
+                        />
+                      </div>
                     </div>
                   </div>
 

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -317,7 +317,23 @@ export default function SetupWizard() {
               <div className="flex gap-2">
                 <button
                   onClick={async () => {
-                    const result = await apiCall("agentchattr-config", { workingDir, projectName, repo, backends });
+                    // Pre-compute available ports for the new project
+                    let agentchattr_port = 8300, mcp_http_port = 8200, mcp_sse_port = 8201;
+                    try {
+                      const cfgRes = await fetch("/api/config");
+                      if (cfgRes.ok) {
+                        const cfg = await cfgRes.json();
+                        const usedChattr = new Set((cfg.projects || []).map((p: { agentchattr_url?: string }) => {
+                          try { return parseInt(new URL(p.agentchattr_url || "").port, 10); } catch { return 0; }
+                        }).filter(Boolean));
+                        const usedMcp = new Set((cfg.projects || []).flatMap((p: { mcp_http_port?: number; mcp_sse_port?: number }) => [p.mcp_http_port, p.mcp_sse_port]).filter(Boolean));
+                        while (usedChattr.has(agentchattr_port)) agentchattr_port++;
+                        while (usedMcp.has(mcp_http_port)) mcp_http_port++;
+                        mcp_sse_port = mcp_http_port + 1;
+                        while (usedMcp.has(mcp_sse_port)) mcp_sse_port++;
+                      }
+                    } catch {}
+                    const result = await apiCall("agentchattr-config", { workingDir, projectName, repo, backends, agentchattr_port, mcp_http_port, mcp_sse_port });
                     if (result.ok) goNext();
                     else updateStep(currentStep, { status: "error", error: result.error });
                   }}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -38,6 +38,8 @@ export default function SetupWizard() {
   // Form state
   const [projectName, setProjectName] = useState("");
   const [repo, setRepo] = useState("");
+  // Per-project AgentChattr config (populated by agentchattr-config step)
+  const [chattrConfig, setChattrConfig] = useState<{ agentchattr_token?: string; agentchattr_port?: number; mcp_http_port?: number; mcp_sse_port?: number }>({});
   const [backends, setBackends] = useState<Record<string, string>>({
     head: "claude", reviewer1: "claude", reviewer2: "claude", dev: "claude",
   });
@@ -112,7 +114,7 @@ export default function SetupWizard() {
   const saveConfig = async () => {
     // Use directory basename as project ID (matches CLI wizard)
     const id = workingDir.split("/").pop() || projectName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
-    const result = await apiCall("add-config", { id, name: projectName, repo, workingDir, backends });
+    const result = await apiCall("add-config", { id, name: projectName, repo, workingDir, backends, ...chattrConfig });
     if (result.ok) {
       updateStep(currentStep, { status: "done" });
       setTimeout(() => router.push(`/project/${id}`), 500);
@@ -334,8 +336,10 @@ export default function SetupWizard() {
                       }
                     } catch {}
                     const result = await apiCall("agentchattr-config", { workingDir, projectName, repo, backends, agentchattr_port, mcp_http_port, mcp_sse_port });
-                    if (result.ok) goNext();
-                    else updateStep(currentStep, { status: "error", error: result.error });
+                    if (result.ok) {
+                      setChattrConfig({ agentchattr_token: result.agentchattr_token, agentchattr_port: result.agentchattr_port, mcp_http_port: result.mcp_http_port, mcp_sse_port: result.mcp_sse_port });
+                      goNext();
+                    } else updateStep(currentStep, { status: "error", error: result.error });
                   }}
                   disabled={loading}
                   className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors disabled:opacity-50"


### PR DESCRIPTION
## Summary
- Moved `agentchattr_url`, `agentchattr_token`, and MCP ports from global config to per-project config
- Added `resolveProjectChattr(projectId)` in `server/config.js` with per-project → global fallback for backward compatibility
- Chat proxy now accepts `project` query param to route to the correct AgentChattr instance
- AgentChattr lifecycle endpoints are per-project (Map of processes instead of single global)
- Setup wizard auto-assigns unique ports per project (8300+idx for AgentChattr, 8200+idx*2 for MCP)
- ChatPanel accepts `projectId` prop and routes all API calls to the project's AgentChattr
- SettingsPage shows per-project AgentChattr URL, token, and MCP port fields
- Existing single-project configs continue to work unchanged (global fields serve as fallbacks)

Fixes #88

## Test plan
- [ ] Existing single-project config still works (backward compat)
- [ ] New project via setup wizard gets auto-assigned ports
- [ ] Chat panel on `/project/<id>` shows only that project's messages
- [ ] Per-project AgentChattr start/stop/restart works via API
- [ ] Settings page shows per-project AgentChattr fields
- [ ] Trigger messages use per-project AgentChattr config
- [ ] `/api/projects` dashboard fetches chat per-project

🤖 Generated with [Claude Code](https://claude.com/claude-code)