### PR TITLE
[#151] Add Homebrew prerequisite check for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Your AI dev team in a box. Four agents — one Head, one Dev, two Reviewers — 
 ## Getting Started
 
 1. Install [Node.js 20+](https://nodejs.org) if you don't have it
-2. Open your terminal and run:
+2. Install [Homebrew](https://brew.sh) if you're on macOS: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+3. Open your terminal and run:
 
 ```bash
 npx quadwork init
 ```
 
-3. The wizard installs everything else and opens your dashboard.
+4. The wizard installs everything else and opens your dashboard.
 
 That's it. The wizard handles Python, GitHub CLI, AI tools, and authentication — you just follow the prompts.
 

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -302,7 +302,27 @@ async function checkPrereqs(rl) {
     allOk = false;
   }
 
-  // ── 2. Python 3.10+ (manual install — guide only) ──
+  // ── 2. Homebrew (macOS only — needed for gh, AI CLIs) ──
+  if (platform === "macos") {
+    if (which("brew")) {
+      ok("Homebrew");
+    } else {
+      console.log("");
+      warn("Homebrew is required to install developer tools (GitHub CLI, AI coding tools).");
+      log("It's the standard macOS package manager. Install it by pasting this into your terminal:");
+      log("");
+      log(`  → /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`);
+      log("");
+      log("After installing, close and reopen your terminal, then run:");
+      log("  → npx quadwork init");
+      console.log("");
+      fail("Homebrew is required before we can set up the remaining tools.");
+      log("Install Homebrew first, then re-run: npx quadwork init");
+      return false;
+    }
+  }
+
+  // ── 3. Python 3.10+ (manual install — guide only) ──
   const pyVer = run("python3 --version");
   if (pyVer) {
     const parts = pyVer.replace("Python ", "").split(".");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js"


### PR DESCRIPTION
## Summary
- Add Homebrew check early in wizard prerequisites (macOS only)
- Exit with friendly install guide if missing — same pattern as Python check
- Update README: Node.js + Homebrew as the two things to install before running `npx quadwork init`

Fixes #151

## Test plan
- [ ] Run `npx quadwork init` on macOS without Homebrew — should show install guide and exit
- [ ] Run on macOS with Homebrew — should pass and continue
- [ ] Run on Linux — should skip Homebrew check entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)