### PR TITLE
[#207] Two-letter project chips in left nav

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -77,13 +77,15 @@ function ProjectIcon({ project, isActive }: { project: Project; isActive: boolea
         onMouseLeave={() => setTooltip(null)}
       >
         <div
-          className={`w-10 h-10 flex items-center justify-center rounded-full text-xs font-semibold uppercase transition-colors ${
+          className={`w-10 h-10 flex items-center justify-center rounded-full text-[11px] font-semibold uppercase tracking-tight transition-colors ${
             isActive
               ? "border-2 border-accent text-accent"
               : "border border-border text-text-muted hover:text-text hover:bg-[#1a1a1a]"
           }`}
         >
-          {project.name.charAt(0)}
+          {/* #207: two-letter chip — first two characters of the project
+              name, falling back to a single character for 1-char names. */}
+          {project.name.slice(0, 2) || "?"}
         </div>
       </Link>
       {tooltip && (


### PR DESCRIPTION
## Summary
Phase 1E of Batch 25 / master #202. The sidebar project chips showed a single first character (e.g. \`D\` for DropCast, \`D\` for Dev — ambiguous with many projects). Switch to the first two characters of the project name (\`DR\`, \`QW\`, \`PL\`, \`FA\`) while preserving the hover tooltip with the full name and the active-state border.

Single file: \`src/components/Sidebar.tsx\`, +4/−2.

### Changes
- \`ProjectIcon\` — \`project.name.slice(0, 2)\` instead of \`charAt(0)\`.
- Font size bumped down one step (\`text-xs\` → \`text-[11px]\`) and added \`tracking-tight\` so two uppercase letters fit comfortably inside the existing 40 px chip without making the sidebar any wider.
- Fallback to \`\"?\"\` for empty names — defensive, shouldn't happen under normal config, but avoids a blank chip.
- Tooltip (\`onMouseEnter\` full-name popover) and \`isActive\` border ring are untouched.

## Acceptance criteria from #207
- ✅ All project chips show two letters.
- ✅ Tooltip on hover still shows the full name.
- ✅ Active project still highlighted (border-accent).

## Test plan
- [ ] Run \`npx quadwork start\`, open the dashboard. Verify existing project \"dropcast\" shows \`DR\`, any other project shows its first two letters, all uppercase.
- [ ] Hover each chip → tooltip shows the full project name.
- [ ] Navigate into a project → its chip shows the accent-bordered active state.
- [ ] Sidebar width unchanged (40 px column).

Fixes #207
Parent: #202