### PR TITLE
[#130] Add token type guidance to reviewer credentials

### DIFF
--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -591,13 +591,35 @@ export default function SetupWizard() {
                         </label>
                       </div>
                       {reviewerTokenMode === "paste" ? (
-                        <input
-                          value={reviewerTokenValue}
-                          onChange={(e) => setReviewerTokenValue(e.target.value)}
-                          placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
-                          type="password"
-                          className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
-                        />
+                        <>
+                          <input
+                            value={reviewerTokenValue}
+                            onChange={(e) => setReviewerTokenValue(e.target.value)}
+                            placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+                            type="password"
+                            className="w-full bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
+                          />
+                          <div className="mt-2 text-[10px] text-text-muted leading-relaxed">
+                            <p>Paste a GitHub <span className="text-text">Personal Access Token (classic)</span>.</p>
+                            <p className="mt-1">
+                              Create one at{" "}
+                              <a
+                                href="https://github.com/settings/tokens"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-accent hover:underline"
+                              >
+                                github.com/settings/tokens
+                              </a>
+                              {" "}&#8594; Generate new token (classic)
+                            </p>
+                            <p className="mt-1">
+                              Required permission: <span className="text-accent">repo</span> (Full control of private repositories)
+                              <br />
+                              <span className="text-text-muted">Needed for reading PRs, posting reviews, and approving/requesting changes</span>
+                            </p>
+                          </div>
+                        </>
                       ) : (
                         <>
                           <input


### PR DESCRIPTION
## Summary
- Show help text below token paste input in setup wizard
- Specifies classic PAT type (not fine-grained — has per-repo scoping issues with PR reviews)
- Lists required `repo` permission with brief explanation
- Clickable link to github.com/settings/tokens
- Text is concise and scannable

## Test plan
- [ ] Help text visible when "Paste token" radio is selected
- [ ] Specifies classic token type
- [ ] Lists `repo` permission with brief explanation
- [ ] Link to github.com/settings/tokens is clickable
- [ ] Text disappears when switching to "Use existing file" mode

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)