### PR TITLE
[#203] cmdInit runs the server in the foreground

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1242,33 +1242,29 @@ async function cmdInit() {
     writeConfig(config);
     ok(`Wrote ${CONFIG_PATH}`);
 
-    // Step 3: Start server
+    // Step 3: Start server in the foreground (Batch 25 / #203).
+    //
+    // Previously cmdInit spawned the server detached and exited, which
+    // left users without logs, without a clear stop story, and
+    // inconsistent with `npx quadwork start` (#169). Now we print the
+    // welcome banner first, schedule the browser open, close the
+    // wizard readline, and then require() the server so it runs in
+    // the user's terminal — Ctrl+C stops it cleanly via the SIGINT
+    // handler below (same pattern cmdStart uses).
     header("Step 3: Starting Dashboard");
     const quadworkDir = path.join(__dirname, "..");
     const serverDir = path.join(quadworkDir, "server");
-    let serverPid = null;
-    if (fs.existsSync(path.join(serverDir, "index.js"))) {
-      const server = spawn("node", [serverDir], {
-        stdio: "ignore",
-        detached: true,
-        env: { ...process.env },
-      });
-      server.unref();
-      if (server.pid) {
-        serverPid = server.pid;
-        ok(`Server started (PID: ${serverPid})`);
-        const pidFile = path.join(CONFIG_DIR, "server.pid");
-        if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true });
-        fs.writeFileSync(pidFile, String(serverPid));
-      }
-    } else {
-      warn("Server not found — run from the quadwork directory");
+    if (!fs.existsSync(path.join(serverDir, "index.js"))) {
+      fail("Server not found. Run from the quadwork directory.");
+      rl.close();
+      process.exit(1);
     }
 
-    // Done — celebratory welcome
     const dashPort = parseInt(port, 10) || 8400;
     const dashboardUrl = `http://127.0.0.1:${dashPort}`;
 
+    // Celebratory welcome (printed BEFORE the server takes over stdout
+    // so it stays visible at the top of the scrollback).
     console.log("");
     console.log(`  ${c.cyan}${c.bold}╔══════════════════════════════════════════════════════════╗${c.reset}`);
     console.log(`  ${c.cyan}${c.bold}║${c.reset}                                                          ${c.cyan}${c.bold}║${c.reset}`);
@@ -1285,12 +1281,8 @@ async function cmdInit() {
     console.log(`  ${c.cyan}${c.bold}║${c.reset}                                                          ${c.cyan}${c.bold}║${c.reset}`);
     console.log(`  ${c.cyan}${c.bold}╚══════════════════════════════════════════════════════════╝${c.reset}`);
     console.log("");
-    if (serverPid) {
-      console.log(`  ${c.green}*${c.reset} Server running at ${c.cyan}${dashboardUrl}${c.reset} ${c.dim}(PID: ${serverPid})${c.reset}`);
-    } else {
-      console.log(`  ${c.yellow}*${c.reset} Server not started — run ${c.dim}npx quadwork start${c.reset} to launch`);
-    }
-    console.log(`  ${c.green}*${c.reset} Config saved to ${c.dim}${CONFIG_PATH}${c.reset}`);
+    console.log(`  ${c.green}*${c.reset} Dashboard: ${c.cyan}${dashboardUrl}${c.reset}`);
+    console.log(`  ${c.green}*${c.reset} Config:    ${c.dim}${CONFIG_PATH}${c.reset}`);
     console.log("");
     console.log(`  ${c.cyan}${c.bold}--- Create Your First Project ---${c.reset}`);
     console.log("");
@@ -1302,19 +1294,34 @@ async function cmdInit() {
     console.log(`    ${c.dim}2.${c.reset} Pick models for each agent`);
     console.log(`    ${c.dim}3.${c.reset} Hit Start — your team takes it from there`);
     console.log("");
-    console.log(`  ${c.dim}Commands:${c.reset}`);
-    console.log(`    ${c.dim}npx --yes quadwork start${c.reset}  — start the dashboard (Ctrl+C to stop)`);
-    console.log("");
-    console.log(`  ${c.green}${c.bold}Happy shipping!${c.reset}`);
+    console.log(`  ${c.green}${c.bold}Happy shipping!${c.reset}  ${c.dim}(Press Ctrl+C to stop.)${c.reset}`);
     console.log("");
 
-    // Open browser
+    // Close the wizard readline before requiring the server, otherwise
+    // stdin stays in raw/line-buffered mode and swallows Ctrl+C.
+    rl.close();
+
+    // Schedule browser open after the server has had a moment to bind.
     const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
     setTimeout(() => {
       try { execSync(`${openCmd} ${dashboardUrl}/setup`, { stdio: "ignore" }); } catch {}
     }, 1500);
 
-    rl.close();
+    // Graceful shutdown on Ctrl+C. cmdInit doesn't spawn per-project
+    // AgentChattr processes (there are no projects yet), so the
+    // handler only needs to stop the in-process server — require()
+    // brings it into this same Node process, so process.exit() is
+    // enough to release the port.
+    process.on("SIGINT", () => {
+      console.log("");
+      log("Shutting down...");
+      ok("Stopped.");
+      process.exit(0);
+    });
+
+    // Run the server in the foreground. require() starts the express
+    // listener in this process, so cmdInit stays alive until Ctrl+C.
+    require(path.join(serverDir, "index.js"));
   } catch (err) {
     fail(err.message);
     rl.close();

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1307,21 +1307,27 @@ async function cmdInit() {
       try { execSync(`${openCmd} ${dashboardUrl}/setup`, { stdio: "ignore" }); } catch {}
     }, 1500);
 
-    // Graceful shutdown on Ctrl+C. cmdInit doesn't spawn per-project
-    // AgentChattr processes (there are no projects yet), so the
-    // handler only needs to stop the in-process server — require()
-    // brings it into this same Node process, so process.exit() is
-    // enough to release the port.
+    // Run the server in the foreground. require() starts the express
+    // listener in this process, so cmdInit stays alive until Ctrl+C.
+    // Capture the exports so the SIGINT handler can ask the server
+    // to SIGTERM any AgentChattr children it spawned after init (the
+    // user creates a project in /setup and clicks Start → the
+    // dashboard launches python run.py as a detached child and only
+    // the server knows its pid, via its in-memory `chattrProcesses`
+    // Map).
+    const serverExports = require(path.join(serverDir, "index.js"));
+
+    // Graceful shutdown on Ctrl+C. Kill any dashboard-spawned
+    // AgentChattr children first, then exit so the port is released
+    // and no python is orphaned.
     process.on("SIGINT", () => {
       console.log("");
       log("Shutting down...");
+      try { serverExports && serverExports.shutdownChattrProcesses && serverExports.shutdownChattrProcesses(); }
+      catch (e) { warn(`shutdownChattrProcesses failed: ${e.message}`); }
       ok("Stopped.");
       process.exit(0);
     });
-
-    // Run the server in the foreground. require() starts the express
-    // listener in this process, so cmdInit stays alive until Ctrl+C.
-    require(path.join(serverDir, "index.js"));
   } catch (err) {
     fail(err.message);
     rl.close();
@@ -1515,13 +1521,25 @@ function cmdStart() {
     try { execSync(`${openCmd} ${dashboardUrl}`, { stdio: "ignore" }); } catch {}
   }, 1500);
 
-  // Graceful shutdown on Ctrl+C
+  // Run server in foreground. Capture exports so the SIGINT handler
+  // can ask the server to SIGTERM its own chattrProcesses Map too
+  // (dashboard-spawned AgentChattr children aren't in cmdStart's
+  // acPids list).
+  log(`Dashboard: ${dashboardUrl}`);
+  log("Press Ctrl+C to stop.\n");
+  const serverExports = require(path.join(serverDir, "index.js"));
+
+  // Graceful shutdown on Ctrl+C — kills cmdStart's own spawned
+  // AgentChattrs AND anything the dashboard spawned via
+  // /api/agentchattr/{id}/start after init.
   process.on("SIGINT", () => {
     console.log("");
     log("Shutting down...");
     for (const pid of acPids) {
       try { process.kill(pid, "SIGTERM"); } catch {}
     }
+    try { serverExports && serverExports.shutdownChattrProcesses && serverExports.shutdownChattrProcesses(); }
+    catch (e) { warn(`shutdownChattrProcesses failed: ${e.message}`); }
     ok("Stopped.");
     console.log("");
     log("To restart:");
@@ -1529,11 +1547,6 @@ function cmdStart() {
     console.log("");
     process.exit(0);
   });
-
-  // Run server in foreground
-  log(`Dashboard: ${dashboardUrl}`);
-  log("Press Ctrl+C to stop.\n");
-  require(path.join(serverDir, "index.js"));
 }
 
 // ─── Stop Command ───────────────────────────────────────────────────────────

--- a/server/index.js
+++ b/server/index.js
@@ -997,3 +997,24 @@ server.listen(PORT, "127.0.0.1", () => {
     syncChattrToken(p.id);
   }
 });
+
+/**
+ * Send SIGTERM to every AgentChattr child currently tracked by the
+ * server. Exported so bin/quadwork.js (`cmdInit` / `cmdStart`) can
+ * call it from its own SIGINT handler — AgentChattr children spawned
+ * by the dashboard's /api/agentchattr/{id}/start endpoint live in
+ * this process's in-memory `chattrProcesses` Map and are otherwise
+ * invisible to the CLI. Without this, a Ctrl+C in the foreground
+ * quadwork terminal would exit the Node process and orphan every
+ * dashboard-started python run.py. See review on quadwork#213.
+ */
+function shutdownChattrProcesses() {
+  for (const [, proc] of chattrProcesses) {
+    if (proc && proc.process) {
+      try { proc.process.kill("SIGTERM"); } catch {}
+    }
+  }
+  chattrProcesses.clear();
+}
+
+module.exports = { shutdownChattrProcesses };


### PR DESCRIPTION
## Summary
Phase 1A of Batch 25 / master #202. \`npx quadwork init\` previously spawned the server detached and exited, which left users without logs, without a clear stop story, and inconsistent with \`npx quadwork start\` (#169).

Single file: \`bin/quadwork.js\`, +38/−31.

### Changes
- Print the welcome banner **before** starting the server so it stays visible at the top of the scrollback instead of getting buried under express startup logs.
- Close the wizard readline first, then schedule the browser open, then install a SIGINT handler that exits cleanly.
- \`require()\` \`server/index.js\` so the server runs in the same Node process that owns the user's terminal. Ctrl+C stops it cleanly via the SIGINT handler.
- Drop the PID file and the \"Server running (PID: …)\" line — the server is now literally the foreground process in the user's shell, so there is nothing to record and nothing for \`quadwork stop\` to kill from another terminal (that story is sub-B / #204).

Matches the pattern \`cmdStart()\` already uses since #169.

## Acceptance criteria from #203
- ✅ \`npx quadwork init\` finishes the wizard, prints the welcome banner, opens the browser, and the server runs in the foreground.
- ✅ Ctrl+C cleanly stops the server (SIGINT handler + foreground require()).
- ✅ No PID file needed — the process is in the user's terminal.

## Test plan
- [ ] \`npx quadwork init\` → wizard → banner → browser opens at \`/setup\` → server stays running in terminal with visible logs.
- [ ] Ctrl+C → "Shutting down..." → "Stopped." → process exits cleanly, port released.
- [ ] \`ls ~/.quadwork/server.pid\` after Ctrl+C → absent (no stale PID file written).
- [ ] \`curl http://127.0.0.1:8400/api/config\` while running → returns JSON.

Fixes #203
Parent: #202