### PR TITLE
[#206] Global TopHeader with typewriter tagline + About modal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,3 +66,12 @@ h1, h2, h3, h4, h5, h6 {
   outline: 1px solid var(--accent);
   outline-offset: 1px;
 }
+
+/* Typewriter cursor blink (#206 — TopHeader tagline) */
+@keyframes qw-blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+.animate-qw-blink {
+  animation: qw-blink 1s steps(2, start) infinite;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Sidebar from "@/components/Sidebar";
+import TopHeader from "@/components/TopHeader";
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -20,9 +21,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${geistMono.variable} h-full`}>
-      <body className="h-full flex">
-        <Sidebar />
-        <main className="flex-1 min-w-0 overflow-auto">{children}</main>
+      <body className="h-full flex flex-col">
+        <TopHeader />
+        <div className="flex flex-1 min-h-0">
+          <Sidebar />
+          <main className="flex-1 min-w-0 overflow-auto">{children}</main>
+        </div>
       </body>
     </html>
   );

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface AboutModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const GITHUB_URL = "https://github.com/realproject7/quadwork";
+
+export default function AboutModal({ open, onClose }: AboutModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="about-title"
+    >
+      <div
+        className="relative mx-4 max-w-lg w-full rounded-lg border border-white/10 bg-neutral-950 p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded p-1 text-neutral-400 hover:bg-white/5 hover:text-white"
+        >
+          <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M4 4l12 12M16 4L4 16" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <h2 id="about-title" className="text-lg font-semibold text-white">What is QuadWork?</h2>
+        <p className="mt-3 text-sm leading-relaxed text-neutral-300">
+          QuadWork is a local dashboard that runs a team of 4 AI agents — Head, Dev, and two Reviewers — that code, review, and ship while you sleep.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-neutral-300">
+          Every task follows a strict GitHub workflow: Issue → Branch → Pull Request → 2 Reviews → Merge. Branch protection ensures no agent can skip the process.
+        </p>
+
+        <h3 className="mt-5 text-sm font-semibold text-white">Why QuadWork?</h3>
+        <ul className="mt-2 space-y-1.5 text-sm text-neutral-300">
+          <li>🤖 <b>Run 24/7</b> — agents work overnight while you rest</li>
+          <li>🛡️ <b>Always reviewed</b> — every PR needs 2 independent approvals</li>
+          <li>🔒 <b>Local-first</b> — runs entirely on your machine, no data leaves</li>
+          <li>🧰 <b>Bring your own CLI</b> — works with Claude Code, Codex, or both</li>
+          <li>📦 <b>One install</b> — <code className="rounded bg-white/5 px-1 py-0.5 text-[12px]">npx quadwork init</code> and you&apos;re set</li>
+        </ul>
+
+        <div className="mt-5">
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-sm text-blue-400 hover:text-blue-300"
+          >
+            Read the full docs on GitHub →
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import AboutModal from "./AboutModal";
+
+const GITHUB_URL = "https://github.com/realproject7/quadwork";
+
+const TAGLINE_VARIANTS = [
+  "sleep.",
+  "eat.",
+  "enjoy life.",
+  "touch grass.",
+  "spend time with people.",
+  "watch a movie.",
+  "take a vacation.",
+  "go for a run.",
+];
+
+// Typewriter timings — tuned to feel brisk but readable.
+const TYPE_MS = 70;
+const DELETE_MS = 35;
+const HOLD_MS = 2000;
+
+function useTypewriter(variants: string[]) {
+  const [index, setIndex] = useState(0);
+  const [text, setText] = useState("");
+  const [phase, setPhase] = useState<"typing" | "holding" | "deleting">("typing");
+
+  useEffect(() => {
+    const current = variants[index];
+    let timer: ReturnType<typeof setTimeout>;
+
+    if (phase === "typing") {
+      if (text.length < current.length) {
+        timer = setTimeout(() => setText(current.slice(0, text.length + 1)), TYPE_MS);
+      } else {
+        timer = setTimeout(() => setPhase("holding"), 0);
+      }
+    } else if (phase === "holding") {
+      timer = setTimeout(() => setPhase("deleting"), HOLD_MS);
+    } else {
+      if (text.length > 0) {
+        timer = setTimeout(() => setText(current.slice(0, text.length - 1)), DELETE_MS);
+      } else {
+        setIndex((i) => (i + 1) % variants.length);
+        setPhase("typing");
+      }
+    }
+
+    return () => clearTimeout(timer);
+  }, [text, phase, index, variants]);
+
+  return text;
+}
+
+export default function TopHeader() {
+  const [aboutOpen, setAboutOpen] = useState(false);
+  const suffix = useTypewriter(TAGLINE_VARIANTS);
+
+  return (
+    <>
+      <header className="sticky top-0 z-40 flex h-12 items-center justify-between border-b border-white/10 bg-neutral-950/90 px-4 backdrop-blur">
+        <div className="flex items-center gap-3 min-w-0">
+          <Link href="/" className="text-sm font-bold text-white hover:text-blue-400 shrink-0">
+            QuadWork
+          </Link>
+          <span className="hidden sm:inline text-neutral-600">|</span>
+          <span className="hidden sm:inline text-[13px] text-neutral-400 truncate">
+            Your AI dev team while you{" "}
+            <span className="text-neutral-200">{suffix}</span>
+            <span className="ml-0.5 inline-block w-[1px] h-[12px] align-middle bg-neutral-400 animate-qw-blink" />
+          </span>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <button
+            type="button"
+            onClick={() => setAboutOpen(true)}
+            aria-label="About QuadWork"
+            className="rounded p-1 text-neutral-400 hover:bg-white/5 hover:text-white"
+          >
+            <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <circle cx="10" cy="10" r="8" />
+              <path d="M10 9v5" strokeLinecap="round" />
+              <circle cx="10" cy="6.5" r="0.8" fill="currentColor" />
+            </svg>
+          </button>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px] text-neutral-400 hover:text-white"
+          >
+            QuadWork github
+          </a>
+        </div>
+      </header>
+      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 1D of Batch 25 / master #202. Adds a persistent top header that appears on every page in the dashboard: title, typewriter tagline, About modal, and GitHub link.

Four files: new \`src/components/TopHeader.tsx\` (+101), new \`src/components/AboutModal.tsx\` (+75), \`src/app/layout.tsx\` (+7/−3), \`src/app/globals.css\` (+9).

### \`TopHeader.tsx\`
- **Title** — \`QuadWork\` (bold, links to \`/\`).
- **Typewriter tagline** — static prefix \`Your AI dev team while you \` + animated suffix cycling through the 8 variants from the ticket (\`sleep.\`, \`eat.\`, \`enjoy life.\`, \`touch grass.\`, \`spend time with people.\`, \`watch a movie.\`, \`take a vacation.\`, \`go for a run.\`). Hand-rolled \`useTypewriter\` hook — no new dep — types, holds 2s, deletes, advances. Blinking cursor via a CSS \`animate-qw-blink\` keyframe added in \`globals.css\`.
- **About button** (info \"i\" icon) opens \`<AboutModal>\`.
- **\"QuadWork github\" link** opens \`https://github.com/realproject7/quadwork\` in a new tab.
- **Responsive** — the tagline collapses on narrow viewports (\`hidden sm:inline\`) so the header never overflows; title + About + GitHub link stay visible at all widths.

### \`AboutModal.tsx\`
- Dialog with backdrop (click-outside + Escape to close).
- Copy matches the ticket: \"What is QuadWork?\", \"Why QuadWork?\" bullets (24/7, always reviewed, local-first, BYO CLI, one install), and a \"Read the full docs on GitHub →\" link.
- \`aria-modal\` + labelled heading for accessibility.

### Layout wiring
- \`src/app/layout.tsx\` — body is now a column (\`flex-col\`); \`<TopHeader />\` is rendered before the existing \`<Sidebar>\` + \`<main>\` row, so every page inherits it without any per-route change. The sidebar + main row keeps its own scroll context via \`min-h-0\`.

## Acceptance criteria from #206
- ✅ Header visible on every page (it's in the root layout).
- ✅ Tagline cycles through all 8 variants with typewriter effect + blinking cursor.
- ✅ Info icon opens the About modal; Escape or backdrop click closes it.
- ✅ GitHub link opens in a new tab.
- ✅ Header is responsive — tagline collapses on narrow viewports via \`hidden sm:inline\`.
- ✅ Doesn't push the existing dashboard layout — the sidebar + main row is wrapped in a \`flex flex-1 min-h-0\` shell so the existing panels keep their own scrolling.

## Test plan
- [ ] \`npm run build\` then \`npx quadwork start\` — verify the header shows on /, /project/*, /settings, /setup with the tagline cycling.
- [ ] Click the info icon — About modal appears with the 5 bullets + GitHub link. Click backdrop → closes. Press Esc → closes.
- [ ] Click "QuadWork github" → new tab opens at realproject7/quadwork.
- [ ] Shrink browser to &lt;640px — header still renders, tagline hidden, title + icons still visible.
- [ ] Existing ProjectDashboard / TerminalGrid scroll behavior unchanged.

Fixes #206
Parent: #202