### PR TITLE
[#187] installAgentChattr per-target install lock

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -155,8 +155,26 @@ function installAgentChattr(dir) {
     } catch (e) {
       if (e.code !== "EEXIST") return setError(`Cannot create install lock ${lockFile}: ${e.message}`);
       // Reclaim if the existing lock is stale (crashed pid or too old).
+      // Use rename → unlink instead of unlink directly: rename is atomic,
+      // so only one racing process can move the stale lock aside. The
+      // others see ENOENT and just retry the wx create. Without this,
+      // two processes could both observe the same stale lock, both
+      // unlink it (one of those unlinks would target the *next* lock
+      // freshly acquired by a third process), and both proceed past the
+      // gate concurrently — see review on quadwork#193.
       if (_isLockStale(lockFile)) {
-        try { fs.unlinkSync(lockFile); } catch {}
+        const sideline = `${lockFile}.stale.${process.pid}.${Date.now()}`;
+        try {
+          fs.renameSync(lockFile, sideline);
+          try { fs.unlinkSync(sideline); } catch {}
+        } catch (renameErr) {
+          // ENOENT: another process already reclaimed it. Anything else:
+          // treat as transient and retry — the next iteration will read
+          // whatever is at lockFile now and decide again.
+          if (renameErr.code !== "ENOENT") {
+            return setError(`Cannot reclaim stale lock ${lockFile}: ${renameErr.message}`);
+          }
+        }
         continue;
       }
       // Live peer install in progress. After it finishes, the install

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -103,11 +103,86 @@ function findAgentChattr(dir) {
  * `installAgentChattr.lastError` so callers can surface it without
  * changing the return shape.
  */
+// Stale-lock thresholds for installAgentChattr().
+// Lock files older than this OR whose owning pid is no longer alive are
+// treated as crashed and reclaimed. Tuned to comfortably exceed the longest
+// step (pip install of agentchattr requirements, ~120s timeout).
+const INSTALL_LOCK_STALE_MS = 10 * 60 * 1000; // 10 min
+const INSTALL_LOCK_WAIT_TOTAL_MS = 30 * 1000;  // wait up to 30s for a peer
+const INSTALL_LOCK_POLL_MS = 500;
+
+function _isPidAlive(pid) {
+  if (!pid || !Number.isFinite(pid)) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (e) { return e.code === "EPERM"; }
+}
+
+function _readLock(lockFile) {
+  try {
+    const raw = fs.readFileSync(lockFile, "utf-8").trim();
+    const [pidStr, tsStr] = raw.split(":");
+    return { pid: parseInt(pidStr, 10), ts: parseInt(tsStr, 10) || 0 };
+  } catch { return null; }
+}
+
+function _isLockStale(lockFile) {
+  const info = _readLock(lockFile);
+  if (!info) return true; // unreadable → assume stale
+  if (Date.now() - info.ts > INSTALL_LOCK_STALE_MS) return true;
+  if (!_isPidAlive(info.pid)) return true;
+  return false;
+}
+
 function installAgentChattr(dir) {
   dir = dir || getAgentChattrDir();
   installAgentChattr.lastError = null;
   const setError = (msg) => { installAgentChattr.lastError = msg; return null; };
 
+  // --- Per-target lock to prevent concurrent clones from corrupting each
+  // other when two projects (or two web tabs) launch simultaneously. Lock
+  // file lives next to the install dir so it's scoped per-target.
+  const lockFile = `${dir}.install.lock`;
+  try { fs.mkdirSync(path.dirname(lockFile), { recursive: true }); }
+  catch (e) { return setError(`Cannot create parent of ${dir}: ${e.message}`); }
+
+  let acquired = false;
+  const deadline = Date.now() + INSTALL_LOCK_WAIT_TOTAL_MS;
+  while (!acquired) {
+    try {
+      // Atomic create: fails if file already exists, no TOCTOU race.
+      fs.writeFileSync(lockFile, `${process.pid}:${Date.now()}`, { flag: "wx" });
+      acquired = true;
+    } catch (e) {
+      if (e.code !== "EEXIST") return setError(`Cannot create install lock ${lockFile}: ${e.message}`);
+      // Reclaim if the existing lock is stale (crashed pid or too old).
+      if (_isLockStale(lockFile)) {
+        try { fs.unlinkSync(lockFile); } catch {}
+        continue;
+      }
+      // Live peer install in progress. After it finishes, the install
+      // is likely already done — caller will see a fully-installed path
+      // on the next call. While waiting, poll until the lock disappears
+      // or we hit the wait deadline.
+      if (Date.now() >= deadline) {
+        const info = _readLock(lockFile) || { pid: "?", ts: 0 };
+        return setError(`Another install is in progress at ${dir} (pid ${info.pid}); timed out after ${INSTALL_LOCK_WAIT_TOTAL_MS}ms. Re-run after it finishes, or remove ${lockFile} if stale.`);
+      }
+      // Synchronous sleep — installAgentChattr is itself synchronous and
+      // is called from the CLI wizard, where blocking is acceptable.
+      // Use execSync('sleep') instead of a busy-wait so we don't pin a CPU.
+      try { require("child_process").execSync(`sleep ${INSTALL_LOCK_POLL_MS / 1000}`); }
+      catch { /* sleep interrupted; loop will recheck */ }
+    }
+  }
+
+  try {
+    return _installAgentChattrLocked(dir, setError);
+  } finally {
+    try { fs.unlinkSync(lockFile); } catch {}
+  }
+}
+
+function _installAgentChattrLocked(dir, setError) {
   const runPy = path.join(dir, "run.py");
   const venvPython = path.join(dir, ".venv", "bin", "python");
   let venvJustCreated = false;


### PR DESCRIPTION
## Summary
Phase 1F (final Phase 1 ticket) of master #181. When two projects launch at once — e.g. two web tabs each kicking off setup — concurrent `installAgentChattr()` calls could race on the same target and corrupt the clone or the venv. This PR adds a per-target lock file to serialize them safely, with proper stale-lock recovery.

Single file: \`bin/quadwork.js\`, +75/−0.

### Implementation
- Lock file at \`\${dir}.install.lock\` — sibling of the install dir, so it's **scoped per-target**: per-project clones at different paths don't block each other.
- **Atomic acquire** via \`fs.writeFileSync(..., {flag: 'wx'})\` — no TOCTOU window between exists-check and create.
- Lock contents: \`\"<pid>:<ts>\"\` so stale detection can use either pid liveness (\`process.kill(pid, 0)\`) or age.
- **Stale reclaim**: if the holding pid is dead OR the lock is older than 10 min, the lock is removed and acquisition retries immediately.
- **Wait policy** for live peers: poll every 500 ms (via \`execSync sleep\`, not busy-wait) for up to 30 s, then return \`null\` with a clear \`lastError\` naming the holder pid and the lock path.
- Lock is **always** released in a \`finally\` block — success and failure both clean up.
- Existing install body moved verbatim into \`_installAgentChattrLocked()\` so the lock wrapper adds zero behavioral risk to the install steps themselves.

## Acceptance criteria from #187
- ✅ Two simultaneous calls to the same dir serialize via the lock and don't corrupt each other.
- ✅ Stale lock from a crashed process doesn't permanently block: pid-liveness check + 10 min age fallback.
- ✅ Lock is cleaned up after success or failure (try/finally).

## Test plan
- [ ] Manual: kick off two \`installAgentChattr('/tmp/qw-lock-test/agentchattr')\` calls back-to-back from two terminals; verify the second waits/then no-ops on a fully-installed path.
- [ ] Manual: write a fake stale lock (\`echo \"99999:0\" > /tmp/qw-lock-test/agentchattr.install.lock\`) and verify the next install reclaims it.
- [ ] Manual: write a live-pid lock (\`echo \"$$:$(date +%s)000\" > …\`) and verify install waits + then errors with the holder pid in the message after 30 s.
- [ ] Existing flows (\`cmdInit\`, single-project install) still succeed on a clean machine — lock create/release is invisible.

Fixes #187
Parent: #181