### PR TITLE
[#117] Fix HEAD prefetch 404 — extend SPA fallback

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -449,7 +449,7 @@ if (fs.existsSync(outDir)) {
 // Static export only generates templates for placeholder params (e.g. /project/_),
 // so we map real dynamic segments back to those template files.
 app.use((req, res, next) => {
-  if (req.method !== "GET" || req.path.startsWith("/api/")) {
+  if ((req.method !== "GET" && req.method !== "HEAD") || req.path.startsWith("/api/")) {
     return next();
   }
 


### PR DESCRIPTION
## Summary
- SPA fallback middleware only handled `GET` requests, causing `HEAD` prefetch requests to fall through and 404
- Extended the method check to allow both `GET` and `HEAD` through the fallback
- 1 file, 1-line change

Fixes #117

## Test plan
- [ ] `HEAD /settings` returns 200
- [ ] `HEAD /setup` returns 200
- [ ] `HEAD /project/quadwork` returns 200
- [ ] No prefetch 404 errors in browser console
- [ ] GET requests still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)