### PR TITLE
[#350] Fix AgentChattr install flow — replace pipx with clone+venv

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Reference: [plotlink at `pre-design-overhaul`](https://github.com/realproject7/p
 
 ## Dependencies
 
-- AgentChattr: external dependency, installed separately (`pipx install agentchattr`)
+- AgentChattr: external dependency, cloned to `~/.quadwork/agentchattr` and run via `.venv/bin/python run.py`
 - Telegram bridge: external (`realproject7/agentchattr-telegram`), optional
 - Shared memory: external (`realproject7/agent-memory`), optional
 

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -93,11 +93,19 @@ function installAgentChattr(dir) {
   // Clone if not already present
   if (!fs.existsSync(path.join(dir, "run.py"))) {
     if (fs.existsSync(dir)) {
-      // Directory exists but no run.py — only clean up if it looks like a failed clone
-      const hasGitDir = fs.existsSync(path.join(dir, ".git"));
+      // Directory exists but no run.py — only clean up if positively identified
       const isEmpty = fs.readdirSync(dir).length === 0;
-      if (hasGitDir || isEmpty) {
+      if (isEmpty) {
         try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+      } else if (fs.existsSync(path.join(dir, ".git"))) {
+        // Verify this is actually an AgentChattr repo by checking the remote
+        const remote = run(`git -C "${dir}" remote get-url origin 2>/dev/null`);
+        if (remote && remote.includes("agentchattr")) {
+          try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+        } else {
+          // Git repo but not AgentChattr — refuse to overwrite
+          return null;
+        }
       } else {
         // Non-empty, non-git directory — refuse to overwrite
         return null;

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -66,28 +66,41 @@ function which(cmd) {
 }
 
 /**
- * Check if AgentChattr is installed in a cloned directory.
- * Returns the directory path if run.py exists, or null.
+ * Resolve the agentchattr_dir from config, falling back to DEFAULT_AGENTCHATTR_DIR.
+ */
+function getAgentChattrDir() {
+  const config = readConfig();
+  return config.agentchattr_dir || DEFAULT_AGENTCHATTR_DIR;
+}
+
+/**
+ * Check if AgentChattr is fully installed (cloned + venv ready).
+ * Returns the directory path if both run.py and .venv/bin/python exist, or null.
  */
 function findAgentChattr(dir) {
-  dir = dir || DEFAULT_AGENTCHATTR_DIR;
-  if (fs.existsSync(path.join(dir, "run.py"))) return dir;
+  dir = dir || getAgentChattrDir();
+  if (fs.existsSync(path.join(dir, "run.py")) && fs.existsSync(path.join(dir, ".venv", "bin", "python"))) return dir;
   return null;
 }
 
 /**
  * Clone AgentChattr and set up its venv. Idempotent — safe to re-run.
+ * Handles partial clones by removing and re-cloning.
  * Returns the directory path on success, null on failure.
  */
 function installAgentChattr(dir) {
-  dir = dir || DEFAULT_AGENTCHATTR_DIR;
-  // Clone if not already present
+  dir = dir || getAgentChattrDir();
+  // Clone if not already present or recover from partial clone
   if (!fs.existsSync(path.join(dir, "run.py"))) {
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    if (fs.existsSync(dir)) {
+      // Partial clone — clean up and re-clone
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+    fs.mkdirSync(path.dirname(dir), { recursive: true });
     const cloneResult = run(`git clone "${AGENTCHATTR_REPO}" "${dir}" 2>&1`, { timeout: 60000 });
     if (cloneResult === null || !fs.existsSync(path.join(dir, "run.py"))) return null;
   }
-  // Create venv and install deps if needed
+  // Create venv and install deps (always ensure venv is ready)
   const venvPython = path.join(dir, ".venv", "bin", "python");
   if (!fs.existsSync(venvPython)) {
     const venvResult = run(`python3 -m venv "${path.join(dir, ".venv")}" 2>&1`, { timeout: 60000 });
@@ -103,14 +116,14 @@ function installAgentChattr(dir) {
 
 /**
  * Get spawn args for launching AgentChattr from its cloned directory.
- * Returns { command, spawnArgs, cwd } or null if not installed.
+ * Returns { command, spawnArgs, cwd } or null if not fully installed.
+ * Requires .venv/bin/python — never falls back to bare python3.
  */
 function chattrSpawnArgs(dir, extraArgs) {
-  dir = dir || DEFAULT_AGENTCHATTR_DIR;
-  if (!fs.existsSync(path.join(dir, "run.py"))) return null;
+  dir = dir || getAgentChattrDir();
   const venvPython = path.join(dir, ".venv", "bin", "python");
-  const command = fs.existsSync(venvPython) ? venvPython : "python3";
-  return { command, spawnArgs: ["run.py", ...(extraArgs || [])], cwd: dir };
+  if (!fs.existsSync(path.join(dir, "run.py")) || !fs.existsSync(venvPython)) return null;
+  return { command: venvPython, spawnArgs: ["run.py", ...(extraArgs || [])], cwd: dir };
 }
 
 function ask(rl, question, defaultVal) {

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -12,6 +12,8 @@ const CONFIG_DIR = path.join(os.homedir(), ".quadwork");
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 const TEMPLATES_DIR = path.join(__dirname, "..", "templates");
 const AGENTS = ["head", "reviewer1", "reviewer2", "dev"];
+const DEFAULT_AGENTCHATTR_DIR = path.join(CONFIG_DIR, "agentchattr");
+const AGENTCHATTR_REPO = "https://github.com/bcurts/agentchattr.git";
 
 // ─── ANSI Helpers ──────────────────────────────────────────────────────────
 
@@ -61,6 +63,54 @@ function run(cmd, opts = {}) {
 
 function which(cmd) {
   return run(`which ${cmd}`) !== null;
+}
+
+/**
+ * Check if AgentChattr is installed in a cloned directory.
+ * Returns the directory path if run.py exists, or null.
+ */
+function findAgentChattr(dir) {
+  dir = dir || DEFAULT_AGENTCHATTR_DIR;
+  if (fs.existsSync(path.join(dir, "run.py"))) return dir;
+  return null;
+}
+
+/**
+ * Clone AgentChattr and set up its venv. Idempotent — safe to re-run.
+ * Returns the directory path on success, null on failure.
+ */
+function installAgentChattr(dir) {
+  dir = dir || DEFAULT_AGENTCHATTR_DIR;
+  // Clone if not already present
+  if (!fs.existsSync(path.join(dir, "run.py"))) {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const cloneResult = run(`git clone "${AGENTCHATTR_REPO}" "${dir}" 2>&1`, { timeout: 60000 });
+    if (cloneResult === null || !fs.existsSync(path.join(dir, "run.py"))) return null;
+  }
+  // Create venv and install deps if needed
+  const venvPython = path.join(dir, ".venv", "bin", "python");
+  if (!fs.existsSync(venvPython)) {
+    const venvResult = run(`python3 -m venv "${path.join(dir, ".venv")}" 2>&1`, { timeout: 60000 });
+    if (venvResult === null) return null;
+  }
+  const reqFile = path.join(dir, "requirements.txt");
+  if (fs.existsSync(reqFile)) {
+    const pipResult = run(`"${venvPython}" -m pip install -r "${reqFile}" 2>&1`, { timeout: 120000 });
+    if (pipResult === null) return null;
+  }
+  return dir;
+}
+
+/**
+ * Get spawn args for launching AgentChattr from its cloned directory.
+ * Returns { command, spawnArgs, cwd } or null if not installed.
+ */
+function chattrSpawnArgs(dir, extraArgs) {
+  dir = dir || DEFAULT_AGENTCHATTR_DIR;
+  if (!fs.existsSync(path.join(dir, "run.py"))) return null;
+  const venvPython = path.join(dir, ".venv", "bin", "python");
+  const command = fs.existsSync(venvPython) ? venvPython : "python3";
+  return { command, spawnArgs: ["run.py", ...(extraArgs || [])], cwd: dir };
 }
 
 function ask(rl, question, defaultVal) {
@@ -151,7 +201,7 @@ function readConfig() {
     const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
     return migrateAgentKeys(config);
   } catch {
-    return { port: 8400, agentchattr_url: "http://127.0.0.1:8300", projects: [] };
+    return { port: 8400, agentchattr_url: "http://127.0.0.1:8300", agentchattr_dir: DEFAULT_AGENTCHATTR_DIR, projects: [] };
   }
 }
 
@@ -207,7 +257,6 @@ async function checkPrereqs(rl) {
   const platform = detectPlatform();
   let allOk = true;
   let hasPython = false;
-  let hasPipx = false;
 
   // ── 1. Node.js 20+ (must already exist — user ran npx) ──
   const nodeVer = run("node --version");
@@ -257,83 +306,43 @@ async function checkPrereqs(rl) {
   }
 
   if (!hasPython) {
-    // Can't continue with pipx/AgentChattr without Python
+    // Can't continue with AgentChattr without Python
     console.log("");
     fail("Python is required before we can set up the remaining tools.");
     log("Install Python first, then re-run: npx quadwork init");
     return false;
   }
 
-  // ── 3. pipx (needs Python) ──
-  if (which("pipx")) {
-    ok("pipx");
-    hasPipx = true;
-  } else {
-    console.log("");
-    warn("pipx is needed to install AgentChattr safely.");
-    log("(pipx keeps Python tools isolated so they don't conflict with your system)");
-    const installed = await tryInstall(rl, "pipx", "We can install it automatically.",
-      "python3 -m pip install --user pipx && python3 -m pipx ensurepath");
-    if (installed) {
-      // Add common pipx binary paths to current session PATH so we don't need a terminal restart
-      const home = os.homedir();
-      const extraPaths = [
-        path.join(home, ".local", "bin"),
-        path.join(home, "Library", "Python", "3.14", "bin"),
-        path.join(home, "Library", "Python", "3.13", "bin"),
-        path.join(home, "Library", "Python", "3.12", "bin"),
-        path.join(home, "Library", "Python", "3.11", "bin"),
-        path.join(home, "Library", "Python", "3.10", "bin"),
-      ];
-      for (const p of extraPaths) {
-        if (fs.existsSync(p) && !process.env.PATH.includes(p)) {
-          process.env.PATH = p + ":" + process.env.PATH;
-        }
-      }
-      if (which("pipx")) {
-        ok("pipx installed");
-        hasPipx = true;
-      } else {
-        // Still not in PATH — use python3 -m pipx as fallback
-        ok("pipx installed (using python3 -m pipx)");
-        hasPipx = true;
-      }
-    } else {
-      warn("pipx skipped — you can install it later:");
-      log("  → python3 -m pip install --user pipx && pipx ensurepath");
-    }
-  }
-
-  // ── 4. AgentChattr (needs pipx) ──
-  const pipxCmd = which("pipx") ? "pipx" : "python3 -m pipx";
-  const acVer = run("agentchattr --version") || run("python3 -m agentchattr --version");
-  if (acVer) {
-    ok(`AgentChattr ${acVer}`);
+  // ── 3. AgentChattr (clone + venv — needs Python and git) ──
+  const acDir = findAgentChattr();
+  if (acDir) {
+    ok(`AgentChattr (${acDir})`);
     agentChattrFound = true;
-  } else if (hasPipx) {
+  } else if (hasPython) {
     console.log("");
     warn("AgentChattr lets your AI agents communicate with each other.");
-    const installed = await tryInstall(rl, "AgentChattr",
-      "We can install it now using pipx.", `${pipxCmd} install agentchattr`);
-    if (installed) {
-      // Re-scan PATH for newly installed agentchattr binary
-      const home = os.homedir();
-      const acBinDir = path.join(home, ".local", "bin");
-      if (fs.existsSync(acBinDir) && !process.env.PATH.includes(acBinDir)) {
-        process.env.PATH = acBinDir + ":" + process.env.PATH;
+    log("It will be cloned and set up in a virtualenv.");
+    const doInstall = await askYN(rl, "Install AgentChattr now?", true);
+    if (doInstall) {
+      const acSpinner = spinner("Cloning and setting up AgentChattr...");
+      const result = installAgentChattr();
+      acSpinner.stop(result !== null);
+      if (result) {
+        ok(`AgentChattr installed (${DEFAULT_AGENTCHATTR_DIR})`);
+        agentChattrFound = true;
+      } else {
+        warn("AgentChattr install failed. You can set it up manually:");
+        log(`  → git clone ${AGENTCHATTR_REPO} ${DEFAULT_AGENTCHATTR_DIR}`);
+        log(`  → cd ${DEFAULT_AGENTCHATTR_DIR} && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt`);
+        allOk = false;
       }
-    }
-    const acVerAfter = run("agentchattr --version") || run("python3 -m agentchattr --version");
-    if (acVerAfter) {
-      ok(`AgentChattr ${acVerAfter} installed`);
-      agentChattrFound = true;
     } else {
-      warn("AgentChattr not available — agents won't be able to chat until it's installed.");
-      log(`  → Install later: ${pipxCmd} install agentchattr`);
+      warn("AgentChattr skipped — agents won't be able to chat until it's installed.");
+      log(`  → Install later: git clone ${AGENTCHATTR_REPO} ${DEFAULT_AGENTCHATTR_DIR}`);
       allOk = false;
     }
   } else {
-    warn("AgentChattr not found — install pipx first, then: pipx install agentchattr");
+    warn("AgentChattr requires Python — install Python first, then re-run init.");
     allOk = false;
   }
 
@@ -706,42 +715,48 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
   ok(`Wrote ${configTomlPath}`);
 
   // Start AgentChattr if available; optionally skip install attempt
-  let acAvailable = which("agentchattr");
+  const acDir = findAgentChattr();
+  let acAvailable = !!acDir;
   if (!acAvailable && !skipInstall) {
-    const acSpinner = spinner("Installing AgentChattr...");
-    const installResult = run("pipx install agentchattr 2>&1");
-    if (installResult !== null) {
+    const acSpinner = spinner("Setting up AgentChattr...");
+    const installResult = installAgentChattr();
+    if (installResult) {
       acSpinner.stop(true);
-      acAvailable = which("agentchattr");
-      if (!acAvailable) warn("agentchattr binary not found in PATH after install");
+      acAvailable = true;
     } else {
       acSpinner.stop(false);
-      warn("Install manually: pipx install agentchattr");
+      warn(`Install manually: git clone ${AGENTCHATTR_REPO} ${DEFAULT_AGENTCHATTR_DIR}`);
     }
   }
 
   // Start AgentChattr server (only if installed)
   if (acAvailable) {
     log("Starting AgentChattr server...");
-    const acProc = spawn("agentchattr", ["--config", configTomlPath], {
-      stdio: "ignore",
-      detached: true,
-    });
-    acProc.on("error", (err) => {
-      warn(`AgentChattr failed to start: ${err.message}`);
-    });
-    acProc.unref();
-    if (acProc.pid) {
-      ok(`AgentChattr started (PID: ${acProc.pid})`);
-      // Per-project PID file
-      if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true });
-      const pidFile = path.join(CONFIG_DIR, `agentchattr-${setup.projectName}.pid`);
-      fs.writeFileSync(pidFile, String(acProc.pid));
+    const acSpawn = chattrSpawnArgs(findAgentChattr(), ["--config", configTomlPath]);
+    if (acSpawn) {
+      const acProc = spawn(acSpawn.command, acSpawn.spawnArgs, {
+        cwd: acSpawn.cwd,
+        stdio: "ignore",
+        detached: true,
+      });
+      acProc.on("error", (err) => {
+        warn(`AgentChattr failed to start: ${err.message}`);
+      });
+      acProc.unref();
+      if (acProc.pid) {
+        ok(`AgentChattr started (PID: ${acProc.pid})`);
+        if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true });
+        const pidFile = path.join(CONFIG_DIR, `agentchattr-${setup.projectName}.pid`);
+        fs.writeFileSync(pidFile, String(acProc.pid));
+      } else {
+        warn("Could not start AgentChattr — check logs in " + (findAgentChattr() || DEFAULT_AGENTCHATTR_DIR));
+      }
     } else {
-      warn("Could not start AgentChattr — start manually: agentchattr --config " + configTomlPath);
+      warn("AgentChattr run.py not found — skipping auto-start.");
     }
   } else {
-    warn("AgentChattr not installed — skipping auto-start. Start manually later: agentchattr --config " + configTomlPath);
+    warn("AgentChattr not installed — skipping auto-start.");
+    log(`  → Install: git clone ${AGENTCHATTR_REPO} ${DEFAULT_AGENTCHATTR_DIR}`);
   }
 
   return configTomlPath;
@@ -1115,12 +1130,16 @@ function cmdStart() {
   fs.writeFileSync(pidFile, String(server.pid));
 
   // Start AgentChattr for each project that has a config.toml
-  if (which("agentchattr")) {
+  const acDir = findAgentChattr(config.agentchattr_dir);
+  if (acDir) {
     for (const project of config.projects) {
       if (!project.working_dir) continue;
       const configToml = path.join(project.working_dir, "agentchattr", "config.toml");
       if (!fs.existsSync(configToml)) continue;
-      const acProc = spawn("agentchattr", ["--config", configToml], {
+      const acSpawn = chattrSpawnArgs(acDir, ["--config", configToml]);
+      if (!acSpawn) continue;
+      const acProc = spawn(acSpawn.command, acSpawn.spawnArgs, {
+        cwd: acSpawn.cwd,
         stdio: "ignore",
         detached: true,
       });

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -85,16 +85,23 @@ function findAgentChattr(dir) {
 
 /**
  * Clone AgentChattr and set up its venv. Idempotent — safe to re-run.
- * Handles partial clones by removing and re-cloning.
+ * Only removes existing directories that are identifiable as failed AgentChattr clones.
  * Returns the directory path on success, null on failure.
  */
 function installAgentChattr(dir) {
   dir = dir || getAgentChattrDir();
-  // Clone if not already present or recover from partial clone
+  // Clone if not already present
   if (!fs.existsSync(path.join(dir, "run.py"))) {
     if (fs.existsSync(dir)) {
-      // Partial clone — clean up and re-clone
-      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+      // Directory exists but no run.py — only clean up if it looks like a failed clone
+      const hasGitDir = fs.existsSync(path.join(dir, ".git"));
+      const isEmpty = fs.readdirSync(dir).length === 0;
+      if (hasGitDir || isEmpty) {
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+      } else {
+        // Non-empty, non-git directory — refuse to overwrite
+        return null;
+      }
     }
     fs.mkdirSync(path.dirname(dir), { recursive: true });
     const cloneResult = run(`git clone "${AGENTCHATTR_REPO}" "${dir}" 2>&1`, { timeout: 60000 });

--- a/docs/PROPOSAL.md
+++ b/docs/PROPOSAL.md
@@ -254,7 +254,7 @@ Step 1/5: Prerequisites Check
   ✓ Node.js 20+ detected
   ✓ Python 3.10+ detected
   ✗ AgentChattr not found
-    → Installing AgentChattr... done (pipx install agentchattr)
+    → Installing AgentChattr... done (clone + venv)
   ✓ GitHub CLI (gh) detected
   ✓ Claude Code detected
 

--- a/server/config.js
+++ b/server/config.js
@@ -104,15 +104,15 @@ function resolveProjectChattr(projectId) {
 
 /**
  * Resolve the command + args to spawn AgentChattr from its cloned directory.
- * Returns { command, args, cwd } or null if the directory is not set up.
+ * Returns { command, args, cwd } or null if not fully set up.
+ * Requires .venv/bin/python — never falls back to bare python3.
  */
 function resolveChattrSpawn(agentchattrDir) {
   const dir = agentchattrDir || path.join(os.homedir(), ".quadwork", "agentchattr");
   const runPy = path.join(dir, "run.py");
-  if (!fs.existsSync(runPy)) return null;
   const venvPython = path.join(dir, ".venv", "bin", "python");
-  const python = fs.existsSync(venvPython) ? venvPython : "python3";
-  return { command: python, args: ["run.py"], cwd: dir };
+  if (!fs.existsSync(runPy) || !fs.existsSync(venvPython)) return null;
+  return { command: venvPython, args: ["run.py"], cwd: dir };
 }
 
 /**

--- a/server/config.js
+++ b/server/config.js
@@ -7,6 +7,7 @@ const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
 const DEFAULT_CONFIG = {
   port: 8400,
   agentchattr_url: "http://127.0.0.1:8300",
+  agentchattr_dir: path.join(os.homedir(), ".quadwork", "agentchattr"),
   projects: [],
 };
 
@@ -97,7 +98,21 @@ function resolveProjectChattr(projectId) {
     token: project?.agentchattr_token || config.agentchattr_token || null,
     mcp_http_port: project?.mcp_http_port || null,
     mcp_sse_port: project?.mcp_sse_port || null,
+    dir: project?.agentchattr_dir || config.agentchattr_dir || path.join(os.homedir(), ".quadwork", "agentchattr"),
   };
+}
+
+/**
+ * Resolve the command + args to spawn AgentChattr from its cloned directory.
+ * Returns { command, args, cwd } or null if the directory is not set up.
+ */
+function resolveChattrSpawn(agentchattrDir) {
+  const dir = agentchattrDir || path.join(os.homedir(), ".quadwork", "agentchattr");
+  const runPy = path.join(dir, "run.py");
+  if (!fs.existsSync(runPy)) return null;
+  const venvPython = path.join(dir, ".venv", "bin", "python");
+  const python = fs.existsSync(venvPython) ? venvPython : "python3";
+  return { command: python, args: ["run.py"], cwd: dir };
 }
 
 /**
@@ -124,4 +139,4 @@ async function syncChattrToken(projectId) {
   } catch {}
 }
 
-module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, syncChattrToken, CONFIG_PATH };
+module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH };

--- a/server/index.js
+++ b/server/index.js
@@ -335,6 +335,25 @@ function handleAgentChattr(req, res) {
         res.status(500).json({ ok: false, state: "error", error: err.message });
       }
     }, 500);
+  } else if (action === "update") {
+    // Update AgentChattr: git pull + refresh venv dependencies
+    const { dir: acDir } = resolveProjectChattr(projectId);
+    if (!acDir || !fs.existsSync(path.join(acDir, "run.py"))) {
+      return res.status(400).json({ ok: false, error: "AgentChattr not installed at " + (acDir || "unknown") });
+    }
+    try {
+      const { execSync } = require("child_process");
+      const pullResult = execSync("git pull 2>&1", { cwd: acDir, encoding: "utf-8", timeout: 30000 }).trim();
+      const venvPython = path.join(acDir, ".venv", "bin", "python");
+      let pipResult = "";
+      const reqFile = path.join(acDir, "requirements.txt");
+      if (fs.existsSync(venvPython) && fs.existsSync(reqFile)) {
+        pipResult = execSync(`"${venvPython}" -m pip install -r requirements.txt 2>&1`, { cwd: acDir, encoding: "utf-8", timeout: 120000 }).trim();
+      }
+      res.json({ ok: true, pull: pullResult, pip: pipResult });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
   } else {
     res.status(400).json({ error: "Unknown action" });
   }

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ const fs = require("fs");
 const { WebSocketServer } = require("ws");
 const pty = require("node-pty");
 const { spawn } = require("child_process");
-const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, syncChattrToken } = require("./config");
+const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken } = require("./config");
 const routes = require("./routes");
 
 const net = require("net");
@@ -249,19 +249,28 @@ function handleAgentChattr(req, res) {
     regenerateConfigToml();
 
     // Use project config.toml if available (isolated data dir + ports), otherwise fall back to --port
-    const args = (projectConfigToml && fs.existsSync(projectConfigToml))
+    const extraArgs = (projectConfigToml && fs.existsSync(projectConfigToml))
       ? ["--config", projectConfigToml]
       : ["--port", chattrPort];
-    const child = spawn("agentchattr", args, {
+
+    // Resolve AgentChattr from its cloned directory
+    const { dir: acDir } = resolveProjectChattr(projectId);
+    const acSpawn = resolveChattrSpawn(acDir);
+    if (!acSpawn) {
+      setProc({ process: null, state: "error", error: "AgentChattr not installed. Clone it: git clone https://github.com/bcurts/agentchattr.git ~/.quadwork/agentchattr" });
+      return null;
+    }
+
+    const child = spawn(acSpawn.command, [...acSpawn.args, ...extraArgs], {
+      cwd: acSpawn.cwd,
       env: process.env,
       stdio: "ignore",
       detached: true,
     });
 
-    // If pid is undefined, spawn failed (binary not found)
+    // If pid is undefined, spawn failed
     if (!child.pid) {
-      setProc({ process: null, state: "error", error: "Failed to start AgentChattr — is it installed? Run: pipx install agentchattr" });
-      // Still register error handler to prevent unhandled error crash
+      setProc({ process: null, state: "error", error: "Failed to start AgentChattr — check that Python venv is set up in " + acDir });
       child.on("error", () => {});
       return null;
     }

--- a/server/routes.js
+++ b/server/routes.js
@@ -19,6 +19,7 @@ const REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 const DEFAULT_CONFIG = {
   port: 8400,
   agentchattr_url: "http://127.0.0.1:8300",
+  agentchattr_dir: path.join(os.homedir(), ".quadwork", "agentchattr"),
   projects: [],
 };
 


### PR DESCRIPTION
## Summary
- Replace broken `pipx install agentchattr` with `git clone` + virtualenv setup in `~/.quadwork/agentchattr`
- Add `agentchattr_dir` config support in `server/config.js` (default `~/.quadwork/agentchattr`, overridable per-project)
- Add `resolveChattrSpawn()` helper that resolves `.venv/bin/python run.py` from the configured directory
- Update wizard `checkPrereqs` and `writeAgentChattrConfig` to use clone+venv install (idempotent, safe to re-run)
- Update `server/index.js` `spawnChattr()` to launch via resolved python from cloned directory
- Update `cmdStart` to use the new clone-based launch for all projects
- Remove all references to `pipx install agentchattr` in error messages and docs

## Test plan
- [ ] Run `npx quadwork init` on a fresh machine (no prior agentchattr) — should clone and set up venv
- [ ] Re-run init — should detect existing install and skip clone
- [ ] Verify `npx quadwork start` launches AgentChattr via `.venv/bin/python run.py`
- [ ] Verify server API `/api/agentchattr/:project/start` spawns correctly
- [ ] Verify `agentchattr_dir` override in config.json is respected

Fixes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)