### PR TITLE
[#118] Fix React hydration #418 with app-shell fallback

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -452,19 +452,13 @@ app.use((req, res, next) => {
     return next();
   }
 
-  // Dynamic routes → serve their pre-rendered template (has the right JS chunks)
-  const dynamicRoutes = [
-    { pattern: /^\/project\/[^/]+\/memory\/?$/, template: "project/_/memory.html" },
-    { pattern: /^\/project\/[^/]+\/queue\/?$/, template: "project/_/queue.html" },
-    { pattern: /^\/project\/[^/]+\/?$/, template: "project/_.html" },
-  ];
-
-  for (const route of dynamicRoutes) {
-    if (route.pattern.test(req.path)) {
-      const templatePath = path.join(outDir, route.template);
-      if (fs.existsSync(templatePath)) {
-        return res.sendFile(templatePath);
-      }
+  // Dynamic routes → serve minimal app shell (no SSG payload = no hydration mismatch).
+  // The client-side router renders the correct page after mount.
+  const isDynamic = /^\/project\/[^/]+(\/memory|\/queue)?\/?$/.test(req.path);
+  if (isDynamic) {
+    const shellPath = path.join(outDir, "app-shell.html");
+    if (fs.existsSync(shellPath)) {
+      return res.sendFile(shellPath);
     }
   }
 


### PR DESCRIPTION
## Summary
- SPA fallback was serving pre-rendered SSG templates (`project/_.html`) for dynamic routes, causing hydration mismatch when client URL differs from SSG context `["", "project", "_"]`
- Switch to serving minimal `app-shell.html` for all dynamic `/project/*` routes — has layout/JS but no route-specific SSG payload
- Client-side router renders correct page after mount (all page clients already use `dynamic(() => ..., { ssr: false })`)

Fixes #118
Fixes realproject7/agent-os#347

## Test plan
- [ ] Zero React hydration errors in console on `/project/quadwork`
- [ ] Dashboard loads correctly at `/project/quadwork`
- [ ] Memory page loads at `/project/quadwork/memory`
- [ ] Queue page loads at `/project/quadwork/queue`
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)