### PR TITLE
[#139] Single-CLI mode — support Claude-only or Codex-only setups

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -251,28 +251,52 @@ async function setupGitHub(rl) {
 async function setupAgents(rl, repo) {
   header("Step 3: Agent Configuration");
 
-  // Prompt for CLI backend
+  // Detect available CLIs
   const hasClaude = which("claude");
   const hasCodex = which("codex");
+  const bothAvailable = hasClaude && hasCodex;
+  const onlyOneCli = (hasClaude && !hasCodex) || (!hasClaude && hasCodex);
   let defaultBackend = hasClaude ? "claude" : "codex";
-  log("Choose which AI CLI to run in agent terminals. Claude Code (`claude`) or OpenAI Codex (`codex`).");
-  const backend = await ask(rl, "Default CLI backend (claude/codex)", defaultBackend);
-  if (backend !== "claude" && backend !== "codex") {
-    fail("Backend must be 'claude' or 'codex'");
+
+  const backends = {};
+
+  if (onlyOneCli) {
+    // Single-CLI mode: default all agents, no prompt needed
+    const cliName = hasClaude ? "Claude Code" : "Codex CLI";
+    const otherName = hasClaude ? "Codex CLI" : "Claude Code";
+    const installCmd = hasClaude ? "npm install -g codex" : "npm install -g @anthropic-ai/claude-code";
+    ok(`${cliName} detected — all 4 agents will use ${cliName}.`);
+    console.log("");
+    log(`Tip: Installing ${otherName} too gives your team different AI perspectives,`);
+    log(`which can improve code review quality. You can add it anytime:`);
+    log(`  → ${installCmd}`);
+    console.log("");
+    for (const agent of AGENTS) backends[agent] = defaultBackend;
+  } else if (bothAvailable) {
+    log("Both Claude Code and Codex CLI are available.");
+    log("Choose which AI CLI to run in agent terminals.");
+    const backend = await ask(rl, "Default CLI backend (claude/codex)", defaultBackend);
+    if (backend !== "claude" && backend !== "codex") {
+      fail("Backend must be 'claude' or 'codex'");
+      return null;
+    }
+    defaultBackend = backend;
+
+    // Per-agent backend selection
+    const customPerAgent = await askYN(rl, "Use same backend for all agents?", true);
+    if (customPerAgent) {
+      for (const agent of AGENTS) backends[agent] = backend;
+    } else {
+      for (const agent of AGENTS) {
+        const agentBackend = await ask(rl, `${agent.toUpperCase()} backend (claude/codex)`, backend);
+        backends[agent] = (agentBackend === "claude" || agentBackend === "codex") ? agentBackend : backend;
+      }
+    }
+  } else {
+    fail("No AI CLI found — install Claude Code or Codex CLI first.");
     return null;
   }
-
-  // Per-agent backend selection
-  const backends = {};
-  const customPerAgent = await askYN(rl, "Use same backend for all agents?", true);
-  if (customPerAgent) {
-    for (const agent of AGENTS) backends[agent] = backend;
-  } else {
-    for (const agent of AGENTS) {
-      const agentBackend = await ask(rl, `${agent.toUpperCase()} backend (claude/codex)`, backend);
-      backends[agent] = (agentBackend === "claude" || agentBackend === "codex") ? agentBackend : backend;
-    }
-  }
+  const backend = defaultBackend;
 
   log("Path to your local clone of the repo. Four worktrees will be created next to it");
   log("(e.g., project-head/, project-reviewer1/, project-reviewer2/, project-dev/).");

--- a/server/index.js
+++ b/server/index.js
@@ -26,6 +26,26 @@ app.get("/api/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
+// --- CLI status detection ---
+
+const { execSync } = require("child_process");
+
+function isCliInstalled(cmd) {
+  try {
+    execSync(`which ${cmd}`, { encoding: "utf-8", stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+app.get("/api/cli-status", (_req, res) => {
+  res.json({
+    claude: isCliInstalled("claude"),
+    codex: isCliInstalled("codex"),
+  });
+});
+
 // --- Port availability check ---
 
 function checkPort(port) {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -221,12 +221,22 @@ export default function SettingsPage() {
   const addProject = () => {
     if (!config) return;
     const id = `project-${Date.now()}`;
+    // Use CLI-status-aware defaults: if only one CLI installed, use it for all agents
+    const defaultCmd = cliStatus
+      ? (cliStatus.claude && !cliStatus.codex ? "claude"
+        : !cliStatus.claude && cliStatus.codex ? "codex"
+        : "claude")
+      : "claude";
+    const agents: Record<string, AgentConfig> = {};
+    for (const [key, val] of Object.entries(DEFAULT_AGENTS)) {
+      agents[key] = { ...val, command: defaultCmd };
+    }
     const newProject: ProjectConfig = {
       id,
       name: "New Project",
       repo: "owner/repo",
       working_dir: "",
-      agents: { ...DEFAULT_AGENTS },
+      agents,
     };
     setConfig({ ...config, projects: [...config.projects, newProject] });
     setExpanded({ ...expanded, [id]: true });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -107,6 +107,7 @@ export default function SettingsPage() {
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [autoAdded, setAutoAdded] = useState(false);
   const [daemonStatus, setDaemonStatus] = useState<Record<string, boolean>>({});
+  const [cliStatus, setCliStatus] = useState<{ claude: boolean; codex: boolean } | null>(null);
 
   const load = useCallback(() => {
     fetch("/api/config")
@@ -124,6 +125,14 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => { load(); }, [load]);
+
+  // Fetch CLI status
+  useEffect(() => {
+    fetch("/api/cli-status")
+      .then((r) => r.json())
+      .then((status) => setCliStatus(status))
+      .catch(() => {});
+  }, []);
 
   // Poll telegram daemon status for each project
   useEffect(() => {
@@ -386,6 +395,19 @@ export default function SettingsPage() {
                   {/* Agents table */}
                   <div className="mt-4">
                     <h3 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Agents</h3>
+                    {cliStatus && (cliStatus.claude ? !cliStatus.codex : cliStatus.codex) && (
+                      <div className="border border-accent/20 bg-accent/5 p-2 mb-2 text-[10px]">
+                        <span className="text-text">
+                          {cliStatus.claude ? "Only Claude Code" : "Only Codex CLI"} is installed.
+                        </span>
+                        <span className="text-text-muted ml-1">
+                          Install {cliStatus.claude ? "Codex" : "Claude Code"} for more backend options:
+                        </span>
+                        <code className="text-accent ml-1">
+                          {cliStatus.claude ? "npm install -g codex" : "npm install -g @anthropic-ai/claude-code"}
+                        </code>
+                      </div>
+                    )}
                     <div className="border border-border">
                       <div className="grid grid-cols-5 gap-0 px-2 py-1 border-b border-border text-[10px] text-text-muted uppercase">
                         <span>Name</span>
@@ -411,9 +433,19 @@ export default function SettingsPage() {
                               value={agent.command || "claude"}
                               onChange={(e) => updateAgent(idx, agentId, { command: e.target.value })}
                               className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"
+                              title={cliStatus && Object.values(cliStatus).filter(Boolean).length === 1
+                                ? `Only one CLI installed — install the other for more options`
+                                : undefined}
                             >
                               {BACKENDS.map((b) => (
-                                <option key={b.value} value={b.value} className="bg-bg-surface">{b.label}</option>
+                                <option
+                                  key={b.value}
+                                  value={b.value}
+                                  className="bg-bg-surface"
+                                  disabled={cliStatus ? !cliStatus[b.value as keyof typeof cliStatus] : false}
+                                >
+                                  {b.label}{cliStatus && !cliStatus[b.value as keyof typeof cliStatus] ? " (not installed)" : ""}
+                                </option>
                               ))}
                             </select>
                             <select

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -165,6 +165,27 @@ export default function SetupWizard() {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [customPorts, setCustomPorts] = useState({ chattr: 0, mcpHttp: 0, mcpSse: 0 });
   const [autoDetectedPorts, setAutoDetectedPorts] = useState({ chattr: 0, mcpHttp: 0, mcpSse: 0 });
+  const [cliStatus, setCliStatus] = useState<{ claude: boolean; codex: boolean } | null>(null);
+
+  // Fetch CLI status on mount
+  useEffect(() => {
+    fetch("/api/cli-status")
+      .then((r) => r.json())
+      .then((status: { claude: boolean; codex: boolean }) => {
+        setCliStatus(status);
+        // Default all agents to the available CLI when only one is installed
+        const availableCli = status.claude && !status.codex ? "claude"
+          : !status.claude && status.codex ? "codex"
+          : null;
+        if (availableCli) {
+          setBackends({ head: availableCli, reviewer1: availableCli, reviewer2: availableCli, dev: availableCli });
+        } else if (status.claude && status.codex) {
+          // Both available — use mixed defaults for review diversity
+          setBackends({ head: "codex", dev: "claude", reviewer1: "codex", reviewer2: "claude" });
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   // Fetch GitHub user on mount
   useEffect(() => {
@@ -575,6 +596,31 @@ export default function SetupWizard() {
                 <p className="text-[11px] text-text-muted mb-4">
                   Each agent runs its own CLI instance. Pick the backend for each role.
                 </p>
+
+                {/* Single-CLI friendly message */}
+                {cliStatus && !cliStatus.claude && cliStatus.codex && (
+                  <div className="border border-accent/20 bg-accent/5 p-3 mb-4 text-[11px]">
+                    <p className="text-text">You have Codex CLI installed — great! All 4 agents will use Codex.</p>
+                    <p className="text-text-muted mt-1.5">
+                      Tip: Installing Claude Code too gives your team different AI perspectives,
+                      which can improve code review quality. You can add it anytime:
+                    </p>
+                    <p className="text-accent mt-1 font-mono text-[10px]">npm install -g @anthropic-ai/claude-code</p>
+                    <p className="text-text-muted mt-1.5">For now, Codex CLI handles everything perfectly. Let&apos;s continue!</p>
+                  </div>
+                )}
+                {cliStatus && cliStatus.claude && !cliStatus.codex && (
+                  <div className="border border-accent/20 bg-accent/5 p-3 mb-4 text-[11px]">
+                    <p className="text-text">You have Claude Code installed — great! All 4 agents will use Claude.</p>
+                    <p className="text-text-muted mt-1.5">
+                      Tip: Installing Codex CLI too gives your team different AI perspectives,
+                      which can improve code review quality. You can add it anytime:
+                    </p>
+                    <p className="text-accent mt-1 font-mono text-[10px]">npm install -g codex</p>
+                    <p className="text-text-muted mt-1.5">For now, Claude Code handles everything perfectly. Let&apos;s continue!</p>
+                  </div>
+                )}
+
                 <div className="border border-border mb-4">
                   {AGENTS.map((agent) => (
                     <div key={agent.key} className="flex items-center justify-between px-3 py-2 border-b border-border/50 last:border-b-0">
@@ -587,7 +633,16 @@ export default function SetupWizard() {
                         onChange={(e) => setBackends({ ...backends, [agent.key]: e.target.value })}
                         className="bg-transparent border border-border px-2 py-0.5 text-[11px] text-text outline-none focus:border-accent cursor-pointer ml-3"
                       >
-                        {BACKENDS.map((b) => <option key={b.value} value={b.value} className="bg-bg-surface">{b.label}</option>)}
+                        {BACKENDS.map((b) => (
+                          <option
+                            key={b.value}
+                            value={b.value}
+                            className="bg-bg-surface"
+                            disabled={cliStatus ? !cliStatus[b.value as keyof typeof cliStatus] : false}
+                          >
+                            {b.label}{cliStatus && !cliStatus[b.value as keyof typeof cliStatus] ? " (not installed)" : ""}
+                          </option>
+                        ))}
                       </select>
                     </div>
                   ))}


### PR DESCRIPTION
## Summary
Fixes #139

- Adds `GET /api/cli-status` endpoint returning `{ claude: boolean, codex: boolean }`
- SetupWizard fetches CLI status on mount, defaults all agents to available CLI when only one installed
- Both CLIs installed: mixed defaults (head=codex, dev=claude, etc.) for review diversity
- Uninstalled CLI options shown as disabled in dropdowns with "(not installed)" suffix
- Friendly info banners in SetupWizard explain single-CLI is fine, with tip to install the other
- SettingsPage shows same disabled options with install command guidance
- CLI wizard (`bin/quadwork.js`) auto-detects single-CLI and skips backend choice prompt

## Test plan
- [ ] With only Claude installed: all agents default to Claude, Codex disabled in dropdowns
- [ ] With only Codex installed: all agents default to Codex, Claude disabled in dropdowns
- [ ] With both installed: mixed defaults, all options selectable
- [ ] `/api/cli-status` returns correct detection
- [ ] CLI wizard skips backend prompt in single-CLI mode
- [ ] Settings page shows install guidance for missing CLI
- [ ] No blocker — user can always proceed with one CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)