### PR TITLE
[#132] Fix restart error handling and PID undefined

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -180,7 +180,20 @@ function handleAgentChattr(req, res) {
     chattrProcesses.set(projectId, val);
   }
 
+  function regenerateConfigToml() {
+    // If project has a config.toml, update the port to match current config
+    if (!projectConfigToml || !fs.existsSync(projectConfigToml)) return;
+    try {
+      let content = fs.readFileSync(projectConfigToml, "utf-8");
+      content = content.replace(/^port = \d+/m, `port = ${chattrPort}`);
+      fs.writeFileSync(projectConfigToml, content);
+    } catch {}
+  }
+
   function spawnChattr() {
+    // Sync config.toml port before starting
+    regenerateConfigToml();
+
     // Use project config.toml if available (isolated data dir + ports), otherwise fall back to --port
     const args = (projectConfigToml && fs.existsSync(projectConfigToml))
       ? ["--config", projectConfigToml]
@@ -190,6 +203,15 @@ function handleAgentChattr(req, res) {
       stdio: "ignore",
       detached: true,
     });
+
+    // If pid is undefined, spawn failed (binary not found)
+    if (!child.pid) {
+      setProc({ process: null, state: "error", error: "Failed to start AgentChattr — is it installed? Run: pipx install agentchattr" });
+      // Still register error handler to prevent unhandled error crash
+      child.on("error", () => {});
+      return null;
+    }
+
     child.unref();
     child.on("error", (err) => {
       setProc({ process: null, state: "error", error: err.message });
@@ -211,6 +233,10 @@ function handleAgentChattr(req, res) {
     }
     try {
       const child = spawnChattr();
+      if (!child) {
+        const errProc = getProc();
+        return res.status(500).json({ ok: false, state: "error", error: errProc.error || "Failed to start AgentChattr" });
+      }
       // Sync token after AgentChattr starts (it generates its own)
       setTimeout(() => syncChattrToken(projectId), 2000);
       res.json({ ok: true, state: "running", pid: child.pid });
@@ -234,6 +260,10 @@ function handleAgentChattr(req, res) {
     setTimeout(() => {
       try {
         const child = spawnChattr();
+        if (!child) {
+          const errProc = getProc();
+          return res.status(500).json({ ok: false, state: "error", error: errProc.error || "Failed to start AgentChattr" });
+        }
         // Sync token after AgentChattr restarts
         setTimeout(() => syncChattrToken(projectId), 2000);
         res.json({ ok: true, state: "running", pid: child.pid });

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -195,7 +195,11 @@ function ServerSection({ projectId }: { projectId: string }) {
         { method: "POST" }
       );
       const d = await r.json();
-      setFeedback(d.ok ? `Restarted (PID: ${d.pid})` : "Failed");
+      if (d.ok && d.pid) {
+        setFeedback(`Restarted (PID: ${d.pid})`);
+      } else {
+        setFeedback(d.error || "Failed to restart");
+      }
     } catch {
       setFeedback("Error");
     }


### PR DESCRIPTION
## Summary
- Detect missing `agentchattr` binary immediately by checking `child.pid` after spawn
- Return `{ ok: false, error: "..." }` instead of `{ ok: true, pid: undefined }` when spawn fails
- Regenerate `config.toml` port before each start/restart to keep port in sync
- Frontend shows descriptive error message instead of "Restarted (PID: undefined)"

## Test plan
- [ ] Restart with agentchattr not on PATH → shows clear error message
- [ ] Restart with agentchattr installed → shows PID correctly
- [ ] Port change in config propagates to config.toml on restart
- [ ] API returns `{ ok: false }` on spawn failure

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)