### PR TITLE
[#165] Fix /setup 404 — .html resolution for all requests

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -645,11 +645,11 @@ app.use((req, res, next) => {
 
 const outDir = path.join(__dirname, "..", "out");
 
-// HEAD requests: express.static extensions don't resolve when a same-name
-// directory exists (e.g. /settings dir shadows settings.html for HEAD).
-// Resolve extensionless HEAD requests to their .html file explicitly.
+// Resolve extensionless requests to .html files before express.static.
+// Next.js static export creates both /setup.html and /setup/ directory —
+// express.static finds the directory first and returns NotFoundError.
 app.use((req, res, next) => {
-  if (req.method !== "HEAD" || req.path.startsWith("/api/") || path.extname(req.path)) {
+  if (req.path.startsWith("/api/") || req.path.startsWith("/_next/") || path.extname(req.path)) {
     return next();
   }
   const htmlPath = path.join(outDir, req.path + ".html");


### PR DESCRIPTION
## Summary
- Resolve extensionless paths to `.html` files for all requests (GET + HEAD), not just HEAD
- Fixes 404 on `/setup`, `/settings` etc. where a same-name directory shadows the .html file

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)