### PR TITLE
[#349] Add compact button to terminal panels

### DIFF
--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -104,6 +104,19 @@ export default function TerminalGrid({
                   className="text-[10px] text-text-muted hover:text-accent transition-colors px-0.5"
                   title="Restart"
                 >↻</button>
+                {agentStates[agent.id] === "running" && (
+                  <button
+                    onClick={() => {
+                      fetch(`/api/agents/${encodeURIComponent(projectId)}/${encodeURIComponent(agent.id)}/write`, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ text: "/compact\n" }),
+                      }).catch(() => {});
+                    }}
+                    className="text-[10px] text-text-muted hover:text-accent transition-colors px-0.5"
+                    title="Compact — frees context/memory when agent is stuck"
+                  >&#x29C9;</button>
+                )}
                 {isExpanded && (
                   <button
                     onClick={() => setExpanded(null)}

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -115,7 +115,7 @@ export default function TerminalGrid({
                     }}
                     className="text-[10px] text-text-muted hover:text-accent transition-colors px-0.5"
                     title="Compact — frees context/memory when agent is stuck"
-                  >&#x29C9;</button>
+                  >/c</button>
                 )}
                 {isExpanded && (
                   <button


### PR DESCRIPTION
## Summary
- Add a compact button (⧉) to each terminal panel header, next to stop/restart controls
- On click, sends `/compact\n` to the terminal via the existing `POST /api/agents/:project/:agent/write` endpoint
- Only shown when the agent is running (same visibility as the stop button)
- Tooltip: "Compact — frees context/memory when agent is stuck"
- Works for both Claude Code and Codex CLI terminals (sends the same `/compact` command)

## Test plan
- [ ] Verify compact button appears on running terminal panels
- [ ] Verify button is hidden when agent is stopped
- [ ] Click compact button — confirm `/compact` is sent to the terminal
- [ ] Verify existing stop/restart/start buttons still work
- [ ] Verify layout isn't broken in both grid and expanded views

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)