### PR TITLE
[#171] Allow start without projects

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1181,8 +1181,7 @@ function cmdStart() {
 
   const config = readConfig();
   if (config.projects.length === 0) {
-    fail("No projects configured. Run: npx quadwork init");
-    process.exit(1);
+    warn("No projects configured yet. Create one at the setup page.");
   }
 
   const quadworkDir = path.join(__dirname, "..");


### PR DESCRIPTION
## Summary
- Show warning instead of exiting when no projects configured
- Server needs to run for /setup page to create projects

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)