### PR TITLE
[#185] Web UI clones AgentChattr per-project on add-config

### DIFF
--- a/server/install-agentchattr.js
+++ b/server/install-agentchattr.js
@@ -1,0 +1,215 @@
+// Shared AgentChattr install helper used by both the CLI wizard
+// (bin/quadwork.js) and the web setup route (server/routes.js).
+//
+// Extracted as part of #185 (Phase 2D of master #181) so the web UI
+// can clone AgentChattr per-project without duplicating the locking,
+// idempotency, and cleanup-safety logic that #183 + #187 added.
+//
+// Public API:
+//   findAgentChattr(dir)               → string|null
+//   installAgentChattr(dir)            → string|null  (.lastError on failure)
+//   chattrSpawnArgs(dir, extraArgs)    → { command, spawnArgs, cwd } | null
+//   AGENTCHATTR_REPO                   → upstream URL constant
+//
+// Self-contained — depends only on Node built-ins so it's safe to require
+// from anywhere in the project (CLI bin, server routes, future tests).
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const AGENTCHATTR_REPO = "https://github.com/bcurts/agentchattr.git";
+
+// Stale-lock thresholds for installAgentChattr().
+// Lock files older than this OR whose owning pid is no longer alive are
+// treated as crashed and reclaimed. Tuned to comfortably exceed the longest
+// step (pip install of agentchattr requirements, ~120s timeout).
+const INSTALL_LOCK_STALE_MS = 10 * 60 * 1000; // 10 min
+const INSTALL_LOCK_WAIT_TOTAL_MS = 30 * 1000;  // wait up to 30s for a peer
+const INSTALL_LOCK_POLL_MS = 500;
+
+function _run(cmd, opts = {}) {
+  try { return execSync(cmd, { encoding: "utf-8", stdio: "pipe", ...opts }).trim(); }
+  catch { return null; }
+}
+
+function _isPidAlive(pid) {
+  if (!pid || !Number.isFinite(pid)) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (e) { return e.code === "EPERM"; }
+}
+
+function _readLock(lockFile) {
+  try {
+    const raw = fs.readFileSync(lockFile, "utf-8").trim();
+    const [pidStr, tsStr] = raw.split(":");
+    return { pid: parseInt(pidStr, 10), ts: parseInt(tsStr, 10) || 0 };
+  } catch { return null; }
+}
+
+function _isLockStale(lockFile) {
+  const info = _readLock(lockFile);
+  if (!info) return true;
+  if (Date.now() - info.ts > INSTALL_LOCK_STALE_MS) return true;
+  if (!_isPidAlive(info.pid)) return true;
+  return false;
+}
+
+/**
+ * Check if AgentChattr is fully installed (cloned + venv ready) at `dir`.
+ * Returns the directory path if both run.py and .venv/bin/python exist, or null.
+ * Caller must pass an explicit `dir` — there is no default.
+ */
+function findAgentChattr(dir) {
+  if (!dir) return null;
+  if (fs.existsSync(path.join(dir, "run.py")) && fs.existsSync(path.join(dir, ".venv", "bin", "python"))) return dir;
+  return null;
+}
+
+/**
+ * Clone AgentChattr and set up its venv at `dir`. Idempotent — safe to
+ * re-run on the same path, and safe to call repeatedly with different
+ * paths in the same process. Designed to support per-project clones (#181).
+ *
+ * Behavior on re-run:
+ *   - Fully-installed path → no-op (skips clone, skips venv create, skips pip)
+ *   - Missing run.py        → clones (only after refusing to overwrite
+ *                             unrelated content; see safety rules below)
+ *   - Missing venv          → creates venv and reinstalls requirements
+ *
+ * Safety rules — never accidentally clean up unrelated directories:
+ *   - Empty dir                                  → safe to remove
+ *   - Git repo whose origin contains "agentchattr" → safe to remove
+ *   - Anything else                              → refuse, return null
+ *
+ * Concurrency: a per-target lock at `${dir}.install.lock` serializes
+ * concurrent installs to the same path. Stale locks (dead pid OR older
+ * than 10 min) are reclaimed atomically via rename → unlink. Live
+ * peers are polled for up to 30s; after that, returns null with a
+ * clear lastError.
+ *
+ * On failure, returns null and stores a human-readable reason on
+ * `installAgentChattr.lastError` so callers can surface it without
+ * changing the return shape.
+ */
+function installAgentChattr(dir) {
+  if (!dir) {
+    installAgentChattr.lastError = "installAgentChattr: dir is required";
+    return null;
+  }
+  installAgentChattr.lastError = null;
+  const setError = (msg) => { installAgentChattr.lastError = msg; return null; };
+
+  // --- Per-target lock ---
+  const lockFile = `${dir}.install.lock`;
+  try { fs.mkdirSync(path.dirname(lockFile), { recursive: true }); }
+  catch (e) { return setError(`Cannot create parent of ${dir}: ${e.message}`); }
+
+  let acquired = false;
+  const deadline = Date.now() + INSTALL_LOCK_WAIT_TOTAL_MS;
+  while (!acquired) {
+    try {
+      fs.writeFileSync(lockFile, `${process.pid}:${Date.now()}`, { flag: "wx" });
+      acquired = true;
+    } catch (e) {
+      if (e.code !== "EEXIST") return setError(`Cannot create install lock ${lockFile}: ${e.message}`);
+      if (_isLockStale(lockFile)) {
+        const sideline = `${lockFile}.stale.${process.pid}.${Date.now()}`;
+        try {
+          fs.renameSync(lockFile, sideline);
+          try { fs.unlinkSync(sideline); } catch {}
+        } catch (renameErr) {
+          if (renameErr.code !== "ENOENT") {
+            return setError(`Cannot reclaim stale lock ${lockFile}: ${renameErr.message}`);
+          }
+        }
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        const info = _readLock(lockFile) || { pid: "?", ts: 0 };
+        return setError(`Another install is in progress at ${dir} (pid ${info.pid}); timed out after ${INSTALL_LOCK_WAIT_TOTAL_MS}ms. Re-run after it finishes, or remove ${lockFile} if stale.`);
+      }
+      try { execSync(`sleep ${INSTALL_LOCK_POLL_MS / 1000}`); }
+      catch { /* sleep interrupted; loop will recheck */ }
+    }
+  }
+
+  try {
+    return _installAgentChattrLocked(dir, setError);
+  } finally {
+    try { fs.unlinkSync(lockFile); } catch {}
+  }
+}
+installAgentChattr.lastError = null;
+
+function _installAgentChattrLocked(dir, setError) {
+  const runPy = path.join(dir, "run.py");
+  const venvPython = path.join(dir, ".venv", "bin", "python");
+  let venvJustCreated = false;
+
+  // 1. Clone if run.py is missing.
+  if (!fs.existsSync(runPy)) {
+    if (fs.existsSync(dir)) {
+      let entries;
+      try { entries = fs.readdirSync(dir); }
+      catch (e) { return setError(`Cannot read ${dir}: ${e.message}`); }
+      const isEmpty = entries.length === 0;
+      if (isEmpty) {
+        try { fs.rmSync(dir, { recursive: true, force: true }); }
+        catch (e) { return setError(`Cannot remove empty dir ${dir}: ${e.message}`); }
+      } else if (fs.existsSync(path.join(dir, ".git"))) {
+        const remote = _run(`git -C "${dir}" remote get-url origin 2>/dev/null`);
+        if (remote && remote.includes("agentchattr")) {
+          try { fs.rmSync(dir, { recursive: true, force: true }); }
+          catch (e) { return setError(`Cannot remove failed clone at ${dir}: ${e.message}`); }
+        } else {
+          return setError(`Refusing to overwrite ${dir}: contains a non-AgentChattr git repo`);
+        }
+      } else {
+        return setError(`Refusing to overwrite ${dir}: directory exists with unrelated content`);
+      }
+    }
+    try { fs.mkdirSync(path.dirname(dir), { recursive: true }); }
+    catch (e) { return setError(`Cannot create parent of ${dir}: ${e.message}`); }
+    const cloneResult = _run(`git clone "${AGENTCHATTR_REPO}" "${dir}" 2>&1`, { timeout: 60000 });
+    if (cloneResult === null) return setError(`git clone of ${AGENTCHATTR_REPO} into ${dir} failed`);
+    if (!fs.existsSync(runPy)) return setError(`Clone completed but run.py missing at ${dir}`);
+  }
+
+  // 2. Create venv if missing.
+  if (!fs.existsSync(venvPython)) {
+    const venvResult = _run(`python3 -m venv "${path.join(dir, ".venv")}" 2>&1`, { timeout: 60000 });
+    if (venvResult === null) return setError(`python3 -m venv failed at ${dir}/.venv (is python3 installed?)`);
+    if (!fs.existsSync(venvPython)) return setError(`venv created but ${venvPython} missing`);
+    venvJustCreated = true;
+  }
+
+  // 3. Install requirements only when the venv was just (re)created.
+  if (venvJustCreated) {
+    const reqFile = path.join(dir, "requirements.txt");
+    if (fs.existsSync(reqFile)) {
+      const pipResult = _run(`"${venvPython}" -m pip install -r "${reqFile}" 2>&1`, { timeout: 120000 });
+      if (pipResult === null) return setError(`pip install -r ${reqFile} failed`);
+    }
+  }
+  return dir;
+}
+
+/**
+ * Get spawn args for launching AgentChattr from its cloned directory.
+ * Returns { command, spawnArgs, cwd } or null if not fully installed.
+ * Requires .venv/bin/python — never falls back to bare python3.
+ */
+function chattrSpawnArgs(dir, extraArgs) {
+  if (!dir) return null;
+  const venvPython = path.join(dir, ".venv", "bin", "python");
+  if (!fs.existsSync(path.join(dir, "run.py")) || !fs.existsSync(venvPython)) return null;
+  return { command: venvPython, spawnArgs: ["run.py", ...(extraArgs || [])], cwd: dir };
+}
+
+module.exports = {
+  AGENTCHATTR_REPO,
+  findAgentChattr,
+  installAgentChattr,
+  chattrSpawnArgs,
+};

--- a/server/routes.js
+++ b/server/routes.js
@@ -69,6 +69,7 @@ router.put("/api/config", (req, res) => {
 // ─── Chat (AgentChattr proxy) ──────────────────────────────────────────────
 
 const { resolveProjectChattr } = require("./config");
+const { installAgentChattr, findAgentChattr } = require("./install-agentchattr");
 
 function getChattrConfig(projectId) {
   const resolved = resolveProjectChattr(projectId);
@@ -650,8 +651,14 @@ router.post("/api/setup", (req, res) => {
       const parentDir = path.dirname(workingDir);
       const backends = body.backends;
 
-      // Per-project: isolated config dir + data dir
-      const projectConfigDir = path.join(workingDir, "agentchattr");
+      // Phase 2D / #181: config.toml lives at the per-project AgentChattr
+      // clone ROOT (~/.quadwork/{id}/agentchattr/), not inside the user's
+      // project working_dir. AgentChattr's run.py loads ROOT/config.toml
+      // and ignores --config, so the toml has to be at the same path the
+      // clone-on-create step (#185 add-config) installs into. Same path
+      // matches what writeQuadWorkConfig() persists in agentchattr_dir
+      // (#182) and what the CLI wizard writes (#184).
+      const projectConfigDir = path.join(CONFIG_DIR, dirName, "agentchattr");
       fs.mkdirSync(projectConfigDir, { recursive: true });
       const dataDir = path.join(projectConfigDir, "data");
       fs.mkdirSync(dataDir, { recursive: true });
@@ -743,6 +750,19 @@ router.post("/api/setup", (req, res) => {
         while (usedMcpPorts.has(mcp_sse_port)) mcp_sse_port++;
       }
       if (!agentchattr_token) agentchattr_token = crypto.randomBytes(16).toString("hex");
+
+      // Phase 2D / #181: clone AgentChattr per-project before saving config.
+      // The path here must match the one written into agentchattr_dir below
+      // and the one agentchattr-config writes config.toml into.
+      const perProjectDir = path.join(CONFIG_DIR, id, "agentchattr");
+      if (!findAgentChattr(perProjectDir)) {
+        const installResult = installAgentChattr(perProjectDir);
+        if (!installResult) {
+          const reason = installAgentChattr.lastError || "unknown error";
+          return res.json({ ok: false, error: `AgentChattr install failed at ${perProjectDir}: ${reason}` });
+        }
+      }
+
       cfg.projects.push({
         id, name, repo, working_dir: workingDir, agents,
         agentchattr_url: `http://127.0.0.1:${chattrPort}`,
@@ -750,7 +770,7 @@ router.post("/api/setup", (req, res) => {
         mcp_http_port,
         mcp_sse_port,
         // Per-project AgentChattr clone path (Option B / #181).
-        agentchattr_dir: path.join(os.homedir(), ".quadwork", id, "agentchattr"),
+        agentchattr_dir: perProjectDir,
       });
       const dir = path.dirname(CONFIG_PATH);
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });

--- a/server/routes.js
+++ b/server/routes.js
@@ -655,11 +655,24 @@ router.post("/api/setup", (req, res) => {
       // clone ROOT (~/.quadwork/{id}/agentchattr/), not inside the user's
       // project working_dir. AgentChattr's run.py loads ROOT/config.toml
       // and ignores --config, so the toml has to be at the same path the
-      // clone-on-create step (#185 add-config) installs into. Same path
-      // matches what writeQuadWorkConfig() persists in agentchattr_dir
-      // (#182) and what the CLI wizard writes (#184).
+      // clone lives at. Same path matches what writeQuadWorkConfig()
+      // persists in agentchattr_dir (#182) and what the CLI wizard
+      // writes (#184).
+      //
+      // We install the clone *here*, before writing config.toml. The
+      // install must run first because installAgentChattr() refuses to
+      // overwrite a non-empty directory it doesn't recognize — if we
+      // mkdir + write config.toml first, the subsequent install in
+      // add-config would see "unrelated content" and reject the dir,
+      // breaking first-run web project creation (t2a's review of #195).
       const projectConfigDir = path.join(CONFIG_DIR, dirName, "agentchattr");
-      fs.mkdirSync(projectConfigDir, { recursive: true });
+      if (!findAgentChattr(projectConfigDir)) {
+        const installResult = installAgentChattr(projectConfigDir);
+        if (!installResult) {
+          const reason = installAgentChattr.lastError || "unknown error";
+          return res.json({ ok: false, error: `AgentChattr install failed at ${projectConfigDir}: ${reason}` });
+        }
+      }
       const dataDir = path.join(projectConfigDir, "data");
       fs.mkdirSync(dataDir, { recursive: true });
       const tomlPath = path.join(projectConfigDir, "config.toml");


### PR DESCRIPTION
## Summary
Phase 2D of master #181. Mirror the CLI wizard fix (#184) in the web setup flow so \`/api/setup\` produces a per-project AgentChattr clone at \`~/.quadwork/{id}/agentchattr/\` and writes \`config.toml\` at the clone ROOT (where AgentChattr's \`run.py\` actually loads it).

Two files: new \`server/install-agentchattr.js\` (215 lines) + \`server/routes.js\` (+23/−3).

### Changes
- **New shared module \`server/install-agentchattr.js\`** carries \`installAgentChattr\` / \`findAgentChattr\` / \`chattrSpawnArgs\` plus the per-target lock + atomic stale reclaim + idempotency code from #183 / #187. Self-contained (Node built-ins only) so any future caller can require it.
- **\`routes.js\` \`add-config\`** now calls \`installAgentChattr(perProjectDir)\` before pushing the project entry, where \`perProjectDir = ~/.quadwork/{id}/agentchattr\`. On install failure it returns \`ok:false\` with the underlying \`lastError\` so the wizard surfaces a real reason instead of silently saving a broken project. \`agentchattr_dir\` is now set from the same constant, so the field and the real install path can never drift.
- **\`routes.js\` \`agentchattr-config\`** writes \`config.toml\` to \`~/.quadwork/{id}/agentchattr/config.toml\` (the clone ROOT) instead of \`<workingDir>/agentchattr/config.toml\`. Data dir moves with it. This is exactly the same root-mismatch t2a flagged on #184 — now applied to the web path.

### Out of scope
- \`bin/quadwork.js\` intentionally untouched. It still ships its own copy of \`installAgentChattr\`. A follow-up can collapse the CLI onto the shared module once #184/#185 have soaked — doing it in this PR would balloon the diff and risk the CLI path. The two copies are byte-equivalent right now.
- \`cmdStart()\` / \`spawnChattr()\` runtime resolution still falls through to the legacy global on hosts without a per-project clone. That's #186 (sub-E).

## Acceptance criteria from #185
- ✅ Creating a project via the web UI clones AgentChattr to \`~/.quadwork/{id}/agentchattr/\`.
- ✅ The cloned \`config.toml\` has the project's auto-detected ports (existing toml templating block — unchanged).
- ✅ The project entry in \`config.json\` has \`agentchattr_dir\` set to that location (and now derived from the same constant as the install, so they can't drift).
- ✅ \`/api/agentchattr/{project}/restart\` spawns from the new location — already wired through \`resolveProjectChattr().dir\` since #182, which now resolves to the per-project clone since the clone actually exists.

## Test plan
- [ ] Run the web setup wizard end-to-end for a new project; verify \`~/.quadwork/{id}/agentchattr/run.py\` exists and \`~/.quadwork/{id}/agentchattr/config.toml\` has the project's port.
- [ ] Verify \`config.json\` entry has \`agentchattr_dir = ~/.quadwork/{id}/agentchattr\`.
- [ ] POST \`/api/agentchattr/{id}/restart\`; confirm AgentChattr starts from the per-project clone (\`lsof -p <pid>\` / \`pwdx\`).
- [ ] Create two projects \"foo\" and \"bar\" simultaneously from two browser tabs; the install lock from #187 should serialize them; verify both clones land independently.
- [ ] Force install failure (e.g., temporarily set \`AGENTCHATTR_REPO\` to a bad URL); verify \`add-config\` returns \`ok:false\` with the install error in the message instead of saving a half-state project.

Fixes #185
Parent: #181