### PR TITLE
[#110] Fix chat 403 by syncing AgentChattr token after startup

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -100,4 +100,28 @@ function resolveProjectChattr(projectId) {
   };
 }
 
-module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, CONFIG_PATH };
+/**
+ * Fetch AgentChattr's real session token from its HTML and save to project config.
+ * AgentChattr generates its own token at startup; this syncs it back.
+ */
+async function syncChattrToken(projectId) {
+  const config = readConfig();
+  const project = config.projects?.find((p) => p.id === projectId);
+  if (!project) return;
+  const url = project.agentchattr_url || config.agentchattr_url || "http://127.0.0.1:8300";
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return;
+    const html = await res.text();
+    const match = html.match(/__SESSION_TOKEN__="([^"]+)"/);
+    if (match && match[1]) {
+      const realToken = match[1];
+      if (project.agentchattr_token !== realToken) {
+        project.agentchattr_token = realToken;
+        fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+      }
+    }
+  } catch {}
+}
+
+module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, syncChattrToken, CONFIG_PATH };

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ const fs = require("fs");
 const { WebSocketServer } = require("ws");
 const pty = require("node-pty");
 const { spawn } = require("child_process");
-const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr } = require("./config");
+const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, syncChattrToken } = require("./config");
 const routes = require("./routes");
 
 const config = readConfig();
@@ -167,6 +167,8 @@ function handleAgentChattr(req, res) {
     }
     try {
       const child = spawnChattr();
+      // Sync token after AgentChattr starts (it generates its own)
+      setTimeout(() => syncChattrToken(projectId), 2000);
       res.json({ ok: true, state: "running", pid: child.pid });
     } catch (err) {
       setProc({ process: null, state: "error", error: err.message });
@@ -188,6 +190,8 @@ function handleAgentChattr(req, res) {
     setTimeout(() => {
       try {
         const child = spawnChattr();
+        // Sync token after AgentChattr restarts
+        setTimeout(() => syncChattrToken(projectId), 2000);
         res.json({ ok: true, state: "running", pid: child.pid });
       } catch (err) {
         setProc({ process: null, state: "error", error: err.message });
@@ -531,4 +535,9 @@ function syncTriggersFromConfig() {
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`QuadWork server listening on http://127.0.0.1:${PORT}`);
   syncTriggersFromConfig();
+  // Sync AgentChattr tokens for all projects on startup
+  const startupCfg = readConfig();
+  for (const p of (startupCfg.projects || [])) {
+    syncChattrToken(p.id);
+  }
 });

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -119,25 +119,36 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const shouldAutoScroll = useRef(true);
+  const authRetryRef = useRef(0);
 
-  // Fetch channels via proxy
+  // Fetch channels via proxy (with 403 retry for token sync race)
   useEffect(() => {
-    fetch(`/api/chat?path=/api/channels${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`)
-      .then((r) => {
-        if (r.status === 403) {
-          setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
-          throw new Error("auth failed");
-        }
-        if (!r.ok) throw new Error("channels fetch failed");
-        return r.json();
-      })
-      .then((data) => {
-        setAuthError(null);
-        const list = Array.isArray(data) ? data : data.channels || [];
-        setChannels(list.map((c: string | { name: string }) => (typeof c === "string" ? c : c.name)));
-      })
-      .catch(() => setChannels(["general"]));
-  }, []);
+    const fetchChannels = () => {
+      fetch(`/api/chat?path=/api/channels${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`)
+        .then((r) => {
+          if (r.status === 403) {
+            if (authRetryRef.current < 3) {
+              authRetryRef.current++;
+              setTimeout(fetchChannels, 2000);
+              return;
+            }
+            setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
+            throw new Error("auth failed");
+          }
+          if (!r.ok) throw new Error("channels fetch failed");
+          return r.json();
+        })
+        .then((data) => {
+          if (!data) return;
+          setAuthError(null);
+          authRetryRef.current = 0;
+          const list = Array.isArray(data) ? data : data.channels || [];
+          setChannels(list.map((c: string | { name: string }) => (typeof c === "string" ? c : c.name)));
+        })
+        .catch(() => setChannels(["general"]));
+    };
+    fetchChannels();
+  }, [projectId]);
 
   // Reset cursor when channel changes
   useEffect(() => {
@@ -150,7 +161,9 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
     fetch(`/api/chat?path=/api/messages&channel=${encodeURIComponent(channel)}&cursor=${cursorRef.current}${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`)
       .then((r) => {
         if (r.status === 403) {
-          setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
+          // Token may still be syncing — clear error on next successful poll
+          if (authRetryRef.current < 3) setAuthError(null);
+          else setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
           throw new Error("auth failed");
         }
         if (!r.ok) throw new Error(`Poll failed: ${r.status}`);


### PR DESCRIPTION
## Summary
- AgentChattr generates its own session token at startup, ignoring the one written to `config.toml`
- Added `syncChattrToken()` in `server/config.js` that fetches the real token from AgentChattr's HTML (`__SESSION_TOKEN__`) and saves it to the project config
- Called after start/restart via lifecycle API (2s delay for AgentChattr startup)
- Also called on QuadWork server startup for all existing projects
- Token stays synced across restarts

Fixes #110

## Test plan
- [ ] Fresh project setup → chat panel loads messages (no 403)
- [ ] AgentChattr restart → token re-synced, chat still works
- [ ] QuadWork server restart → tokens synced for all projects on startup
- [ ] No 403 errors in browser console for chat API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)