### PR TITLE
[#167] Fix /setup 404 — .html file shadowed by directory

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -643,18 +643,21 @@ app.use((req, res, next) => {
   next();
 });
 
-const outDir = path.join(__dirname, "..", "out");
+const outDir = path.resolve(__dirname, "..", "out");
 
 // Resolve extensionless requests to .html files before express.static.
 // Next.js static export creates both /setup.html and /setup/ directory —
 // express.static finds the directory first and returns NotFoundError.
 app.use((req, res, next) => {
-  if (req.path.startsWith("/api/") || req.path.startsWith("/_next/") || path.extname(req.path)) {
+  if (req.path === "/" || req.path.startsWith("/api/") || req.path.startsWith("/_next/") || path.extname(req.path)) {
     return next();
   }
-  const htmlPath = path.join(outDir, req.path + ".html");
+  const htmlFile = req.path.slice(1) + ".html";
+  const htmlPath = path.join(outDir, htmlFile);
   if (fs.existsSync(htmlPath)) {
-    return res.sendFile(htmlPath);
+    return res.sendFile(htmlFile, { root: outDir }, (err) => {
+      if (err) next();
+    });
   }
   next();
 });


### PR DESCRIPTION
## Root cause
express.static with `redirect: false` and `extensions: ["html"]` returns 404 when both `setup.html` and `setup/` directory exist. The directory is found first and blocks .html resolution.

## Fix
- Resolve extensionless paths to `.html` files BEFORE express.static
- Use `sendFile` with `root` option and error callback fallback
- Skip root path `/` from resolution
- Use `path.resolve` for outDir

## Verified
Tested locally — `/`, `/setup`, `/settings` all return 200.

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)