### PR TITLE
[#189] Cleanup command + disk-usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,36 @@ Every task follows a GitHub workflow: Issue → Branch → PR → 2 Reviews → 
 | `npx quadwork init` | One-time setup — installs prerequisites and opens the dashboard |
 | `npx quadwork start` | Start the dashboard server |
 | `npx quadwork stop` | Stop all processes |
+| `npx quadwork cleanup --project <id>` | Remove a project's AgentChattr clone and config entry |
+| `npx quadwork cleanup --legacy` | Remove the legacy `~/.quadwork/agentchattr/` install after migration |
 
 After init, create projects from the web UI at `http://127.0.0.1:8400/setup`.
+
+### Disk usage
+
+Each project gets its own AgentChattr clone at `~/.quadwork/{project_id}/agentchattr/` (~77 MB). For example:
+
+| Projects | Disk |
+|---------:|-----:|
+| 1 | ~77 MB |
+| 5 | ~385 MB |
+| 10 | ~770 MB |
+
+Per-project clones are necessary so multiple projects can run AgentChattr simultaneously without port conflicts (each clone has its own `config.toml`, ports, and data directory).
+
+To free space, delete unused projects from the dashboard or run:
+
+```sh
+npx quadwork cleanup --project <id>
+```
+
+Existing v1 users are auto-migrated to per-project clones on the next `npx quadwork start`. After all projects are migrated, the legacy shared install can be removed with:
+
+```sh
+npx quadwork cleanup --legacy
+```
+
+`cleanup --legacy` refuses to run unless every project already has its own working per-project clone, so it can never strand a project on a missing install.
 
 ## Configuration
 

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1618,6 +1618,112 @@ async function cmdAddProject() {
   }
 }
 
+// ─── Cleanup Command (#181 sub-H) ───────────────────────────────────────────
+
+/**
+ * Reclaim disk space taken by per-project AgentChattr clones (~77 MB each)
+ * or by the legacy shared install left behind after migration (#188).
+ *
+ * Usage:
+ *   npx quadwork cleanup --project <id>
+ *     Removes ~/.quadwork/{id}/ and the matching entry from config.json.
+ *     Leaves the user's worktrees and source repos completely alone.
+ *
+ *   npx quadwork cleanup --legacy
+ *     Removes the legacy shared ~/.quadwork/agentchattr/ install. Refuses
+ *     to run unless every project in config.json already has its own
+ *     working per-project clone (so nothing falls back onto the legacy
+ *     install via #186's resolution ladder).
+ *
+ * Both modes prompt for confirmation before deleting.
+ */
+async function cmdCleanup() {
+  const args = process.argv.slice(3);
+  const projectFlagIdx = args.indexOf("--project");
+  const projectId = projectFlagIdx >= 0 ? args[projectFlagIdx + 1] : null;
+  const legacy = args.includes("--legacy");
+
+  if (!projectId && !legacy) {
+    console.log(`
+  Usage:
+    npx quadwork cleanup --project <id>   Remove a project's AgentChattr clone + config entry
+    npx quadwork cleanup --legacy         Remove the legacy ~/.quadwork/agentchattr/ install
+`);
+    process.exit(1);
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const config = readConfig();
+
+    // --- Per-project cleanup ---
+    if (projectId) {
+      const idx = (config.projects || []).findIndex((p) => p.id === projectId);
+      const projectDir = path.join(CONFIG_DIR, projectId);
+      if (idx < 0 && !fs.existsSync(projectDir)) {
+        warn(`No project '${projectId}' in config and no directory at ${projectDir}.`);
+        return;
+      }
+      header(`Cleanup: ${projectId}`);
+      if (fs.existsSync(projectDir)) log(`  Directory: ${projectDir}`);
+      if (idx >= 0) log(`  Config entry: ${projectId} (${config.projects[idx].repo || "no repo"})`);
+      log("  Worktrees and source repos will NOT be touched.");
+      const confirm = await askYN(rl, `Delete ${projectDir} and remove the config entry?`, false);
+      if (!confirm) { warn("Aborted."); return; }
+
+      if (fs.existsSync(projectDir)) {
+        try { fs.rmSync(projectDir, { recursive: true, force: true }); ok(`Removed ${projectDir}`); }
+        catch (e) { fail(`Could not remove ${projectDir}: ${e.message}`); return; }
+      }
+      if (idx >= 0) {
+        config.projects.splice(idx, 1);
+        try { writeConfig(config); ok(`Updated ${CONFIG_PATH}`); }
+        catch (e) { fail(`Could not write config: ${e.message}`); return; }
+      }
+      return;
+    }
+
+    // --- Legacy cleanup ---
+    if (legacy) {
+      const legacyDir = path.join(CONFIG_DIR, "agentchattr");
+      if (!fs.existsSync(legacyDir)) {
+        warn(`No legacy install at ${legacyDir}.`);
+        return;
+      }
+      header("Cleanup: legacy ~/.quadwork/agentchattr/");
+
+      // Refuse if any project still depends on the legacy install — i.e.
+      // any project without its own working per-project clone (run.py +
+      // venv + config.toml at ROOT). Mirrors #186's resolution ladder.
+      const stillDepends = [];
+      for (const p of config.projects || []) {
+        if (!p.id) continue;
+        const dir = p.agentchattr_dir || path.join(CONFIG_DIR, p.id, "agentchattr");
+        const ok = fs.existsSync(path.join(dir, "run.py")) &&
+                   fs.existsSync(path.join(dir, ".venv", "bin", "python")) &&
+                   fs.existsSync(path.join(dir, "config.toml"));
+        if (!ok) stillDepends.push(p.id);
+      }
+      if (stillDepends.length > 0) {
+        fail(`Refusing to remove legacy install — these projects still depend on it:`);
+        for (const id of stillDepends) console.log(`    - ${id}`);
+        warn(`Run 'npx quadwork start' to migrate them (#188), then re-run cleanup --legacy.`);
+        return;
+      }
+
+      log(`  Directory: ${legacyDir}`);
+      log("  All projects already have their own per-project clones.");
+      const confirm = await askYN(rl, `Delete ${legacyDir}?`, false);
+      if (!confirm) { warn("Aborted."); return; }
+
+      try { fs.rmSync(legacyDir, { recursive: true, force: true }); ok(`Removed ${legacyDir}`); }
+      catch (e) { fail(`Could not remove ${legacyDir}: ${e.message}`); return; }
+    }
+  } finally {
+    rl.close();
+  }
+}
+
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 const command = process.argv[2];
@@ -1635,6 +1741,9 @@ switch (command) {
   case "add-project":
     cmdAddProject();
     break;
+  case "cleanup":
+    cmdCleanup();
+    break;
   default:
     console.log(`
   Usage: quadwork <command>
@@ -1644,6 +1753,7 @@ switch (command) {
     start         Start the QuadWork dashboard and backend
     stop          Stop all QuadWork processes
     add-project   Add a project via CLI (alternative to web UI /setup)
+    cleanup       Reclaim disk space (--project <id> or --legacy)
 
   Workflow:
     1. npx quadwork init     — one-time global setup, opens dashboard
@@ -1654,6 +1764,8 @@ switch (command) {
     npx quadwork init
     npx quadwork start
     npx quadwork stop
+    npx quadwork cleanup --project my-project
+    npx quadwork cleanup --legacy
 `);
     if (command) process.exit(1);
 }


### PR DESCRIPTION
## Summary
Phase 4 / sub-H of master #181. Add a \`cleanup\` CLI command and document the per-project disk footprint introduced by the rest of the batch.

Two files: \`bin/quadwork.js\` (+112/−0) + \`README.md\` (+28/−0).

### \`bin/quadwork.js\` — \`cmdCleanup()\`
- \`cleanup --project <id>\` — removes \`~/.quadwork/{id}/\` and the matching entry from \`config.json\`. Worktrees and source repos are never touched. Confirmation prompt before deleting.
- \`cleanup --legacy\` — removes the legacy \`~/.quadwork/agentchattr/\` install. **Refuses to run** unless every project in \`config.json\` already has its own working per-project clone (run.py + venv + config.toml at ROOT) — exactly the same readiness criteria the migration in #188 uses to persist \`agentchattr_dir\`. Lists any projects that still depend on the legacy install and tells the user to run \`quadwork start\` to migrate them first. Confirmation prompt before deleting.
- Wired into the top-level command switch + usage banner.

### \`README.md\`
- New \"Disk usage\" section under Commands explaining the ~77 MB per-project clone footprint, the migration story (auto-migration on next \`start\` since #188), and both cleanup commands.
- Command table now includes both \`cleanup\` forms.

## Acceptance criteria from #189
- ✅ README has clear disk usage docs.
- ✅ \`cleanup --project <id>\` removes the per-project install + config entry.
- ✅ \`cleanup --legacy\` removes the shared install only after confirming all projects have their own clones (refuses with a list otherwise).
- ✅ Cleanup commands ask for confirmation before deleting.

## Test plan
- [ ] \`npx quadwork cleanup --project nonexistent\` → warns "no such project" and exits cleanly.
- [ ] Create a project, then \`cleanup --project foo\`. Verify \`~/.quadwork/foo/\` is gone, the \`config.json\` entry is removed, and \`<wt>\` worktrees are still on disk.
- [ ] On a host with a v1 setup that hasn't been migrated, run \`cleanup --legacy\`. Verify it refuses with the list of unmigrated projects.
- [ ] Migrate (run \`start\` per #188), then \`cleanup --legacy\`. Verify the legacy directory is removed.
- [ ] Both modes: confirmation prompt is honored — answering "n" leaves everything untouched.

Fixes #189
Parent: #181