### PR TITLE
[#102] Fix React hydration mismatch error #418

### DIFF
--- a/src/app/project/[id]/ProjectPageClient.tsx
+++ b/src/app/project/[id]/ProjectPageClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
-import ProjectDashboard from "@/components/ProjectDashboard";
+
+const ProjectDashboard = dynamic(() => import("@/components/ProjectDashboard"), { ssr: false });
 
 export default function ProjectPageClient() {
   const pathname = usePathname();

--- a/src/app/project/[id]/memory/MemoryPageClient.tsx
+++ b/src/app/project/[id]/memory/MemoryPageClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
-import MemoryDashboard from "@/components/MemoryDashboard";
+
+const MemoryDashboard = dynamic(() => import("@/components/MemoryDashboard"), { ssr: false });
 
 export default function MemoryPageClient() {
   const pathname = usePathname();

--- a/src/app/project/[id]/queue/QueuePageClient.tsx
+++ b/src/app/project/[id]/queue/QueuePageClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
-import QueueManager from "@/components/QueueManager";
+
+const QueueManager = dynamic(() => import("@/components/QueueManager"), { ssr: false });
 
 export default function QueuePageClient() {
   const pathname = usePathname();


### PR DESCRIPTION
## Summary
- Static export pre-renders with placeholder `_` data, causing React error #418 (hydration mismatch) when client renders with real project ID
- Used `dynamic(() => import(...), { ssr: false })` for ProjectDashboard, MemoryDashboard, and QueueManager in their client page wrappers
- Components now only render on the client, eliminating server/client HTML mismatch
- Page server components (page.tsx) remain unchanged — `generateStaticParams` still works

Fixes #102

## Test plan
- [ ] No React hydration errors in browser console on `/project/<id>`
- [ ] No errors on `/project/<id>/memory` or `/project/<id>/queue`
- [ ] Project dashboard still loads correctly with real project data
- [ ] Direct URL navigation still works (SPA fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)