### PR TITLE
[#188] Migrate legacy v1 projects to per-project AgentChattr clones

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1324,6 +1324,94 @@ async function cmdInit() {
 
 // ─── Start Command ──────────────────────────────────────────────────────────
 
+/**
+ * Phase 3 / #181 sub-G: migrate legacy v1 projects to per-project clones.
+ *
+ * Runs eagerly at the top of cmdStart() so users see clear progress before
+ * any agents launch. For each project that doesn't yet have a working
+ * per-project clone:
+ *   1. Compute perProjectDir = ~/.quadwork/{project_id}/agentchattr
+ *   2. installAgentChattr(perProjectDir) — idempotent (#183 + #187)
+ *   3. Copy the existing legacy <working_dir>/agentchattr/config.toml into
+ *      the new clone ROOT if it exists. AgentChattr's run.py reads
+ *      ROOT/config.toml from the clone dir, so this is what makes the
+ *      project actually start from its own clone.
+ *   4. Set project.agentchattr_dir on the config entry and persist.
+ *
+ * Idempotent: if a project already has a working per-project clone with a
+ * config.toml at the ROOT and agentchattr_dir set, it is skipped silently.
+ * The legacy ~/.quadwork/agentchattr/ install is left alone — cleanup is
+ * sub-H (#189).
+ *
+ * The migration never touches worktrees, repo content, or token files;
+ * only the per-project AgentChattr install dir and config.json.
+ */
+function migrateLegacyProjects(config) {
+  if (!config.projects || config.projects.length === 0) return false;
+
+  const needsMigration = config.projects.filter((p) => {
+    if (!p.id) return false;
+    const target = p.agentchattr_dir || path.join(CONFIG_DIR, p.id, "agentchattr");
+    const hasClone = fs.existsSync(path.join(target, "run.py")) &&
+                     fs.existsSync(path.join(target, ".venv", "bin", "python"));
+    const hasToml = fs.existsSync(path.join(target, "config.toml"));
+    const hasField = !!p.agentchattr_dir;
+    return !(hasField && hasClone && hasToml);
+  });
+
+  if (needsMigration.length === 0) return false;
+
+  header("Migrating legacy projects to per-project AgentChattr clones");
+  let mutated = false;
+  for (const project of needsMigration) {
+    const perProjectDir = path.join(CONFIG_DIR, project.id, "agentchattr");
+    log(`  ${project.id} → ${perProjectDir}`);
+
+    // 1. Install (idempotent — no-op if clone is already valid).
+    if (!findAgentChattr(perProjectDir)) {
+      const acSpinner = spinner(`    Cloning AgentChattr for ${project.id}...`);
+      const installResult = installAgentChattr(perProjectDir);
+      if (!installResult) {
+        acSpinner.stop(false);
+        const reason = installAgentChattr.lastError || "unknown error";
+        warn(`    Migration failed for ${project.id}: ${reason}`);
+        warn(`    ${project.id} will keep using the legacy global install until this is resolved.`);
+        continue;
+      }
+      acSpinner.stop(true);
+    }
+
+    // 2. Seed config.toml at the clone ROOT from the legacy in-worktree
+    //    location if present. Do not overwrite an existing per-project
+    //    config.toml — re-running the migration must be a no-op.
+    const targetToml = path.join(perProjectDir, "config.toml");
+    if (!fs.existsSync(targetToml) && project.working_dir) {
+      const legacyToml = path.join(project.working_dir, "agentchattr", "config.toml");
+      if (fs.existsSync(legacyToml)) {
+        try {
+          fs.copyFileSync(legacyToml, targetToml);
+          log(`    Copied legacy config.toml → ${targetToml}`);
+        } catch (e) {
+          warn(`    Could not copy ${legacyToml}: ${e.message}`);
+        }
+      }
+    }
+
+    // 3. Persist agentchattr_dir on the project entry.
+    if (project.agentchattr_dir !== perProjectDir) {
+      project.agentchattr_dir = perProjectDir;
+      mutated = true;
+    }
+  }
+
+  if (mutated) {
+    try { writeConfig(config); ok("Updated config.json with per-project agentchattr_dir entries"); }
+    catch (e) { warn(`Failed to write config.json: ${e.message}`); }
+  }
+  log("  Legacy ~/.quadwork/agentchattr/ left in place; remove via cleanup script (#189).");
+  return true;
+}
+
 function cmdStart() {
   console.log("\n  QuadWork Start\n");
 
@@ -1331,6 +1419,11 @@ function cmdStart() {
   if (config.projects.length === 0) {
     warn("No projects configured yet. Create one at the setup page.");
   }
+
+  // Phase 3 / #181: migrate legacy single-install projects to their
+  // own per-project clones before any AgentChattr spawn happens.
+  // Idempotent — a no-op once every project already has a working clone.
+  migrateLegacyProjects(config);
 
   const quadworkDir = path.join(__dirname, "..");
   const port = config.port || 8400;

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1384,20 +1384,44 @@ function migrateLegacyProjects(config) {
     // 2. Seed config.toml at the clone ROOT from the legacy in-worktree
     //    location if present. Do not overwrite an existing per-project
     //    config.toml — re-running the migration must be a no-op.
+    //
+    //    If the legacy toml exists but the copy fails, we MUST NOT persist
+    //    agentchattr_dir — otherwise #186's resolver would switch this
+    //    project to a clone that lacks the project's real ports, and
+    //    AgentChattr would silently start on run.py defaults. Leaving
+    //    agentchattr_dir unset keeps the project on the legacy global
+    //    install via #186's fallback ladder until the next attempt.
     const targetToml = path.join(perProjectDir, "config.toml");
-    if (!fs.existsSync(targetToml) && project.working_dir) {
+    let tomlReady = fs.existsSync(targetToml);
+    if (!tomlReady && project.working_dir) {
       const legacyToml = path.join(project.working_dir, "agentchattr", "config.toml");
       if (fs.existsSync(legacyToml)) {
         try {
           fs.copyFileSync(legacyToml, targetToml);
           log(`    Copied legacy config.toml → ${targetToml}`);
+          tomlReady = true;
         } catch (e) {
           warn(`    Could not copy ${legacyToml}: ${e.message}`);
+          warn(`    ${project.id} migration aborted: legacy config.toml not transferred.`);
+          warn(`    ${project.id} will keep using the legacy global install via #186 fallback.`);
+          continue;
         }
+      } else {
+        // No legacy toml at all (e.g. user removed it). Refuse to migrate
+        // — without a config.toml at the clone ROOT, run.py would start
+        // on built-in defaults and bind to the wrong ports.
+        warn(`    ${project.id} has no legacy config.toml at ${legacyToml}; skipping migration.`);
+        warn(`    Re-run setup to regenerate config.toml, then 'quadwork start' will retry migration.`);
+        continue;
       }
     }
+    if (!tomlReady) {
+      warn(`    ${project.id} migration aborted: no config.toml at ${targetToml}.`);
+      continue;
+    }
 
-    // 3. Persist agentchattr_dir on the project entry.
+    // 3. Persist agentchattr_dir on the project entry — only after the
+    //    clone has run.py + venv + config.toml all in place.
     if (project.agentchattr_dir !== perProjectDir) {
       project.agentchattr_dir = perProjectDir;
       mutated = true;


### PR DESCRIPTION
## Summary
Phase 3 / sub-G of master #181. Existing v1 users have one shared install at \`~/.quadwork/agentchattr/\` and projects with no \`agentchattr_dir\` set. Migrate them **eagerly at the top of \`cmdStart()\`** so users see clear progress before any agents launch.

Single file: \`bin/quadwork.js\`, +93/−0 (one new function + a 4-line call site).

### Migration logic — `migrateLegacyProjects(config)`
For each project that doesn't yet have a working per-project clone:
1. \`perProjectDir = ~/.quadwork/{project_id}/agentchattr\`
2. \`installAgentChattr(perProjectDir)\` — idempotent via #183 + #187
3. **Copy** legacy \`<working_dir>/agentchattr/config.toml\` into the clone ROOT if it exists. AgentChattr's \`run.py\` reads \`ROOT/config.toml\`, so this is what makes the project actually start from its own clone after migration.
4. Set \`project.agentchattr_dir\` on the config entry and \`writeConfig()\`.

### Idempotent
A project with \`agentchattr_dir\` set + working clone + \`config.toml\` at the ROOT is skipped silently. Re-running \`cmdStart()\` on a fully-migrated config produces zero output and zero writes — \`needsMigration\` is empty, the function returns immediately.

### Safety
- Worktrees, repos, and token files are never touched.
- The legacy \`~/.quadwork/agentchattr/\` install is **left in place** — cleanup is sub-H (#189).
- Per-project failures are logged with \`installAgentChattr.lastError\` and that project is left unmigrated. The existing #186 fallback ladder (per-project clone → legacy global) keeps it running on the legacy install until the next start attempt.

## Acceptance criteria from #188
- ✅ Existing v1 user with N projects auto-migrates on next \`quadwork start\`.
- ✅ User sees clear progress messages during migration (header + per-project line + spinner).
- ✅ Migration is idempotent (re-running is a no-op).
- ✅ User's existing project data (worktrees, repos) is untouched.

## Test plan
- [ ] Stage a v1 config (one or two projects, no \`agentchattr_dir\`, with \`<wt>/agentchattr/config.toml\` populated). Run \`npx quadwork start\`. Verify each project gets a per-project clone, the legacy \`config.toml\` is copied to the new clone ROOT, and \`config.json\` is updated.
- [ ] Run \`npx quadwork start\` again. Verify zero migration output and zero writes.
- [ ] Stage a corrupt clone (rm \`.venv\` from \`~/.quadwork/foo/agentchattr\`). Run \`start\`. Verify the migration loop reuses the existing dir, recreates the venv via \`installAgentChattr\` (Phase 1B), and proceeds.
- [ ] Stage a project where the legacy \`<wt>/agentchattr/config.toml\` is missing. Verify migration still installs the clone but logs no copy step (and the project will start from \`run.py\` defaults until the user re-runs setup).
- [ ] Verify legacy \`~/.quadwork/agentchattr/\` still exists after a successful migration (cleanup is #189).

Fixes #188
Parent: #181