### PR TITLE
[#117] Fix HEAD prefetch 404 for static pages

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -441,6 +441,21 @@ app.use((req, res, next) => {
 });
 
 const outDir = path.join(__dirname, "..", "out");
+
+// HEAD requests: express.static extensions don't resolve when a same-name
+// directory exists (e.g. /settings dir shadows settings.html for HEAD).
+// Resolve extensionless HEAD requests to their .html file explicitly.
+app.use((req, res, next) => {
+  if (req.method !== "HEAD" || req.path.startsWith("/api/") || path.extname(req.path)) {
+    return next();
+  }
+  const htmlPath = path.join(outDir, req.path + ".html");
+  if (fs.existsSync(htmlPath)) {
+    return res.sendFile(htmlPath);
+  }
+  next();
+});
+
 if (fs.existsSync(outDir)) {
   app.use(express.static(outDir, { redirect: false, extensions: ["html"] }));
 }


### PR DESCRIPTION
## Summary
- Fix HEAD prefetch 404 caused by `express.static` `extensions: ['html']` not resolving when a same-name directory exists (e.g. `/settings` dir shadows `settings.html`)
- Add middleware before `express.static` that explicitly resolves extensionless HEAD requests to their `.html` file

Fixes #117
Fixes realproject7/agent-os#348

## Test plan
- [ ] `HEAD /settings` returns 200
- [ ] `HEAD /setup` returns 200
- [ ] `GET /settings` still works
- [ ] No 404 prefetch errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)