### PR TITLE
[#208] 4-quadrant project dashboard layout

### DIFF
--- a/src/components/AgentTerminalsGrid.tsx
+++ b/src/components/AgentTerminalsGrid.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import TerminalGrid from "./TerminalGrid";
+
+type AgentState = "running" | "stopped" | "error";
+
+interface AgentTerminalsGridProps {
+  projectId: string;
+  agentStates: Record<string, AgentState>;
+  onStatusChange?: (agent: string, state: string) => void;
+}
+
+/**
+ * Top-right quadrant of the project dashboard (#208).
+ *
+ * Wraps the existing TerminalGrid 2x2 with a header and a ? tooltip
+ * that tells operators the terminals are read-only status mirrors —
+ * real communication happens through the AgentChattr chat panel in
+ * the top-left quadrant. Without this hint, users try to type into
+ * the terminals and their messages are lost to the other agents.
+ */
+export default function AgentTerminalsGrid({ projectId, agentStates, onStatusChange }: AgentTerminalsGridProps) {
+  const [tipOpen, setTipOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] text-text-muted uppercase tracking-wider">Agent Terminals</span>
+          <div
+            className="relative"
+            onMouseEnter={() => setTipOpen(true)}
+            onMouseLeave={() => setTipOpen(false)}
+            onFocus={() => setTipOpen(true)}
+            onBlur={() => setTipOpen(false)}
+          >
+            <button
+              type="button"
+              aria-label="About agent terminals"
+              className="w-3.5 h-3.5 rounded-full border border-border text-[9px] text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
+            >?</button>
+            {tipOpen && (
+              <div
+                role="tooltip"
+                className="absolute top-5 left-0 z-20 w-72 p-2 text-[11px] leading-snug text-text bg-bg-surface border border-border shadow-lg"
+              >
+                These show what each agent is doing in their CLI session.{" "}
+                <b>Do not type here directly</b> — use the AgentChattr chat
+                above instead. Agents won&apos;t see messages typed in their
+                terminals.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="flex-1 min-h-0">
+        <TerminalGrid
+          projectId={projectId}
+          agentStates={agentStates}
+          onStatusChange={onStatusChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/AgentTerminalsGrid.tsx
+++ b/src/components/AgentTerminalsGrid.tsx
@@ -3,6 +3,19 @@
 import { useState } from "react";
 import TerminalGrid from "./TerminalGrid";
 
+// #208: the top-right quadrant must show all four agents
+// (Head, Reviewer1, Reviewer2, Dev) as a 2x2 grid. TerminalGrid's
+// default agent list only has three entries (Reviewer1, Reviewer2,
+// Dev) because it used to live alongside a dedicated Head panel —
+// pass the full four-agent list explicitly so Head doesn't get
+// dropped when the old Head panel was removed.
+const FOUR_AGENTS = [
+  { id: "head", label: "Head" },
+  { id: "reviewer1", label: "Reviewer1" },
+  { id: "reviewer2", label: "Reviewer2" },
+  { id: "dev", label: "Dev" },
+];
+
 type AgentState = "running" | "stopped" | "error";
 
 interface AgentTerminalsGridProps {
@@ -57,6 +70,7 @@ export default function AgentTerminalsGrid({ projectId, agentStates, onStatusCha
       <div className="flex-1 min-h-0">
         <TerminalGrid
           projectId={projectId}
+          agents={FOUR_AGENTS}
           agentStates={agentStates}
           onStatusChange={onStatusChange}
         />

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import PanelHeader from "./PanelHeader";
+
+/**
+ * Bottom-right quadrant of the project dashboard (#208).
+ *
+ * Placeholder container for the Operator Features panel. Sub-tickets
+ * #209 (OVERNIGHT-QUEUE.md viewer), #210 (Scheduled Trigger widget),
+ * and #211 (Telegram Bridge widget) will fill the body.
+ */
+export default function OperatorFeaturesPanel(_props: { projectId: string }) {
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <PanelHeader label="Operator Features" />
+      <div className="flex-1 min-h-0 overflow-auto p-3 text-[11px] text-text-muted">
+        <ul className="space-y-1">
+          <li>• OVERNIGHT-QUEUE.md viewer <span className="text-text-muted/70">(#209)</span></li>
+          <li>• Scheduled Trigger <span className="text-text-muted/70">(#210)</span></li>
+          <li>• Telegram Bridge <span className="text-text-muted/70">(#211)</span></li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import TerminalPanel from "./TerminalPanel";
-import TerminalGrid from "./TerminalGrid";
 import PanelHeader from "./PanelHeader";
 import ChatPanel from "./ChatPanel";
 import GitHubPanel from "./GitHubPanel";
 import ControlBar from "./ControlBar";
+import AgentTerminalsGrid from "./AgentTerminalsGrid";
+import OperatorFeaturesPanel from "./OperatorFeaturesPanel";
 
 const MIN_SIZE = 150; // px
 const DIVIDER = 4; // px
@@ -108,18 +108,15 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
         gridTemplateRows: rowTemplate,
       }}
     >
-      {/* Panel 1: Head Terminal — top-left */}
-      <div className="flex flex-col overflow-hidden">
-        <PanelHeader
-          label="Head"
-          status={agentStates["head"] || "stopped"}
-          projectId={projectId}
-          agentId="head"
-          onStatusChange={(s) => updateAgentState("head", s)}
-        />
+      {/* Quadrant 1 (top-left): AgentChattr chat — highlighted as
+          the primary interface (#208). 2px accent border + explicit
+          "primary chat" label in the panel header. */}
+      <div className="flex flex-col overflow-hidden border-2 border-accent">
+        <PanelHeader label="AgentChattr — primary chat" />
         <div className="flex-1 min-h-0">
-          <TerminalPanel projectId={projectId} agentId="head" />
+          <ChatPanel projectId={projectId} />
         </div>
+        <ControlBar projectId={projectId} />
       </div>
 
       {/* Vertical divider — top segment */}
@@ -128,12 +125,14 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
         onMouseDown={() => startDrag("col")}
       />
 
-      {/* Panel 2: GitHub placeholder — top-right */}
+      {/* Quadrant 2 (top-right): Agent terminals — 2x2 grid with
+          header + "do not type here" tooltip (#208). */}
       <div className="flex flex-col overflow-hidden">
-        <PanelHeader label="GitHub" />
-        <div className="flex-1 min-h-0">
-          <GitHubPanel projectId={projectId} />
-        </div>
+        <AgentTerminalsGrid
+          projectId={projectId}
+          agentStates={agentStates}
+          onStatusChange={updateAgentState}
+        />
       </div>
 
       {/* Horizontal divider — left segment */}
@@ -154,13 +153,12 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
         onMouseDown={() => startDrag("row")}
       />
 
-      {/* Panel 3: Chat — bottom-left */}
+      {/* Quadrant 3 (bottom-left): GitHub (#208). */}
       <div className="flex flex-col overflow-hidden">
-        <PanelHeader label="Chat" />
+        <PanelHeader label="GitHub" />
         <div className="flex-1 min-h-0">
-          <ChatPanel projectId={projectId} />
+          <GitHubPanel projectId={projectId} />
         </div>
-        <ControlBar projectId={projectId} />
       </div>
 
       {/* Vertical divider — bottom segment */}
@@ -169,17 +167,9 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
         onMouseDown={() => startDrag("col")}
       />
 
-      {/* Panel 4: Agent terminals — bottom-right */}
-      <div className="flex flex-col overflow-hidden">
-        <PanelHeader label="Panel 4" />
-        <div className="flex-1 min-h-0">
-          <TerminalGrid
-            projectId={projectId}
-            agentStates={agentStates}
-            onStatusChange={updateAgentState}
-          />
-        </div>
-      </div>
+      {/* Quadrant 4 (bottom-right): Operator Features (#208) —
+          placeholder container. Sub-tickets #209/#210/#211 fill it. */}
+      <OperatorFeaturesPanel projectId={projectId} />
     </div>
   );
 }

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -21,10 +21,19 @@ const DEFAULT_AGENTS: Agent[] = [
   { id: "dev", label: "Dev" },
 ];
 
-const GRID_CLASSES = [
+// Border classes per tile. 3-agent legacy layout (reviewer1/reviewer2/dev)
+// has a full-width bottom tile; the 4-agent layout used by the new
+// #208 top-right quadrant has all four tiles in a 2x2 grid.
+const GRID_CLASSES_3 = [
   "border-r border-b border-border", // top-left
   "border-b border-border",          // top-right
   "col-span-2",                      // bottom full-width
+];
+const GRID_CLASSES_4 = [
+  "border-r border-b border-border", // top-left
+  "border-b border-border",          // top-right
+  "border-r border-border",          // bottom-left
+  "",                                // bottom-right
 ];
 
 export default function TerminalGrid({
@@ -34,6 +43,7 @@ export default function TerminalGrid({
   onStatusChange,
 }: TerminalGridProps) {
   const [expanded, setExpanded] = useState<string | null>(null);
+  const gridClasses = agents.length >= 4 ? GRID_CLASSES_4 : GRID_CLASSES_3;
 
   return (
     <div className="w-full h-full relative grid grid-rows-2 grid-cols-2">
@@ -47,7 +57,7 @@ export default function TerminalGrid({
             className={`flex flex-col ${
               isExpanded
                 ? "absolute inset-0 z-10 bg-bg"
-                : `${GRID_CLASSES[i] || ""}`
+                : `${gridClasses[i] || ""}`
             }`}
             style={isHidden ? { visibility: "hidden", overflow: "hidden" } : undefined}
           >

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -60,11 +60,20 @@ export default function TerminalGrid({
                 className={`flex items-center gap-1.5 ${!isExpanded ? "cursor-pointer" : ""}`}
                 onClick={isExpanded ? undefined : () => setExpanded(agent.id)}
               >
-                <span className={`w-1.5 h-1.5 rounded-full ${
-                  agentStates[agent.id] === "running" ? "bg-accent"
-                    : agentStates[agent.id] === "error" ? "bg-error"
-                    : "bg-text-muted"
-                }`} />
+                {/* #208: status dot with activity ring when the
+                    agent is running — pulsing ring around the dot
+                    signals "agent is working". Idle/stopped/error
+                    states omit the ring. */}
+                <span className="relative inline-flex items-center justify-center w-2 h-2">
+                  {agentStates[agent.id] === "running" && (
+                    <span className="absolute inline-flex h-full w-full rounded-full bg-accent opacity-60 animate-ping" />
+                  )}
+                  <span className={`relative w-1.5 h-1.5 rounded-full ${
+                    agentStates[agent.id] === "running" ? "bg-accent"
+                      : agentStates[agent.id] === "error" ? "bg-error"
+                      : "bg-text-muted"
+                  }`} />
+                </span>
                 <span className="text-[11px] text-text-muted uppercase tracking-wider">
                   {agent.label}
                 </span>


### PR DESCRIPTION
## Summary
Phase 1F of Batch 25 / master #202. Restructure the project dashboard into the new 4-quadrant layout that promotes AgentChattr as the primary operator interface.

Four files, +127/−37.

### New layout
- **Top-left** — AgentChattr chat, wrapped in a 2-px accent border and labelled `AgentChattr — primary chat` in the panel header.
- **Top-right** — Agent Terminals 2x2 grid in a new wrapper with an `Agent Terminals` header and a `?` tooltip that warns operators not to type into terminals directly (messages typed there are invisible to other agents — use the chat above instead).
- **Bottom-left** — GitHub panel (unchanged content, moved from top-right).
- **Bottom-right** — new `OperatorFeaturesPanel` placeholder listing the three features that land in #209/#210/#211.

### `src/components/ProjectDashboard.tsx`
- Swap the four quadrant contents. Drag-to-resize row/col behavior + min sizes preserved.
- Drop the orphaned Head-only `TerminalPanel` — the 2x2 grid in the top-right quadrant already renders the Head terminal as one of its four tiles, so the old top-left Head panel was redundant.

### New components
- `src/components/AgentTerminalsGrid.tsx` — wraps the existing `<TerminalGrid />` with the header + tooltip. Tooltip shows on hover and keyboard focus, with `role="tooltip"` and an `aria-label` on the trigger.
- `src/components/OperatorFeaturesPanel.tsx` — placeholder with three bulleted items (queue viewer, scheduled trigger, telegram bridge) referencing their sub-tickets.

### `src/components/TerminalGrid.tsx`
- Status dots gain a pulsing accent ring (`animate-ping`) when the agent is `running`. Idle/stopped/error keep the plain dot.

`ChatPanel` + `ControlBar` untouched — the \"primary\" highlight is applied by the parent wrapper `div` in `ProjectDashboard` so `ChatPanel` stays reusable anywhere.

## Acceptance criteria from #208
- ✅ Project page uses 4-quadrant layout (TL=Chat, TR=Terminals, BL=GitHub, BR=Operator Features).
- ✅ AgentChattr is visually highlighted as primary (2-px accent border + header label).
- ✅ Agent Terminals header has the `?` tooltip with the exact ticket copy.
- ✅ Terminal status dots show an activity ring when the agent is busy.
- ✅ Existing functionality (start/stop/restart buttons, drag-to-resize, expand/collapse) preserved — only parents/wrappers changed, no panel internals.
- ✅ Layout degrades to the existing min-size clamp behavior on narrow viewports.

## Test plan
- [ ] \`npx quadwork start\`, open a project page. Verify TL=Chat with accent border, TR=Agent Terminals header with `?`, BL=GitHub, BR=Operator Features list.
- [ ] Hover the `?` → tooltip appears with the exact copy: "These show what each agent is doing in their CLI session. **Do not type here directly** — use the AgentChattr chat above instead. Agents won't see messages typed in their terminals."
- [ ] Start an agent → its status dot in the top-right grid shows the pulsing accent ring.
- [ ] Drag the vertical / horizontal / center dividers → all four quadrants resize as before.
- [ ] Expand one terminal tile → other three collapse (existing behavior preserved).

Fixes #208
Parent: #202