### PR TITLE
[#97] Switch AgentChattr install from pip to pipx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Reference: [plotlink at `pre-design-overhaul`](https://github.com/realproject7/p
 
 ## Dependencies
 
-- AgentChattr: external dependency, installed separately (`pip install agentchattr`)
+- AgentChattr: external dependency, installed separately (`pipx install agentchattr`)
 - Telegram bridge: external (`realproject7/agentchattr-telegram`), optional
 - Shared memory: external (`realproject7/agent-memory`), optional
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Each agent runs in its own git worktree (sibling directories).
 Shared chat server for agent coordination. Install separately:
 
 ```bash
-pip install agentchattr
+pipx install agentchattr
 ```
 
 The setup wizard configures AgentChattr automatically. See [agentchattr](https://github.com/realproject7/agentchattr) for details.

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -185,10 +185,14 @@ function checkPrereqs() {
     else { fail(`${pyVer} — need 3.10+`); allOk = false; }
   } else { fail("Python 3 not found"); allOk = false; }
 
+  // pipx
+  if (which("pipx")) ok("pipx");
+  else warn("pipx not found — install: python3 -m pip install --user pipx && pipx ensurepath");
+
   // AgentChattr
   const acVer = run("agentchattr --version") || run("python3 -m agentchattr --version");
   if (acVer) { ok(`AgentChattr ${acVer}`); agentChattrFound = true; }
-  else { warn("AgentChattr not found — install: pip install agentchattr"); allOk = false; }
+  else { warn("AgentChattr not found — install: pipx install agentchattr"); allOk = false; }
 
   // gh CLI
   if (which("gh")) ok("GitHub CLI (gh)");
@@ -411,14 +415,14 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
   let acAvailable = which("agentchattr");
   if (!acAvailable && !skipInstall) {
     const acSpinner = spinner("Installing AgentChattr...");
-    const installResult = run("pip install agentchattr 2>&1");
+    const installResult = run("pipx install agentchattr 2>&1");
     if (installResult !== null) {
       acSpinner.stop(true);
       acAvailable = which("agentchattr");
       if (!acAvailable) warn("agentchattr binary not found in PATH after install");
     } else {
       acSpinner.stop(false);
-      warn("Install manually: pip install agentchattr");
+      warn("Install manually: pipx install agentchattr");
     }
   }
 

--- a/docs/PROPOSAL.md
+++ b/docs/PROPOSAL.md
@@ -254,7 +254,7 @@ Step 1/5: Prerequisites Check
   ✓ Node.js 20+ detected
   ✓ Python 3.10+ detected
   ✗ AgentChattr not found
-    → Installing AgentChattr... done (pip install agentchattr)
+    → Installing AgentChattr... done (pipx install agentchattr)
   ✓ GitHub CLI (gh) detected
   ✓ Claude Code detected
 


### PR DESCRIPTION
## Summary
- Updated all `pip install agentchattr` references to `pipx install agentchattr` across 4 files
- Added pipx to prereq check with install hint (`python3 -m pip install --user pipx && pipx ensurepath`)
- Wizard auto-install path now uses pipx
- Grep-clean: no remaining `pip install agentchattr` in source

Fixes #97

## Test plan
- [ ] `npx quadwork init` prereq check shows pipx status
- [ ] AgentChattr not-found message says `pipx install agentchattr`
- [ ] Auto-install attempts `pipx install agentchattr`
- [ ] README shows `pipx install agentchattr`
- [ ] No `pip install agentchattr` remaining in repo (except explicit fallback notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)