### PR TITLE
[#184] CLI wizard clones AgentChattr per-project on add

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1469,7 +1469,11 @@ async function cmdAddProject() {
 
     writeQuadWorkConfig(setup);
 
-    const configTomlPath = path.join(setup.absDir, "agentchattr", "config.toml");
+    // Phase 2C / #181: config.toml lives at the per-project clone ROOT
+    // because AgentChattr's run.py loads ROOT/config.toml and ignores
+    // --config. Must match the install path used inside
+    // writeAgentChattrConfig(): CONFIG_DIR/{projectName}/agentchattr.
+    const configTomlPath = path.join(CONFIG_DIR, setup.projectName, "agentchattr", "config.toml");
     writeAgentChattrConfig(setup, configTomlPath);
 
     header("Project Added");

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -929,25 +929,33 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
   fs.writeFileSync(configTomlPath, tomlContent);
   ok(`Wrote ${configTomlPath}`);
 
-  // Start AgentChattr if available; optionally skip install attempt
-  const acDir = findAgentChattr();
+  // Phase 2C / #181: clone AgentChattr per-project at
+  // ~/.quadwork/{project_id}/agentchattr/. AgentChattr's run.py loads
+  // ROOT/config.toml, so each project needs its own clone to avoid
+  // multi-instance port conflicts (see master #181). The path is the
+  // same one writeQuadWorkConfig() persists in project.agentchattr_dir.
+  const perProjectDir = path.join(CONFIG_DIR, setup.projectName, "agentchattr");
+  let acDir = findAgentChattr(perProjectDir);
   let acAvailable = !!acDir;
   if (!acAvailable && !skipInstall) {
-    const acSpinner = spinner("Setting up AgentChattr...");
-    const installResult = installAgentChattr();
+    const acSpinner = spinner(`Setting up AgentChattr at ${perProjectDir}...`);
+    const installResult = installAgentChattr(perProjectDir);
     if (installResult) {
       acSpinner.stop(true);
+      acDir = installResult;
       acAvailable = true;
     } else {
       acSpinner.stop(false);
-      warn(`Install manually: git clone ${AGENTCHATTR_REPO} ${DEFAULT_AGENTCHATTR_DIR}`);
+      const reason = installAgentChattr.lastError || "unknown error";
+      warn(`AgentChattr install failed at ${perProjectDir}: ${reason}`);
+      warn(`Install manually: git clone ${AGENTCHATTR_REPO} ${perProjectDir}`);
     }
   }
 
   // Start AgentChattr server (only if installed)
   if (acAvailable) {
     log("Starting AgentChattr server...");
-    const acSpawn = chattrSpawnArgs(findAgentChattr(), ["--config", configTomlPath]);
+    const acSpawn = chattrSpawnArgs(acDir, ["--config", configTomlPath]);
     if (acSpawn) {
       const acProc = spawn(acSpawn.command, acSpawn.spawnArgs, {
         cwd: acSpawn.cwd,
@@ -964,14 +972,14 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
         const pidFile = path.join(CONFIG_DIR, `agentchattr-${setup.projectName}.pid`);
         fs.writeFileSync(pidFile, String(acProc.pid));
       } else {
-        warn("Could not start AgentChattr — check logs in " + (findAgentChattr() || DEFAULT_AGENTCHATTR_DIR));
+        warn("Could not start AgentChattr — check logs in " + (acDir || perProjectDir));
       }
     } else {
       warn("AgentChattr run.py not found — skipping auto-start.");
     }
   } else {
     warn("AgentChattr not installed — skipping auto-start.");
-    log(`  → Install: git clone ${AGENTCHATTR_REPO} ${DEFAULT_AGENTCHATTR_DIR}`);
+    log(`  → Install: git clone ${AGENTCHATTR_REPO} ${perProjectDir}`);
   }
 
   return configTomlPath;


### PR DESCRIPTION
## Summary
Phase 2C of master #181. \`writeAgentChattrConfig()\` in \`bin/quadwork.js\` previously installed and spawned AgentChattr from the legacy global path. Switch it to use the per-project dir at \`~/.quadwork/{project_id}/agentchattr/\` — the same path \`writeQuadWorkConfig()\` already persists in \`project.agentchattr_dir\` (added in #182).

Single file: \`bin/quadwork.js\`, +16/−8.

### Changes
- \`writeAgentChattrConfig()\` now resolves \`perProjectDir = path.join(CONFIG_DIR, setup.projectName, \"agentchattr\")\` and threads it through \`findAgentChattr(perProjectDir)\` → \`installAgentChattr(perProjectDir)\` → \`chattrSpawnArgs(acDir, ...)\`. The legacy global path is no longer read in this function.
- Install failure now surfaces \`installAgentChattr.lastError\` (added in #183) so users see *why* a clone failed instead of a generic warning.
- \"Install manually\" hint and the \"could not start\" log now point at the per-project dir, not \`DEFAULT_AGENTCHATTR_DIR\`.
- \`writeQuadWorkConfig()\` unchanged — has written \`agentchattr_dir\` per project since #182.

### Out of scope
- \`cmdStart()\` / \`spawnChattr()\` still resolve via the legacy global path. That lands in **#186 (sub-E)**. Until #186 ships, the runtime fallback added in #182 (`resolveProjectChattr()` falls back to legacy global if the per-project dir lacks `run.py`) keeps existing v1 setups working — and *new* projects created via this PR get a real per-project clone, so the fallback isn't taken for them.

## Acceptance criteria from #184
- ✅ \`npx quadwork init\` (or \`add-project\`) creates \`~/.quadwork/{id}/agentchattr/\` for the new project.
- ✅ \`~/.quadwork/{id}/agentchattr/config.toml\` is the wizard's templated copy with the project's ports (templated by the existing block above this PR's diff — unchanged).
- ✅ The project's \`config.json\` entry has \`agentchattr_dir\` pointing to that location (already true since #182).
- ✅ Spawn from the new location works in the same call (we now pass \`acDir\` directly to \`chattrSpawnArgs\`).

## Test plan
- [ ] \`npx quadwork add-project\` for a new project \"foo\"; verify \`~/.quadwork/foo/agentchattr/run.py\` exists and \`config.json\` entry has \`agentchattr_dir: ~/.quadwork/foo/agentchattr\`.
- [ ] Verify the spawned AgentChattr cwd is \`~/.quadwork/foo/agentchattr\` (not the legacy global) — e.g. \`lsof -p <pid>\` or \`pwdx\`.
- [ ] Add a second project \"bar\"; verify both \`~/.quadwork/foo\` and \`~/.quadwork/bar\` clones exist independently and can coexist on different ports.
- [ ] Re-run \`add-project\` for an existing project name; verify the second call is a no-op on the install (Phase 1B/1F idempotency + lock still hold).
- [ ] On a host with a live legacy global install but no per-project dir for a new project, verify the new project still gets its own clone (no shortcut to legacy).

Fixes #184
Parent: #181