### PR TITLE
[#153] Add sudo for global npm installs on macOS/Linux

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -436,6 +436,9 @@ async function checkPrereqs(rl) {
     console.log("");
   }
 
+  // sudo needed for global npm installs on macOS/Linux
+  const npmPrefix = process.platform === "win32" ? "" : "sudo ";
+
   // Offer to install Claude Code if missing
   if (!hasClaude) {
     const isRequired = !hasCodex;
@@ -443,11 +446,11 @@ async function checkPrereqs(rl) {
     const installClaude = await askYN(rl, "Install Claude Code?", isRequired);
     if (installClaude) {
       const sp = spinner("Installing Claude Code...");
-      const result = run("npm install -g @anthropic-ai/claude-code 2>&1", { timeout: 120000 });
+      const result = run(`${npmPrefix}npm install -g @anthropic-ai/claude-code 2>&1`, { timeout: 120000 });
       sp.stop(result !== null);
       hasClaude = which("claude");
       if (hasClaude) ok("Claude Code installed");
-      else warn("Install failed — try manually: npm install -g @anthropic-ai/claude-code");
+      else warn(`Install failed — try manually: ${npmPrefix}npm install -g @anthropic-ai/claude-code`);
     }
   }
 
@@ -462,11 +465,11 @@ async function checkPrereqs(rl) {
     const installCodex = await askYN(rl, "Install Codex CLI?", isRequired);
     if (installCodex) {
       const sp = spinner("Installing Codex CLI...");
-      const result = run("npm install -g codex 2>&1", { timeout: 120000 });
+      const result = run(`${npmPrefix}npm install -g codex 2>&1`, { timeout: 120000 });
       sp.stop(result !== null);
       hasCodex = which("codex");
       if (hasCodex) ok("Codex CLI installed");
-      else warn("Install failed — try manually: npm install -g codex");
+      else warn(`Install failed — try manually: ${npmPrefix}npm install -g codex`);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js"


### PR DESCRIPTION
## Summary
- Add `sudo` prefix for `npm install -g` on macOS/Linux (fixes EACCES permission denied)
- Applies to both Claude Code and Codex CLI installs
- Updates manual install hints to include sudo

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)