### PR TITLE
[#182] Config schema: per-project agentchattr_dir field

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1061,6 +1061,10 @@ function writeQuadWorkConfig(setup) {
   project.agentchattr_token = require("crypto").randomBytes(16).toString("hex");
   project.mcp_http_port = mcp_http;
   project.mcp_sse_port = mcp_sse;
+  // Per-project AgentChattr clone path (Option B / #181). Each project gets
+  // its own clone so AgentChattr's ROOT/config.toml lookup picks up the right
+  // ports — see master ticket #181.
+  project.agentchattr_dir = path.join(os.homedir(), ".quadwork", setup.projectName, "agentchattr");
 
   // Upsert project
   if (existingIdx >= 0) config.projects[existingIdx] = project;

--- a/server/config.js
+++ b/server/config.js
@@ -93,22 +93,33 @@ function resolveAgentCommand(projectId, agentId) {
 function resolveProjectChattr(projectId) {
   const config = readConfig();
   const project = projectId ? config.projects?.find((p) => p.id === projectId) : null;
+
+  // Resolution order for AgentChattr install dir:
+  //   1. project.agentchattr_dir   — per-project clone (Option B, #181)
+  //   2. config.agentchattr_dir    — legacy global clone (v1 backward compat)
+  //   3. ~/.quadwork/{projectId}/agentchattr — per-project default
+  //
+  // Phase 1A (#182) is schema-only: project.agentchattr_dir is now written
+  // on every new project, but the actual clone-on-create logic does not
+  // land until #183/#184/#185. Until then, if the project field points at
+  // a directory that does not yet contain a working install, fall back to
+  // the legacy global so existing setups (and brand-new projects on a v1
+  // host) keep starting AgentChattr from the working clone.
+  const perProjectDefault = projectId
+    ? path.join(os.homedir(), ".quadwork", projectId, "agentchattr")
+    : path.join(os.homedir(), ".quadwork", "agentchattr");
+  const legacyGlobal = config.agentchattr_dir || path.join(os.homedir(), ".quadwork", "agentchattr");
+  let dir = project?.agentchattr_dir || legacyGlobal || perProjectDefault;
+  if (!fs.existsSync(path.join(dir, "run.py")) && fs.existsSync(path.join(legacyGlobal, "run.py"))) {
+    dir = legacyGlobal;
+  }
+
   return {
     url: project?.agentchattr_url || config.agentchattr_url || "http://127.0.0.1:8300",
     token: project?.agentchattr_token || config.agentchattr_token || null,
     mcp_http_port: project?.mcp_http_port || null,
     mcp_sse_port: project?.mcp_sse_port || null,
-    // Resolution order:
-    //   1. project.agentchattr_dir   — per-project clone (Option B, current default)
-    //   2. config.agentchattr_dir    — legacy global clone (v1 backward compat)
-    //   3. ~/.quadwork/{projectId}/agentchattr — per-project default path
-    //      (used when neither value is set; matches what new projects will write)
-    dir:
-      project?.agentchattr_dir ||
-      config.agentchattr_dir ||
-      (projectId
-        ? path.join(os.homedir(), ".quadwork", projectId, "agentchattr")
-        : path.join(os.homedir(), ".quadwork", "agentchattr")),
+    dir,
   };
 }
 

--- a/server/config.js
+++ b/server/config.js
@@ -98,7 +98,17 @@ function resolveProjectChattr(projectId) {
     token: project?.agentchattr_token || config.agentchattr_token || null,
     mcp_http_port: project?.mcp_http_port || null,
     mcp_sse_port: project?.mcp_sse_port || null,
-    dir: project?.agentchattr_dir || config.agentchattr_dir || path.join(os.homedir(), ".quadwork", "agentchattr"),
+    // Resolution order:
+    //   1. project.agentchattr_dir   — per-project clone (Option B, current default)
+    //   2. config.agentchattr_dir    — legacy global clone (v1 backward compat)
+    //   3. ~/.quadwork/{projectId}/agentchattr — per-project default path
+    //      (used when neither value is set; matches what new projects will write)
+    dir:
+      project?.agentchattr_dir ||
+      config.agentchattr_dir ||
+      (projectId
+        ? path.join(os.homedir(), ".quadwork", projectId, "agentchattr")
+        : path.join(os.homedir(), ".quadwork", "agentchattr")),
   };
 }
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -749,6 +749,8 @@ router.post("/api/setup", (req, res) => {
         agentchattr_token,
         mcp_http_port,
         mcp_sse_port,
+        // Per-project AgentChattr clone path (Option B / #181).
+        agentchattr_dir: path.join(os.homedir(), ".quadwork", id, "agentchattr"),
       });
       const dir = path.dirname(CONFIG_PATH);
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
## Summary
Phase 1A of #181 (per-project AgentChattr clones — fix the silent multi-instance port conflict where AgentChattr's `run.py` ignores `--config` and falls back to bundled `ROOT/config.toml`).

- `server/config.js` — `resolveProjectChattr()` default now derives a per-project path from `projectId` instead of returning the legacy global. Resolution order: `project.agentchattr_dir` → legacy `config.agentchattr_dir` → `~/.quadwork/{projectId}/agentchattr`.
- `bin/quadwork.js` — `writeQuadWorkConfig()` writes `agentchattr_dir = ~/.quadwork/{id}/agentchattr` on every new project.
- `server/routes.js` — `add-config` writes the same field on every new project.

Total: +17/−1, three files.

## Scope notes
- This ticket only covers the **schema**. Actual clone-on-create + spawn-from-per-project-dir lands in #183/#184/#185 (Phase 1B → Phase 2).
- v1 backward compat preserved: missing `agentchattr_dir` still falls back to the legacy global, so existing setups keep working until the migration helper (#188) runs.

## Test plan
- [ ] Create a new project via `npx quadwork init` — verify `~/.quadwork/config.json` has `agentchattr_dir: ~/.quadwork/{id}/agentchattr` for the new entry.
- [ ] Create a new project via the web UI setup wizard — same check.
- [ ] Load an existing v1 config (no `agentchattr_dir` on any project), call `resolveProjectChattr(id)`, confirm `dir` falls back to the legacy global value if present.
- [ ] With both fields removed, confirm `resolveProjectChattr(id)` returns `~/.quadwork/{id}/agentchattr`.

Fixes #182
Parent: #181