### PR TITLE
[#98] Remove default_backend from CLI, improve wizard prompt UX

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -670,7 +670,7 @@ async function cmdInit() {
   console.log(`  ${c.cyan}${c.bold}║${c.reset}  ${c.white}${c.bold}QuadWork Init${c.reset}                           ${c.cyan}${c.bold}║${c.reset}`);
   console.log(`  ${c.cyan}${c.bold}║${c.reset}  ${c.dim}Global setup — projects via web UI${c.reset}       ${c.cyan}${c.bold}║${c.reset}`);
   console.log(`  ${c.cyan}${c.bold}╚══════════════════════════════════════════╝${c.reset}`);
-  console.log(`\n  ${c.dim}Tip: Press Enter to accept defaults shown in [brackets].${c.reset}\n`);
+  console.log(`\n  ${c.dim}Press Enter to accept defaults. Takes under 30 seconds.${c.reset}\n`);
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
@@ -682,16 +682,13 @@ async function cmdInit() {
       if (!proceed) { rl.close(); process.exit(1); }
     }
 
-    // Step 2: Global config
-    header("Step 2: Global Configuration");
-    const port = await ask(rl, "Dashboard port", "8400");
-    const defaultBackend = which("claude") ? "claude" : which("codex") ? "codex" : "claude";
-    const backend = await ask(rl, "Default CLI backend (claude/codex)", defaultBackend);
+    // Step 2: Dashboard port
+    header("Step 2: Dashboard Port");
+    const port = await ask(rl, "Port for the QuadWork dashboard (Enter for default)", "8400");
 
     // Write global config
     const config = readConfig();
     config.port = parseInt(port, 10) || 8400;
-    config.default_backend = backend;
     writeConfig(config);
     ok(`Wrote ${CONFIG_PATH}`);
 
@@ -723,7 +720,6 @@ async function cmdInit() {
     header("Setup Complete");
     log(`Config:     ${CONFIG_PATH}`);
     log(`Dashboard:  ${dashboardUrl}`);
-    log(`Backend:    ${backend}`);
     log("");
     log("Next steps:");
     log(`  Open ${c.cyan}${dashboardUrl}/setup${c.reset} to create your first project`);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -39,7 +39,6 @@ interface Config {
   port: number;
   agentchattr_url: string;
   agentchattr_token: string;
-  default_backend: string;
   projects: ProjectConfig[];
 }
 
@@ -119,7 +118,6 @@ export default function SettingsPage() {
         port: data.port || 8400,
         agentchattr_url: data.agentchattr_url || "http://127.0.0.1:8300",
         agentchattr_token: data.agentchattr_token || "",
-        default_backend: data.default_backend || "claude",
         projects: data.projects || [],
       }))
       .catch(() => {});
@@ -330,12 +328,6 @@ export default function SettingsPage() {
             value={config.agentchattr_url}
             onChange={(v) => updateGlobal("agentchattr_url", v)}
             placeholder="http://127.0.0.1:8300"
-          />
-          <Select
-            label="Default CLI Backend"
-            value={config.default_backend}
-            onChange={(v) => updateGlobal("default_backend", v)}
-            options={BACKENDS}
           />
           <Input
             label="QuadWork Port"

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 type StepStatus = "pending" | "active" | "done" | "error" | "skipped";
@@ -47,19 +47,6 @@ export default function SetupWizard() {
   const [reviewerUser, setReviewerUser] = useState("");
   const [reviewerTokenPath, setReviewerTokenPath] = useState("");
   const [loading, setLoading] = useState(false);
-
-  // Read default_backend from global config to initialize agent backends
-  useEffect(() => {
-    fetch("/api/config")
-      .then((r) => r.ok ? r.json() : null)
-      .then((cfg) => {
-        const defaultBackend = cfg?.default_backend;
-        if (defaultBackend && (defaultBackend === "claude" || defaultBackend === "codex")) {
-          setBackends({ head: defaultBackend, reviewer1: defaultBackend, reviewer2: defaultBackend, dev: defaultBackend });
-        }
-      })
-      .catch(() => {});
-  }, []);
 
   const updateStep = (idx: number, updates: Partial<Step>) => {
     setSteps((prev) => prev.map((s, i) => (i === idx ? { ...s, ...updates } : s)));


### PR DESCRIPTION
## Summary
- Removed "Default CLI backend" prompt from `npx quadwork init` — per-agent model selection belongs in web UI project setup
- Improved dashboard port prompt with clearer guidance text
- Removed `default_backend` from SettingsPage global config UI and SetupWizard config reading
- Init wizard is now clean 3 steps: prereqs → port → start server

Fixes #98

## Test plan
- [ ] `npx quadwork init` has no backend question — only prereqs, port, start
- [ ] Port prompt shows clear guidance text
- [ ] Settings page has no "Default CLI Backend" dropdown
- [ ] Web UI /setup still lets you pick per-agent backends during project creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)