### PR TITLE
[#104] Add caffeinate sleep prevention toggle

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -882,6 +882,18 @@ function cmdStop() {
 
   if (stopPid("Server", "server.pid")) stopped++;
 
+  // Stop caffeinate if running (send stop to API before server dies, or kill by PID)
+  if (process.platform === "darwin") {
+    try {
+      const result = run("pgrep -f 'caffeinate -d -i -s'");
+      if (result) {
+        run(`kill ${result.split("\n")[0]}`);
+        ok("Stopped caffeinate (sleep prevention)");
+        stopped++;
+      }
+    } catch {}
+  }
+
   if (stopped === 0) warn("No running processes found");
   else ok(`Stopped ${stopped} process(es)`);
   log("");

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -882,12 +882,13 @@ function cmdStop() {
 
   if (stopPid("Server", "server.pid")) stopped++;
 
-  // Stop caffeinate if running (send stop to API before server dies, or kill by PID)
+  // Stop caffeinate via the running server's API (targets only QuadWork's instance)
   if (process.platform === "darwin") {
+    const cfg = readConfig();
+    const qwPort = cfg.port || 8400;
     try {
-      const result = run("pgrep -f 'caffeinate -d -i -s'");
-      if (result) {
-        run(`kill ${result.split("\n")[0]}`);
+      const result = run(`curl -s -X POST http://127.0.0.1:${qwPort}/api/caffeinate/stop 2>/dev/null`);
+      if (result && result.includes('"ok":true')) {
         ok("Stopped caffeinate (sleep prevention)");
         stopped++;
       }

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,50 @@ app.get("/api/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
+// --- Caffeinate (sleep prevention) ---
+
+let caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
+
+app.post("/api/caffeinate/start", (req, res) => {
+  if (process.platform !== "darwin") {
+    return res.status(400).json({ ok: false, error: "Sleep prevention is only available on macOS" });
+  }
+  // Kill existing if running
+  if (caffeinateProcess.process) {
+    try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
+  }
+  const duration = req.body?.duration || 0; // seconds, 0 = indefinite
+  const args = ["-d", "-i", "-s"];
+  if (duration > 0) args.push("-t", String(duration));
+  const child = spawn("caffeinate", args, { stdio: "ignore", detached: true });
+  child.unref();
+  child.on("exit", () => {
+    if (caffeinateProcess.process === child) {
+      caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
+    }
+  });
+  caffeinateProcess = { process: child, pid: child.pid, startedAt: Date.now(), duration: duration || null };
+  res.json({ ok: true, active: true, pid: child.pid, duration });
+});
+
+app.post("/api/caffeinate/stop", (_req, res) => {
+  if (caffeinateProcess.process) {
+    try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
+  }
+  caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
+  res.json({ ok: true, active: false });
+});
+
+app.get("/api/caffeinate/status", (_req, res) => {
+  const active = !!(caffeinateProcess.process && caffeinateProcess.pid);
+  let remaining = null;
+  if (active && caffeinateProcess.duration && caffeinateProcess.startedAt) {
+    const elapsed = Math.floor((Date.now() - caffeinateProcess.startedAt) / 1000);
+    remaining = Math.max(0, caffeinateProcess.duration - elapsed);
+  }
+  res.json({ active, pid: caffeinateProcess.pid, remaining, platform: process.platform });
+});
+
 // --- Unified agent sessions ---
 // Single map: key = "project/agent" → { projectId, agentId, term, ws, state, error }
 // PTY (term) is the source of truth for "running". WS is optional (attaches to view terminal).

--- a/src/components/CaffeinateWidget.tsx
+++ b/src/components/CaffeinateWidget.tsx
@@ -7,6 +7,7 @@ const PRESETS = [
   { label: "4 hours", seconds: 14400 },
   { label: "8 hours", seconds: 28800 },
   { label: "Until stopped", seconds: 0 },
+  { label: "Custom...", seconds: -1 },
 ];
 
 function formatTime(seconds: number): string {
@@ -21,6 +22,8 @@ export default function CaffeinateWidget() {
   const [remaining, setRemaining] = useState<number | null>(null);
   const [platform, setPlatform] = useState<string>("");
   const [showPresets, setShowPresets] = useState(false);
+  const [showCustom, setShowCustom] = useState(false);
+  const [customHours, setCustomHours] = useState("1");
 
   const poll = useCallback(() => {
     fetch("/api/caffeinate/status")
@@ -95,13 +98,34 @@ export default function CaffeinateWidget() {
           </p>
           {PRESETS.map((p) => (
             <button
-              key={p.seconds}
-              onClick={() => start(p.seconds)}
+              key={p.label}
+              onClick={() => {
+                if (p.seconds === -1) { setShowCustom(true); }
+                else start(p.seconds);
+              }}
               className="w-full text-left px-3 py-1.5 text-[11px] text-text hover:bg-[#1a1a1a] transition-colors"
             >
               {p.label}
             </button>
           ))}
+          {showCustom && (
+            <div className="flex items-center gap-1 px-3 py-1.5 border-t border-border">
+              <input
+                type="number"
+                min="1"
+                value={customHours}
+                onChange={(e) => setCustomHours(e.target.value)}
+                className="w-12 bg-transparent border border-border px-1 py-0.5 text-[11px] text-text outline-none focus:border-accent"
+              />
+              <span className="text-[10px] text-text-muted">hours</span>
+              <button
+                onClick={() => { const h = parseFloat(customHours); if (h > 0) start(Math.round(h * 3600)); }}
+                className="px-2 py-0.5 bg-accent text-bg text-[10px] font-semibold hover:bg-accent-dim transition-colors"
+              >
+                Start
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/CaffeinateWidget.tsx
+++ b/src/components/CaffeinateWidget.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const PRESETS = [
+  { label: "2 hours", seconds: 7200 },
+  { label: "4 hours", seconds: 14400 },
+  { label: "8 hours", seconds: 28800 },
+  { label: "Until stopped", seconds: 0 },
+];
+
+function formatTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+export default function CaffeinateWidget() {
+  const [active, setActive] = useState(false);
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const [platform, setPlatform] = useState<string>("");
+  const [showPresets, setShowPresets] = useState(false);
+
+  const poll = useCallback(() => {
+    fetch("/api/caffeinate/status")
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (!data) return;
+        setActive(data.active);
+        setRemaining(data.remaining);
+        setPlatform(data.platform);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    poll();
+    const interval = setInterval(poll, 5000);
+    return () => clearInterval(interval);
+  }, [poll]);
+
+  const start = (seconds: number) => {
+    fetch("/api/caffeinate/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ duration: seconds }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.ok) {
+          setActive(true);
+          setRemaining(seconds || null);
+        }
+      })
+      .catch(() => {});
+    setShowPresets(false);
+  };
+
+  const stop = () => {
+    fetch("/api/caffeinate/stop", { method: "POST" })
+      .then(() => {
+        setActive(false);
+        setRemaining(null);
+      })
+      .catch(() => {});
+  };
+
+  // Hide on non-macOS
+  if (platform && platform !== "darwin") return null;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => active ? stop() : setShowPresets(!showPresets)}
+        className={`flex items-center gap-1.5 px-2 py-1 text-[11px] border transition-colors ${
+          active
+            ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
+            : "border-border text-text-muted hover:text-text hover:border-accent"
+        }`}
+      >
+        <span>{active ? "Awake" : "Keep awake"}</span>
+        {active && remaining !== null && remaining > 0 && (
+          <span className="text-[10px] text-accent/70">{formatTime(remaining)}</span>
+        )}
+        {active && remaining === null && (
+          <span className="text-[10px] text-accent/70">on</span>
+        )}
+      </button>
+
+      {showPresets && !active && (
+        <div className="absolute top-full right-0 mt-1 border border-border bg-bg-surface z-20 min-w-[160px]">
+          <p className="px-3 py-1.5 text-[10px] text-[#ffcc00] border-b border-border">
+            Make sure your Mac is plugged in
+          </p>
+          {PRESETS.map((p) => (
+            <button
+              key={p.seconds}
+              onClick={() => start(p.seconds)}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-text hover:bg-[#1a1a1a] transition-colors"
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -7,6 +7,7 @@ import PanelHeader from "./PanelHeader";
 import ChatPanel from "./ChatPanel";
 import GitHubPanel from "./GitHubPanel";
 import TriggerWidget from "./TriggerWidget";
+import CaffeinateWidget from "./CaffeinateWidget";
 
 const MIN_SIZE = 150; // px
 const DIVIDER = 4; // px
@@ -160,7 +161,10 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
         <div className="flex-1 min-h-0">
           <ChatPanel projectId={projectId} />
         </div>
-        <TriggerWidget projectId={projectId} />
+        <div className="flex items-center gap-2 px-2 py-1 border-t border-border">
+          <TriggerWidget projectId={projectId} />
+          <CaffeinateWidget />
+        </div>
       </div>
 
       {/* Vertical divider — bottom segment */}


### PR DESCRIPTION
## Summary
- **Backend**: 3 new API endpoints (`/api/caffeinate/start`, `/stop`, `/status`) that manage a `caffeinate -d -i -s` child process with optional timed duration
- **Frontend**: CaffeinateWidget component with duration presets (2h, 4h, 8h, until stopped), countdown display, "plugged in" warning, hidden on non-macOS
- **Dashboard**: Widget integrated alongside TriggerWidget in chat panel footer
- **CLI**: `npx quadwork stop` now kills caffeinate via pgrep

Fixes #104

## Test plan
- [ ] Widget shows "Keep awake" button on macOS dashboard
- [ ] Clicking shows duration presets with "plugged in" warning
- [ ] Selecting a duration starts caffeinate (verify with `pgrep caffeinate`)
- [ ] Widget shows "Awake" with countdown when active
- [ ] Clicking "Awake" stops caffeinate
- [ ] `npx quadwork stop` kills caffeinate
- [ ] Widget hidden on non-macOS (check platform field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)