### PR TITLE
[#352] Agent launch flags — permission bypass + MCP config injection

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1022,11 +1022,12 @@ function writeQuadWorkConfig(setup) {
   for (const agent of AGENTS) {
     const cmd = (setup.backends && setup.backends[agent]) || setup.backend;
     const cliBase = cmd.split("/").pop().split(" ")[0];
+    const injectMode = cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag";
     project.agents[agent] = {
       cwd: setup.worktrees[agent],
       command: cmd,
       auto_approve: true,
-      mcp_inject: cliBase === "codex" ? "proxy_flag" : "flag",
+      mcp_inject: injectMode,
     };
   }
 

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1020,7 +1020,14 @@ function writeQuadWorkConfig(setup) {
   };
 
   for (const agent of AGENTS) {
-    project.agents[agent] = { cwd: setup.worktrees[agent], command: (setup.backends && setup.backends[agent]) || setup.backend };
+    const cmd = (setup.backends && setup.backends[agent]) || setup.backend;
+    const cliBase = cmd.split("/").pop().split(" ")[0];
+    project.agents[agent] = {
+      cwd: setup.worktrees[agent],
+      command: cmd,
+      auto_approve: true,
+      mcp_inject: cliBase === "codex" ? "proxy_flag" : "flag",
+    };
   }
 
   if (setup.memoryDir) {

--- a/server/index.js
+++ b/server/index.js
@@ -136,20 +136,27 @@ const chattrProcesses = new Map();
 const mcpProxies = new Map();
 
 /**
+ * Grab a free port synchronously by spawning a child process.
+ */
+function getFreePortSync() {
+  const result = execSync(
+    `node -e "const s=require('net').createServer();s.listen(0,'127.0.0.1',()=>{process.stdout.write(String(s.address().port));s.close()})"`,
+    { encoding: "utf-8", timeout: 5000 }
+  );
+  return parseInt(result.trim(), 10);
+}
+
+/**
  * Start a local HTTP proxy that forwards MCP requests with Bearer token.
  * Returns the proxy URL (e.g. http://127.0.0.1:54321/mcp).
- * Uses a pre-allocated port to avoid async listen race.
+ * Port is allocated synchronously via a subprocess to avoid async races.
  */
 function startMcpProxy(projectId, agentId, upstreamUrl, token) {
   const key = `${projectId}/${agentId}`;
   const existing = mcpProxies.get(key);
   if (existing) return `http://127.0.0.1:${existing.port}/mcp`;
 
-  // Pre-allocate a free port synchronously using a temporary net server
-  const tmpServer = net.createServer();
-  tmpServer.listen(0, "127.0.0.1");
-  const port = tmpServer.address().port;
-  tmpServer.close();
+  const port = getFreePortSync();
 
   const proxyServer = http.createServer((req, res) => {
     const parsedUrl = new URL(req.url, `http://127.0.0.1`);
@@ -181,7 +188,7 @@ function startMcpProxy(projectId, agentId, upstreamUrl, token) {
     });
   });
 
-  // Bind to the pre-allocated port
+  // Bind to the pre-allocated port (listen is async but port is reserved)
   proxyServer.listen(port, "127.0.0.1");
   mcpProxies.set(key, { server: proxyServer, port });
   return `http://127.0.0.1:${port}/mcp`;

--- a/server/index.js
+++ b/server/index.js
@@ -186,7 +186,7 @@ function buildAgentArgs(projectId, agentId) {
   const mcpHttpPort = project.mcp_http_port;
   const token = project.agentchattr_token;
   if (mcpHttpPort) {
-    const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : "flag");
+    const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag");
     if (injectMode === "flag") {
       // Claude/Kimi: write config file, pass --mcp-config
       const mcpConfigPath = writeMcpConfigFile(projectId, agentId, mcpHttpPort, token);

--- a/server/index.js
+++ b/server/index.js
@@ -136,62 +136,52 @@ const chattrProcesses = new Map();
 const mcpProxies = new Map();
 
 /**
- * Grab a free port synchronously by spawning a child process.
- */
-function getFreePortSync() {
-  const result = execSync(
-    `node -e "const s=require('net').createServer();s.listen(0,'127.0.0.1',()=>{process.stdout.write(String(s.address().port));s.close()})"`,
-    { encoding: "utf-8", timeout: 5000 }
-  );
-  return parseInt(result.trim(), 10);
-}
-
-/**
  * Start a local HTTP proxy that forwards MCP requests with Bearer token.
- * Returns the proxy URL (e.g. http://127.0.0.1:54321/mcp).
- * Port is allocated synchronously via a subprocess to avoid async races.
+ * Returns a Promise that resolves to the proxy URL once listening.
  */
 function startMcpProxy(projectId, agentId, upstreamUrl, token) {
   const key = `${projectId}/${agentId}`;
   const existing = mcpProxies.get(key);
-  if (existing) return `http://127.0.0.1:${existing.port}/mcp`;
+  if (existing) return Promise.resolve(`http://127.0.0.1:${existing.port}/mcp`);
 
-  const port = getFreePortSync();
+  return new Promise((resolve, reject) => {
+    const proxyServer = http.createServer((req, res) => {
+      const parsedUrl = new URL(req.url, `http://127.0.0.1`);
+      const targetUrl = `${upstreamUrl}${parsedUrl.pathname}${parsedUrl.search}`;
+      const headers = { ...req.headers, host: new URL(upstreamUrl).host };
+      if (token) {
+        headers["authorization"] = `Bearer ${token}`;
+        headers["x-agent-token"] = token;
+      }
+      delete headers["content-length"];
 
-  const proxyServer = http.createServer((req, res) => {
-    const parsedUrl = new URL(req.url, `http://127.0.0.1`);
-    const targetUrl = `${upstreamUrl}${parsedUrl.pathname}${parsedUrl.search}`;
-    const headers = { ...req.headers, host: new URL(upstreamUrl).host };
-    if (token) {
-      headers["authorization"] = `Bearer ${token}`;
-      headers["x-agent-token"] = token;
-    }
-    delete headers["content-length"];
-
-    const chunks = [];
-    req.on("data", (chunk) => chunks.push(chunk));
-    req.on("end", () => {
-      const body = Buffer.concat(chunks);
-      const proxyReq = (upstreamUrl.startsWith("https") ? require("https") : http).request(
-        targetUrl,
-        { method: req.method, headers: { ...headers, "content-length": body.length } },
-        (proxyRes) => {
-          res.writeHead(proxyRes.statusCode, proxyRes.headers);
-          proxyRes.pipe(res);
-        }
-      );
-      proxyReq.on("error", (err) => {
-        res.writeHead(502);
-        res.end(`Proxy error: ${err.message}`);
+      const chunks = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks);
+        const proxyReq = (upstreamUrl.startsWith("https") ? require("https") : http).request(
+          targetUrl,
+          { method: req.method, headers: { ...headers, "content-length": body.length } },
+          (proxyRes) => {
+            res.writeHead(proxyRes.statusCode, proxyRes.headers);
+            proxyRes.pipe(res);
+          }
+        );
+        proxyReq.on("error", (err) => {
+          res.writeHead(502);
+          res.end(`Proxy error: ${err.message}`);
+        });
+        proxyReq.end(body);
       });
-      proxyReq.end(body);
+    });
+
+    proxyServer.on("error", (err) => reject(err));
+    proxyServer.listen(0, "127.0.0.1", () => {
+      const port = proxyServer.address().port;
+      mcpProxies.set(key, { server: proxyServer, port });
+      resolve(`http://127.0.0.1:${port}/mcp`);
     });
   });
-
-  // Bind to the pre-allocated port (listen is async but port is reserved)
-  proxyServer.listen(port, "127.0.0.1");
-  mcpProxies.set(key, { server: proxyServer, port });
-  return `http://127.0.0.1:${port}/mcp`;
 }
 
 function stopMcpProxy(projectId, agentId) {
@@ -237,8 +227,9 @@ function writeMcpConfigFile(projectId, agentId, mcpHttpPort, token) {
 
 /**
  * Build extra launch args for an agent (permission flags + MCP injection).
+ * Async because Codex proxy_flag mode needs to await proxy startup.
  */
-function buildAgentArgs(projectId, agentId) {
+async function buildAgentArgs(projectId, agentId) {
   const cfg = readConfig();
   const project = cfg.projects?.find((p) => p.id === projectId);
   if (!project) return [];
@@ -267,7 +258,7 @@ function buildAgentArgs(projectId, agentId) {
     } else if (injectMode === "proxy_flag") {
       // Codex: start local auth proxy, pass proxy URL via -c flag
       const upstreamUrl = `http://127.0.0.1:${mcpHttpPort}`;
-      const proxyUrl = startMcpProxy(projectId, agentId, upstreamUrl, token);
+      const proxyUrl = await startMcpProxy(projectId, agentId, upstreamUrl, token);
       if (proxyUrl) {
         args.push("-c", `mcp_servers.agentchattr.url="${proxyUrl}"`);
       }
@@ -314,14 +305,14 @@ function buildAgentEnv(projectId, agentId) {
 }
 
 // Helper: spawn a PTY for a project/agent and register in agentSessions
-function spawnAgentPty(project, agent) {
+async function spawnAgentPty(project, agent) {
   const key = `${project}/${agent}`;
 
   const cwd = resolveAgentCwd(project, agent);
   if (!cwd) return { ok: false, error: `Unknown agent: ${key}` };
 
   const command = resolveAgentCommand(project, agent) || (process.env.SHELL || "/bin/zsh");
-  const args = buildAgentArgs(project, agent);
+  const args = await buildAgentArgs(project, agent);
   const extraEnv = buildAgentEnv(project, agent);
 
   try {
@@ -610,7 +601,7 @@ app.post("/api/agents/:project/reset", async (req, res) => {
 
 // --- Lifecycle: start spawns PTY (visible in terminal panel) ---
 
-app.post("/api/agents/:project/:agent/start", (req, res) => {
+app.post("/api/agents/:project/:agent/start", async (req, res) => {
   const { project, agent } = req.params;
   const key = `${project}/${agent}`;
 
@@ -619,7 +610,7 @@ app.post("/api/agents/:project/:agent/start", (req, res) => {
     return res.json({ ok: true, state: "running", message: "Already running" });
   }
 
-  const result = spawnAgentPty(project, agent);
+  const result = await spawnAgentPty(project, agent);
   if (result.ok) {
     res.json({ ok: true, state: "running", pid: result.pid });
   } else {
@@ -638,14 +629,14 @@ app.post("/api/agents/:project/:agent/stop", (req, res) => {
 
 // --- Lifecycle: restart ---
 
-app.post("/api/agents/:project/:agent/restart", (req, res) => {
+app.post("/api/agents/:project/:agent/restart", async (req, res) => {
   const { project, agent } = req.params;
   const key = `${project}/${agent}`;
 
   stopAgentSession(key);
 
-  setTimeout(() => {
-    const result = spawnAgentPty(project, agent);
+  setTimeout(async () => {
+    const result = await spawnAgentPty(project, agent);
     if (result.ok) {
       res.json({ ok: true, state: "running", pid: result.pid });
     } else {
@@ -895,7 +886,7 @@ app.use((req, res, next) => {
 
 const wss = new WebSocketServer({ server, path: "/ws/terminal" });
 
-wss.on("connection", (ws, req) => {
+wss.on("connection", async (ws, req) => {
   const params = new URL(req.url, `http://localhost:${PORT}`).searchParams;
   const projectId = params.get("project");
   const agentId = params.get("agent");
@@ -910,7 +901,7 @@ wss.on("connection", (ws, req) => {
 
   // If no active PTY, spawn one
   if (!session || !session.term) {
-    const result = spawnAgentPty(projectId, agentId);
+    const result = await spawnAgentPty(projectId, agentId);
     if (!result.ok) {
       ws.close(1011, "pty-spawn-failed");
       return;

--- a/server/index.js
+++ b/server/index.js
@@ -131,6 +131,72 @@ const agentSessions = new Map();
 // AgentChattr server processes — per-project (key = projectId)
 const chattrProcesses = new Map();
 
+// --- MCP auth proxy for Codex (can't pass headers via -c flag) ---
+// Maps "project/agent" → { server, port }
+const mcpProxies = new Map();
+
+/**
+ * Start a local HTTP proxy that forwards MCP requests with Bearer token.
+ * Returns the proxy URL (e.g. http://127.0.0.1:54321/mcp).
+ */
+function startMcpProxy(projectId, agentId, upstreamUrl, token) {
+  const key = `${projectId}/${agentId}`;
+  const existing = mcpProxies.get(key);
+  if (existing) return `http://127.0.0.1:${existing.port}/mcp`;
+
+  const proxyServer = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1`);
+    const targetUrl = `${upstreamUrl}${url.pathname}${url.search}`;
+    const headers = { ...req.headers, host: new URL(upstreamUrl).host };
+    if (token) {
+      headers["authorization"] = `Bearer ${token}`;
+      headers["x-agent-token"] = token;
+    }
+    delete headers["content-length"]; // will be set by the forwarded request
+
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks);
+      const proxyReq = (upstreamUrl.startsWith("https") ? require("https") : http).request(
+        targetUrl,
+        { method: req.method, headers: { ...headers, "content-length": body.length } },
+        (proxyRes) => {
+          res.writeHead(proxyRes.statusCode, proxyRes.headers);
+          proxyRes.pipe(res);
+        }
+      );
+      proxyReq.on("error", (err) => {
+        res.writeHead(502);
+        res.end(`Proxy error: ${err.message}`);
+      });
+      proxyReq.end(body);
+    });
+  });
+
+  proxyServer.listen(0, "127.0.0.1", () => {
+    const port = proxyServer.address().port;
+    mcpProxies.set(key, { server: proxyServer, port });
+  });
+
+  // Wait synchronously for port assignment (will be ready immediately for localhost)
+  const addr = proxyServer.address();
+  if (addr) {
+    mcpProxies.set(key, { server: proxyServer, port: addr.port });
+    return `http://127.0.0.1:${addr.port}/mcp`;
+  }
+  return null;
+}
+
+function stopMcpProxy(projectId, agentId) {
+  const key = `${projectId}/${agentId}`;
+  const proxy = mcpProxies.get(key);
+  if (proxy) {
+    try { proxy.server.close(); } catch {}
+    mcpProxies.delete(key);
+  }
+}
+
 // --- Permission bypass flags per CLI ---
 const PERMISSION_FLAGS = {
   claude: ["--dangerously-skip-permissions"],
@@ -193,9 +259,12 @@ function buildAgentArgs(projectId, agentId) {
       const flag = agentCfg.mcp_flag || "--mcp-config";
       args.push(flag, mcpConfigPath);
     } else if (injectMode === "proxy_flag") {
-      // Codex: pass -c flag with proxy URL
-      const url = `http://127.0.0.1:${mcpHttpPort}/mcp`;
-      args.push("-c", `mcp_servers.agentchattr.url="${url}"`);
+      // Codex: start local auth proxy, pass proxy URL via -c flag
+      const upstreamUrl = `http://127.0.0.1:${mcpHttpPort}`;
+      const proxyUrl = startMcpProxy(projectId, agentId, upstreamUrl, token);
+      if (proxyUrl) {
+        args.push("-c", `mcp_servers.agentchattr.url="${proxyUrl}"`);
+      }
     }
   }
 
@@ -299,6 +368,9 @@ function stopAgentSession(key) {
   session.ws = null;
   session.state = "stopped";
   session.error = null;
+  // Clean up MCP auth proxy if running
+  const [projectId, agentId] = key.split("/");
+  if (projectId && agentId) stopMcpProxy(projectId, agentId);
 }
 
 app.get("/api/agents", (_req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -138,21 +138,28 @@ const mcpProxies = new Map();
 /**
  * Start a local HTTP proxy that forwards MCP requests with Bearer token.
  * Returns the proxy URL (e.g. http://127.0.0.1:54321/mcp).
+ * Uses a pre-allocated port to avoid async listen race.
  */
 function startMcpProxy(projectId, agentId, upstreamUrl, token) {
   const key = `${projectId}/${agentId}`;
   const existing = mcpProxies.get(key);
   if (existing) return `http://127.0.0.1:${existing.port}/mcp`;
 
+  // Pre-allocate a free port synchronously using a temporary net server
+  const tmpServer = net.createServer();
+  tmpServer.listen(0, "127.0.0.1");
+  const port = tmpServer.address().port;
+  tmpServer.close();
+
   const proxyServer = http.createServer((req, res) => {
-    const url = new URL(req.url, `http://127.0.0.1`);
-    const targetUrl = `${upstreamUrl}${url.pathname}${url.search}`;
+    const parsedUrl = new URL(req.url, `http://127.0.0.1`);
+    const targetUrl = `${upstreamUrl}${parsedUrl.pathname}${parsedUrl.search}`;
     const headers = { ...req.headers, host: new URL(upstreamUrl).host };
     if (token) {
       headers["authorization"] = `Bearer ${token}`;
       headers["x-agent-token"] = token;
     }
-    delete headers["content-length"]; // will be set by the forwarded request
+    delete headers["content-length"];
 
     const chunks = [];
     req.on("data", (chunk) => chunks.push(chunk));
@@ -174,18 +181,10 @@ function startMcpProxy(projectId, agentId, upstreamUrl, token) {
     });
   });
 
-  proxyServer.listen(0, "127.0.0.1", () => {
-    const port = proxyServer.address().port;
-    mcpProxies.set(key, { server: proxyServer, port });
-  });
-
-  // Wait synchronously for port assignment (will be ready immediately for localhost)
-  const addr = proxyServer.address();
-  if (addr) {
-    mcpProxies.set(key, { server: proxyServer, port: addr.port });
-    return `http://127.0.0.1:${addr.port}/mcp`;
-  }
-  return null;
+  // Bind to the pre-allocated port
+  proxyServer.listen(port, "127.0.0.1");
+  mcpProxies.set(key, { server: proxyServer, port });
+  return `http://127.0.0.1:${port}/mcp`;
 }
 
 function stopMcpProxy(projectId, agentId) {

--- a/server/index.js
+++ b/server/index.js
@@ -131,6 +131,113 @@ const agentSessions = new Map();
 // AgentChattr server processes — per-project (key = projectId)
 const chattrProcesses = new Map();
 
+// --- Permission bypass flags per CLI ---
+const PERMISSION_FLAGS = {
+  claude: ["--dangerously-skip-permissions"],
+  codex: ["--dangerously-bypass-approvals-and-sandbox"],
+  gemini: ["--yolo"],
+};
+
+// --- MCP config generation & agent launch args ---
+
+/**
+ * Generate a per-agent MCP config file for Claude (--mcp-config).
+ * Returns the absolute path to the written JSON file.
+ */
+function writeMcpConfigFile(projectId, agentId, mcpHttpPort, token) {
+  const os = require("os");
+  const configDir = path.join(os.homedir(), ".quadwork", projectId);
+  if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+  const filePath = path.join(configDir, `mcp-${agentId}.json`);
+  const url = `http://127.0.0.1:${mcpHttpPort}/mcp`;
+  const config = {
+    mcpServers: {
+      agentchattr: {
+        type: "http",
+        url,
+        ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+      },
+    },
+  };
+  fs.writeFileSync(filePath, JSON.stringify(config, null, 2));
+  return filePath;
+}
+
+/**
+ * Build extra launch args for an agent (permission flags + MCP injection).
+ */
+function buildAgentArgs(projectId, agentId) {
+  const cfg = readConfig();
+  const project = cfg.projects?.find((p) => p.id === projectId);
+  if (!project) return [];
+
+  const agentCfg = project.agents?.[agentId] || {};
+  const command = agentCfg.command || "claude";
+  const cliBase = command.split("/").pop().split(" ")[0]; // extract base CLI name
+  const args = [];
+
+  // Permission bypass flags
+  if (agentCfg.auto_approve !== false) {
+    const flags = PERMISSION_FLAGS[cliBase];
+    if (flags) args.push(...flags);
+  }
+
+  // MCP config injection
+  const mcpHttpPort = project.mcp_http_port;
+  const token = project.agentchattr_token;
+  if (mcpHttpPort) {
+    const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : "flag");
+    if (injectMode === "flag") {
+      // Claude/Kimi: write config file, pass --mcp-config
+      const mcpConfigPath = writeMcpConfigFile(projectId, agentId, mcpHttpPort, token);
+      const flag = agentCfg.mcp_flag || "--mcp-config";
+      args.push(flag, mcpConfigPath);
+    } else if (injectMode === "proxy_flag") {
+      // Codex: pass -c flag with proxy URL
+      const url = `http://127.0.0.1:${mcpHttpPort}/mcp`;
+      args.push("-c", `mcp_servers.agentchattr.url="${url}"`);
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Build extra env vars for an agent (MCP injection via env for Gemini).
+ */
+function buildAgentEnv(projectId, agentId) {
+  const cfg = readConfig();
+  const project = cfg.projects?.find((p) => p.id === projectId);
+  if (!project) return {};
+
+  const agentCfg = project.agents?.[agentId] || {};
+  const command = agentCfg.command || "claude";
+  const cliBase = command.split("/").pop().split(" ")[0];
+  const env = {};
+
+  // Gemini: inject MCP via env var
+  if (cliBase === "gemini" && project.mcp_http_port) {
+    const os = require("os");
+    const configDir = path.join(os.homedir(), ".quadwork", projectId);
+    if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+    const settingsPath = path.join(configDir, `mcp-${agentId}-settings.json`);
+    const url = `http://127.0.0.1:${project.mcp_http_port}/mcp`;
+    const settings = {
+      mcpServers: {
+        agentchattr: {
+          type: "http",
+          url,
+          ...(project.agentchattr_token ? { headers: { Authorization: `Bearer ${project.agentchattr_token}` } } : {}),
+        },
+      },
+    };
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = settingsPath;
+  }
+
+  return env;
+}
+
 // Helper: spawn a PTY for a project/agent and register in agentSessions
 function spawnAgentPty(project, agent) {
   const key = `${project}/${agent}`;
@@ -139,14 +246,16 @@ function spawnAgentPty(project, agent) {
   if (!cwd) return { ok: false, error: `Unknown agent: ${key}` };
 
   const command = resolveAgentCommand(project, agent) || (process.env.SHELL || "/bin/zsh");
+  const args = buildAgentArgs(project, agent);
+  const extraEnv = buildAgentEnv(project, agent);
 
   try {
-    const term = pty.spawn(command, [], {
+    const term = pty.spawn(command, args, {
       name: "xterm-256color",
       cols: 120,
       rows: 30,
       cwd,
-      env: process.env,
+      env: { ...process.env, ...extraEnv },
     });
 
     const session = { projectId: project, agentId: agent, term, ws: null, state: "running", error: null };

--- a/server/routes.js
+++ b/server/routes.js
@@ -710,11 +710,12 @@ router.post("/api/setup", (req, res) => {
       for (const agentId of ["head", "reviewer1", "reviewer2", "dev"]) {
         const cmd = (backends && backends[agentId]) || "claude";
         const cliBase = cmd.split("/").pop().split(" ")[0];
+        const injectMode = cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag";
         agents[agentId] = {
           cwd: path.join(parentDir, `${dirName}-${agentId}`),
           command: cmd,
           auto_approve: autoApprove,
-          mcp_inject: cliBase === "codex" ? "proxy_flag" : "flag",
+          mcp_inject: injectMode,
         };
       }
       // Use pre-assigned ports/token from agentchattr-config step if provided,

--- a/server/routes.js
+++ b/server/routes.js
@@ -697,19 +697,24 @@ router.post("/api/setup", (req, res) => {
     }
     case "add-config": {
       const { id, name, repo, workingDir, backends } = body;
+      const autoApprove = body.auto_approve !== false; // default true
       // Use directory basename for sibling paths (matches CLI wizard)
       const dirName = path.basename(workingDir);
       const parentDir = path.dirname(workingDir);
       let cfg;
       try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); }
-      catch { cfg = { port: 8400, agentchattr_url: "http://127.0.0.1:8300", projects: [] }; }
+      catch { cfg = { port: 8400, agentchattr_url: "http://127.0.0.1:8300", agentchattr_dir: path.join(os.homedir(), ".quadwork", "agentchattr"), projects: [] }; }
       if (cfg.projects.some((p) => p.id === id)) return res.json({ ok: true, message: "Project already in config" });
-      // Match CLI wizard agent structure: { cwd, command }
+      // Match CLI wizard agent structure: { cwd, command, auto_approve, mcp_inject }
       const agents = {};
       for (const agentId of ["head", "reviewer1", "reviewer2", "dev"]) {
+        const cmd = (backends && backends[agentId]) || "claude";
+        const cliBase = cmd.split("/").pop().split(" ")[0];
         agents[agentId] = {
           cwd: path.join(parentDir, `${dirName}-${agentId}`),
-          command: (backends && backends[agentId]) || "claude",
+          command: cmd,
+          auto_approve: autoApprove,
+          mcp_inject: cliBase === "codex" ? "proxy_flag" : "flag",
         };
       }
       // Use pre-assigned ports/token from agentchattr-config step if provided,

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -152,6 +152,7 @@ export default function SetupWizard() {
   const [backends, setBackends] = useState<Record<string, string>>({
     head: "claude", reviewer1: "claude", reviewer2: "claude", dev: "claude",
   });
+  const [autoApprove, setAutoApprove] = useState(true);
   const [showReviewerCreds, setShowReviewerCreds] = useState(false);
   const [reviewerUser, setReviewerUser] = useState("");
   const [reviewerTokenMode, setReviewerTokenMode] = useState<"paste" | "file">("paste");
@@ -365,7 +366,7 @@ export default function SetupWizard() {
     // 2. Save config
     const id = workingDir.split("/").pop() || projectName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
     const configResult = await apiCall("add-config", {
-      id, name: projectName, repo, workingDir, backends,
+      id, name: projectName, repo, workingDir, backends, auto_approve: autoApprove,
       ...(chattrResult.ok ? {
         agentchattr_token: chattrResult.agentchattr_token,
         agentchattr_port: chattrResult.agentchattr_port,
@@ -647,6 +648,22 @@ export default function SetupWizard() {
                     </div>
                   ))}
                 </div>
+
+                {/* Auto-approve toggle */}
+                <label className="flex items-center gap-2 mb-3 cursor-pointer" title="Enable permission bypass flags so agents can work autonomously without prompting for approval on every action">
+                  <input
+                    type="checkbox"
+                    checked={autoApprove}
+                    onChange={(e) => setAutoApprove(e.target.checked)}
+                    className="accent-accent"
+                  />
+                  <span className="text-[11px] text-text">
+                    Auto-approve agent actions
+                  </span>
+                  <span className="text-[10px] text-text-muted">
+                    (required for autonomous work)
+                  </span>
+                </label>
 
                 {/* Reviewer credentials toggle */}
                 <label className="flex items-center gap-2 mb-3 cursor-pointer">


### PR DESCRIPTION
## Summary
- Add permission bypass flags to agent spawn: `--dangerously-skip-permissions` (Claude), `--dangerously-bypass-approvals-and-sandbox` (Codex), `--yolo` (Gemini)
- Generate per-agent MCP config files at `~/.quadwork/{project}/mcp-{agent}.json` with AgentChattr URL + bearer token
- MCP injection: Claude via `--mcp-config` flag, Codex via `-c` proxy flag, Gemini via env var
- Store `auto_approve` and `mcp_inject` per agent in config
- Add auto-approve toggle to setup wizard UI (default: on)
- CLI wizard (`writeQuadWorkConfig`) also writes `auto_approve` and `mcp_inject` per agent

## Test plan
- [ ] Start an agent — verify permission bypass flag is passed (check process args)
- [ ] Verify MCP config file is generated at `~/.quadwork/{project}/mcp-{agent}.json`
- [ ] Verify Claude agent gets `--mcp-config` flag pointing to generated file
- [ ] Verify Codex agent gets `-c mcp_servers.agentchattr.url=...` flag
- [ ] Toggle auto-approve off in wizard — verify flags are omitted
- [ ] Verify agents can communicate via AgentChattr MCP after launch

Fixes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)