### PR TITLE
[#101] Fix trailing-slash 404s with redirect middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -382,6 +382,16 @@ app.set("syncTriggers", syncTriggersFromConfig);
 
 // --- Serve static frontend (built Next.js export) ---
 
+// Strip trailing slashes (redirect /settings/ → /settings, /setup/ → /setup)
+app.use((req, res, next) => {
+  if (req.path !== "/" && req.path.endsWith("/")) {
+    const clean = req.path.slice(0, -1);
+    const query = req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : "";
+    return res.redirect(301, clean + query);
+  }
+  next();
+});
+
 const outDir = path.join(__dirname, "..", "out");
 if (fs.existsSync(outDir)) {
   app.use(express.static(outDir));


### PR DESCRIPTION
## Summary
- Added trailing-slash strip middleware in `server/index.js` before static file serving
- Requests to `/settings/`, `/setup/`, `/project/foo/` etc. now get a 301 redirect to the clean path
- Preserves query strings across the redirect
- Root path `/` is excluded from stripping

Fixes #101

## Test plan
- [ ] `GET /settings/` redirects to `/settings` (301)
- [ ] `GET /setup/` redirects to `/setup` (301)
- [ ] `HEAD /settings/` redirects to `/settings` (301)
- [ ] `GET /settings` still works directly
- [ ] `GET /` still works (no redirect loop)
- [ ] Query strings preserved: `/settings/?foo=bar` → `/settings?foo=bar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)