### PR TITLE
[#186] cmdStart + spawnChattr resolve per-project agentchattr_dir

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1349,27 +1349,38 @@ function cmdStart() {
     process.exit(1);
   }
 
-  // Start AgentChattr for each project that has a config.toml
+  // Start AgentChattr for each project from its own per-project clone.
+  // Phase 2E / #181: each project entry now has agentchattr_dir, set by
+  // the wizards in #184/#185. Resolve per-project so two projects with
+  // their own clones (and their own ports) can run side by side without
+  // sharing a single global install. Falls back to the legacy global
+  // install dir for v1 entries that have not been migrated yet (#188).
   const acPids = [];
-  const acDir = findAgentChattr(config.agentchattr_dir);
-  if (acDir) {
-    for (const project of config.projects) {
-      if (!project.working_dir) continue;
-      const configToml = path.join(project.working_dir, "agentchattr", "config.toml");
-      if (!fs.existsSync(configToml)) continue;
-      const acSpawn = chattrSpawnArgs(acDir, ["--config", configToml]);
-      if (!acSpawn) continue;
-      const acProc = spawn(acSpawn.command, acSpawn.spawnArgs, {
-        cwd: acSpawn.cwd,
-        stdio: "ignore",
-        detached: true,
-      });
-      acProc.on("error", () => {});
-      acProc.unref();
-      if (acProc.pid) {
-        ok(`AgentChattr started for ${project.id} (PID: ${acProc.pid})`);
-        acPids.push(acProc.pid);
-      }
+  const legacyAcDir = findAgentChattr(config.agentchattr_dir);
+  for (const project of config.projects) {
+    if (!project.working_dir) continue;
+    const projectAcDir = findAgentChattr(project.agentchattr_dir) || legacyAcDir;
+    if (!projectAcDir) continue;
+    // config.toml lives at the clone ROOT for new projects; legacy v1
+    // setups still keep it under <working_dir>/agentchattr/config.toml.
+    const perProjectToml = path.join(projectAcDir, "config.toml");
+    const legacyToml = path.join(project.working_dir, "agentchattr", "config.toml");
+    const configToml = fs.existsSync(perProjectToml)
+      ? perProjectToml
+      : (fs.existsSync(legacyToml) ? legacyToml : null);
+    if (!configToml) continue;
+    const acSpawn = chattrSpawnArgs(projectAcDir, ["--config", configToml]);
+    if (!acSpawn) continue;
+    const acProc = spawn(acSpawn.command, acSpawn.spawnArgs, {
+      cwd: acSpawn.cwd,
+      stdio: "ignore",
+      detached: true,
+    });
+    acProc.on("error", () => {});
+    acProc.unref();
+    if (acProc.pid) {
+      ok(`AgentChattr started for ${project.id} from ${projectAcDir} (PID: ${acProc.pid})`);
+      acPids.push(acProc.pid);
     }
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -398,12 +398,21 @@ async function handleAgentChattr(req, res) {
   const { url: chattrUrl } = resolveProjectChattr(projectId);
   const chattrPort = new URL(chattrUrl).port || "8300";
 
-  // Find per-project config.toml (prefer project working_dir/agentchattr/config.toml)
+  // Find per-project config.toml. Phase 2E / #181: prefer the
+  // per-project AgentChattr clone ROOT (where the web/CLI wizards now
+  // write it as of #184/#185 — and where run.py actually reads it from).
+  // Fall back to the legacy <working_dir>/agentchattr/config.toml for
+  // v1 setups that haven't been migrated yet (#188).
   const cfg = readConfig();
   const project = cfg.projects?.find((p) => p.id === projectId);
-  const projectConfigToml = project?.working_dir
-    ? path.join(project.working_dir, "agentchattr", "config.toml")
-    : null;
+  const { dir: resolvedAcDir } = resolveProjectChattr(projectId);
+  let projectConfigToml = null;
+  if (resolvedAcDir && fs.existsSync(path.join(resolvedAcDir, "config.toml"))) {
+    projectConfigToml = path.join(resolvedAcDir, "config.toml");
+  } else if (project?.working_dir) {
+    const legacyToml = path.join(project.working_dir, "agentchattr", "config.toml");
+    if (fs.existsSync(legacyToml)) projectConfigToml = legacyToml;
+  }
 
   function getProc() {
     return chattrProcesses.get(projectId) || { process: null, state: "stopped", error: null };


### PR DESCRIPTION
## Summary
Phase 2E of master #181. Both runtime spawn paths now resolve AgentChattr from each project's own per-project clone instead of a single global install — closing the multi-instance port-conflict loop that the whole batch is built around. After this PR, two projects with their own \`agentchattr_dir\` and ports can run side by side.

Two files: \`server/index.js\` (+13/−4) + \`bin/quadwork.js\` (+30/−19).

### \`server/index.js\` \`spawnChattr()\`
- The function already used \`resolveProjectChattr().dir\` for the AgentChattr install (since #182), so the install side was already per-project. The bug: \`projectConfigToml\` was still hard-coded to \`<working_dir>/agentchattr/config.toml\` — the legacy in-worktree path. After #184/#185, the wizards write \`config.toml\` at the per-project clone ROOT (\`~/.quadwork/{id}/agentchattr/config.toml\`), and AgentChattr's \`run.py\` reads \`ROOT/config.toml\` from there.
- Update \`projectConfigToml\` to prefer the resolved per-project clone toml, with the legacy in-worktree path as a v1 fallback. \`regenerateConfigToml()\` now updates the right file.

### \`bin/quadwork.js\` \`cmdStart()\`
- Replace the single \`findAgentChattr(config.agentchattr_dir)\` lookup before the loop with a **per-project** resolve inside the loop: \`findAgentChattr(project.agentchattr_dir) || legacyAcDir\`.
- \`config.toml\` resolution mirrors the server path: prefer per-project clone ROOT, fall back to \`<working_dir>/agentchattr/config.toml\` for v1 setups.
- Status line now logs the clone path so it's obvious which install each project is starting from.

### Backward compatibility
- v1 setups (no \`project.agentchattr_dir\`, no per-project clone) still use the legacy global \`findAgentChattr(config.agentchattr_dir)\` and the legacy in-worktree \`config.toml\`. The fallback ladder is: per-project clone → legacy global. Migration of v1 entries to per-project lands in **#188 (sub-G)**.
- New projects created via #184 (CLI) or #185 (web) already have a real per-project clone, so they take the new path immediately.

## Acceptance criteria from #186
- ✅ \`npx quadwork start\` spawns each project's AgentChattr from its own per-project clone (verified by the new status line).
- ✅ Two projects starting in parallel use their own clones (each loop iteration calls \`chattrSpawnArgs\` with that project's resolved \`projectAcDir\`).
- ✅ Each AgentChattr instance binds to its own ports without collision (each clone reads its own \`ROOT/config.toml\`).

## Test plan
- [ ] Create two projects \"foo\" and \"bar\" via the wizard. Run \`npx quadwork start\`. Verify the log shows each project starting from its own \`~/.quadwork/foo/agentchattr\` / \`~/.quadwork/bar/agentchattr\` and the two AgentChattr processes bind to different ports without EADDRINUSE.
- [ ] On a v1 host with no \`project.agentchattr_dir\`, run \`npx quadwork start\`. Verify it still falls back to the legacy global install and the legacy in-worktree \`config.toml\`.
- [ ] Trigger \`/api/agentchattr/{id}/restart\` on a per-project setup. Verify \`spawnChattr()\` regenerates the per-project clone toml (not the legacy in-worktree one) before relaunching.

Fixes #186
Parent: #181