### PR TITLE
[#111] Fix HEAD prefetch 404 with html extensions

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -398,7 +398,7 @@ app.use((req, res, next) => {
 
 const outDir = path.join(__dirname, "..", "out");
 if (fs.existsSync(outDir)) {
-  app.use(express.static(outDir, { redirect: false }));
+  app.use(express.static(outDir, { redirect: false, extensions: ["html"] }));
 }
 
 // SPA fallback: serve the correct pre-rendered HTML for dynamic routes.


### PR DESCRIPTION
## Summary
- Added `extensions: ['html']` to `express.static` options in `server/index.js`
- `/settings` now resolves to `settings.html`, `/setup` to `setup.html` — no `.html` extension needed
- Fixes HEAD prefetch 404s from browser link prefetching

Fixes #111

## Test plan
- [ ] `HEAD /settings` returns 200 (not 404)
- [ ] `HEAD /setup` returns 200 (not 404)
- [ ] `GET /settings` still works
- [ ] `GET /setup` still works
- [ ] No redirect loops with trailing-slash middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)