### PR TITLE
[#179] Always (re)write AGENTS.md from seed on project creation

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -590,21 +590,26 @@ router.post("/api/setup", (req, res) => {
         const wtDir = path.join(parentDir, `${dirName}-${agent}`);
         if (!fs.existsSync(wtDir)) continue;
 
-        // AGENTS.md — use template with placeholder substitution (matches CLI)
+        // AGENTS.md — always (re)write from template so role definitions
+        // stay in sync with templates/seeds/ on every project (re)creation.
+        // Previously this was guarded by `!exists`, so if a worktree already
+        // had any AGENTS.md (stale, hand-edited, or empty) it was preserved
+        // forever and agents could launch with no/outdated role definition.
         const agentsMd = path.join(wtDir, "AGENTS.md");
-        if (!fs.existsSync(agentsMd)) {
-          const seedSrc = path.join(TEMPLATES_DIR, "seeds", `${agent}.AGENTS.md`);
-          if (fs.existsSync(seedSrc)) {
-            let content = fs.readFileSync(seedSrc, "utf-8");
-            content = content.replace(/\{\{reviewer_github_user\}\}/g, reviewerUser);
-            content = content.replace(/\{\{reviewer_token_path\}\}/g, reviewerTokenPath);
-            fs.writeFileSync(agentsMd, content);
-          } else {
-            // Fallback stub if template missing
-            fs.writeFileSync(agentsMd, `# ${dirName} — ${agent.charAt(0).toUpperCase() + agent.slice(1)} Agent\n\nRepo: ${body.repo}\nRole: ${agent === "head" ? "Owner" : agent.startsWith("reviewer") ? "Reviewer" : "Builder"}\n`);
-          }
-          seeded.push(`${agent}/AGENTS.md`);
+        const seedSrc = path.join(TEMPLATES_DIR, "seeds", `${agent}.AGENTS.md`);
+        if (!fs.existsSync(seedSrc)) {
+          // Hard fail: missing seed means role is undefined. Better to surface
+          // the error than silently write a generic stub.
+          return res.json({
+            ok: false,
+            error: `Missing seed template: templates/seeds/${agent}.AGENTS.md`,
+          });
         }
+        let agentsContent = fs.readFileSync(seedSrc, "utf-8");
+        agentsContent = agentsContent.replace(/\{\{reviewer_github_user\}\}/g, reviewerUser);
+        agentsContent = agentsContent.replace(/\{\{reviewer_token_path\}\}/g, reviewerTokenPath);
+        fs.writeFileSync(agentsMd, agentsContent);
+        seeded.push(`${agent}/AGENTS.md`);
 
         // CLAUDE.md — use template with placeholder substitution (matches CLI)
         const claudeMd = path.join(wtDir, "CLAUDE.md");


### PR DESCRIPTION
## Summary
- `seed-files` route in `server/routes.js` was guarded by `!fs.existsSync(agentsMd)` — any stale, hand-edited, or partial `AGENTS.md` already in a worktree was preserved forever and the template was never reapplied. Fix: always (re)write `AGENTS.md` from `templates/seeds/${agent}.AGENTS.md`.
- Hard-fail with a clear error if the seed template is missing instead of silently writing a generic stub (which would launch the agent with no real role definition).
- CLI wizard (`bin/quadwork.js:714`) already writes unconditionally — no change needed there. This patch brings the web UI / `seed-files` path to parity.

## Notes
- Issue body claimed `#178` regressed seed copying. Verified that is not the case — `#178` (`task/352-agent-launch-flags`) did not touch either seed path. The real (smaller) gap is the existence guard above; this PR addresses it.
- `CLAUDE.md` and `.gitignore` blocks intentionally left as-is (they were not part of the reported bug).

## Test plan
- [ ] Run setup wizard, verify `<wt>/AGENTS.md` matches the corresponding `templates/seeds/*.AGENTS.md` for all four agents.
- [ ] Pre-create a stale `AGENTS.md` in a worktree, re-run `seed-files`, confirm it is overwritten.
- [ ] Temporarily rename a seed template, re-run `seed-files`, confirm the route returns `ok:false` with the missing-template error instead of writing a stub.

Fixes #179