### PR TITLE
[#211] Per-project Telegram Bridge widget + save-config

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -1005,7 +1005,28 @@ function getProjectTelegram(projectId) {
 router.get("/api/telegram", (req, res) => {
   const projectId = req.query.project || "";
   if (!projectId) return res.status(400).json({ error: "Missing project" });
-  res.json({ running: isTelegramRunning(projectId) });
+  // #211: expose whether credentials are configured + the chat_id,
+  // but never the raw bot token. Widget uses `configured` + the last
+  // 4 chars of the stored token to decide between "Set up" and
+  // "Edit credentials" copy.
+  let configured = false;
+  let chatId = "";
+  let bridgeInstalled = false;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const project = cfg.projects?.find((p) => p.id === projectId);
+    if (project?.telegram?.bot_token && project?.telegram?.chat_id) {
+      configured = true;
+      chatId = project.telegram.chat_id;
+    }
+    bridgeInstalled = fs.existsSync(path.join(BRIDGE_DIR, "telegram_bridge.py"));
+  } catch {}
+  res.json({
+    running: isTelegramRunning(projectId),
+    configured,
+    chat_id: chatId,
+    bridge_installed: bridgeInstalled,
+  });
 });
 
 router.post("/api/telegram", async (req, res) => {
@@ -1090,6 +1111,37 @@ router.post("/api/telegram", async (req, res) => {
         }
       } catch {}
       return res.json({ ok: true, env_key: envKey });
+    }
+    case "save-config": {
+      // #211: atomic save of bot_token + chat_id for the per-project
+      // Telegram Bridge widget. Unlike save-token (which requires
+      // project.telegram to already exist), save-config creates the
+      // telegram block on the fly for projects that haven't been
+      // configured yet. The raw token is written to ~/.quadwork/.env
+      // (0600) and replaced on the config entry with `env:KEY`.
+      const projectId = body.project_id;
+      const bot_token = typeof body.bot_token === "string" ? body.bot_token.trim() : "";
+      const chat_id = typeof body.chat_id === "string" ? body.chat_id.trim() : "";
+      if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      if (!bot_token || !chat_id) return res.json({ ok: false, error: "bot_token and chat_id are required" });
+      const envKey = envKeyForProject(projectId);
+      try { writeEnvToken(envKey, bot_token); }
+      catch (err) { return res.json({ ok: false, error: `Could not write .env: ${err.message}` }); }
+      try {
+        const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+        const cfg = JSON.parse(raw);
+        const project = cfg.projects?.find((p) => p.id === projectId);
+        if (!project) return res.json({ ok: false, error: "Unknown project" });
+        project.telegram = {
+          ...(project.telegram || {}),
+          bot_token: `env:${envKey}`,
+          chat_id,
+        };
+        fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+        return res.json({ ok: true, env_key: envKey });
+      } catch (err) {
+        return res.json({ ok: false, error: err.message || "Config write failed" });
+      }
     }
     default:
       return res.status(400).json({ error: "Unknown action" });

--- a/server/routes.js
+++ b/server/routes.js
@@ -1002,29 +1002,50 @@ function getProjectTelegram(projectId) {
   }
 }
 
-router.get("/api/telegram", (req, res) => {
+router.get("/api/telegram", async (req, res) => {
   const projectId = req.query.project || "";
   if (!projectId) return res.status(400).json({ error: "Missing project" });
-  // #211: expose whether credentials are configured + the chat_id,
-  // but never the raw bot token. Widget uses `configured` + the last
-  // 4 chars of the stored token to decide between "Set up" and
-  // "Edit credentials" copy.
+  // #211: expose whether credentials are configured + the chat_id
+  // and the bot's @username (fetched from Telegram's getMe, cached
+  // on the project entry). Never returns the raw bot token.
   let configured = false;
   let chatId = "";
+  let botUsername = "";
   let bridgeInstalled = false;
+  let cfg = null;
+  let project = null;
   try {
-    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
-    const project = cfg.projects?.find((p) => p.id === projectId);
+    cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    project = cfg.projects?.find((p) => p.id === projectId) || null;
     if (project?.telegram?.bot_token && project?.telegram?.chat_id) {
       configured = true;
       chatId = project.telegram.chat_id;
+      botUsername = project.telegram.bot_username || "";
     }
     bridgeInstalled = fs.existsSync(path.join(BRIDGE_DIR, "telegram_bridge.py"));
   } catch {}
+  // Lazy-resolve bot username via Telegram getMe the first time
+  // after a token is saved. Cache it on the project entry so later
+  // requests don't hit the network.
+  if (configured && !botUsername && project?.telegram?.bot_token && cfg) {
+    try {
+      const resolved = resolveToken(project.telegram.bot_token);
+      if (resolved) {
+        const r = await fetch(`https://api.telegram.org/bot${resolved}/getMe`);
+        const data = await r.json();
+        if (data && data.ok && data.result && typeof data.result.username === "string") {
+          botUsername = data.result.username;
+          project.telegram.bot_username = botUsername;
+          try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2)); } catch {}
+        }
+      }
+    } catch { /* non-fatal — widget will just show no username */ }
+  }
   res.json({
     running: isTelegramRunning(projectId),
     configured,
     chat_id: chatId,
+    bot_username: botUsername,
     bridge_installed: bridgeInstalled,
   });
 });
@@ -1136,6 +1157,9 @@ router.post("/api/telegram", async (req, res) => {
           ...(project.telegram || {}),
           bot_token: `env:${envKey}`,
           chat_id,
+          // Clear any cached bot_username — the next GET /api/telegram
+          // will re-fetch it from Telegram's getMe for the new token.
+          bot_username: "",
         };
         fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
         return res.json({ ok: true, env_key: envKey });

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -3,14 +3,15 @@
 import PanelHeader from "./PanelHeader";
 import OvernightQueueWidget from "./OvernightQueueWidget";
 import ScheduledTriggerWidget from "./ScheduledTriggerWidget";
+import TelegramBridgeWidget from "./TelegramBridgeWidget";
 
 /**
  * Bottom-right quadrant of the project dashboard (#208).
  *
  * Hosts the operator-only widgets:
  *   - #209 OVERNIGHT-QUEUE.md viewer/editor
- *   - #210 Scheduled Trigger (this ticket)
- *   - #211 Telegram Bridge (pending)
+ *   - #210 Scheduled Trigger
+ *   - #211 Telegram Bridge (this ticket)
  */
 export default function OperatorFeaturesPanel({ projectId }: { projectId: string }) {
   return (
@@ -21,9 +22,7 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
           <OvernightQueueWidget projectId={projectId} />
         </div>
         <ScheduledTriggerWidget projectId={projectId} />
-        <div className="shrink-0 px-3 py-2 border border-dashed border-border text-[10px] text-text-muted">
-          Telegram Bridge (#211) — coming soon
-        </div>
+        <TelegramBridgeWidget projectId={projectId} />
       </div>
     </div>
   );

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import TelegramSetupModal from "./TelegramSetupModal";
+
+interface TelegramBridgeWidgetProps {
+  projectId: string;
+}
+
+interface TelegramStatus {
+  running: boolean;
+  configured: boolean;
+  chat_id: string;
+  bridge_installed: boolean;
+}
+
+async function callTelegram(action: string, body: Record<string, unknown>) {
+  const r = await fetch(`/api/telegram?action=${encodeURIComponent(action)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await r.json();
+  if (!r.ok || data.ok === false) throw new Error(data.error || `${r.status}`);
+  return data;
+}
+
+/**
+ * Per-project Telegram Bridge widget (#211).
+ *
+ * Lives in the bottom-right Operator Features quadrant. Shows
+ * whether the bridge is running + chat id, and gives the operator
+ * start/stop + a setup modal to configure bot_token + chat_id from
+ * scratch.
+ */
+export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidgetProps) {
+  const [status, setStatus] = useState<TelegramStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [setupOpen, setSetupOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch(`/api/telegram?project=${encodeURIComponent(projectId)}`);
+      if (!r.ok) throw new Error(`${r.status}`);
+      const data = (await r.json()) as TelegramStatus;
+      setStatus(data);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    load();
+    const id = window.setInterval(load, 5000);
+    return () => window.clearInterval(id);
+  }, [load]);
+
+  const start = async () => {
+    setBusy(true); setError(null);
+    try {
+      // The first-time path clones + pip-installs the bridge before
+      // spawning it. "install" is a no-op if it's already installed.
+      if (status && !status.bridge_installed) {
+        await callTelegram("install", {});
+      }
+      await callTelegram("start", { project_id: projectId });
+      await load();
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(false); }
+  };
+
+  const stop = async () => {
+    setBusy(true); setError(null);
+    try {
+      await callTelegram("stop", { project_id: projectId });
+      await load();
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(false); }
+  };
+
+  const onSaveCredentials = async (bot_token: string, chat_id: string) => {
+    await callTelegram("save-config", { project_id: projectId, bot_token, chat_id });
+    // After saving, try to start immediately — matches the
+    // "Save and start bridge" affordance in the modal.
+    try {
+      if (status && !status.bridge_installed) await callTelegram("install", {});
+      await callTelegram("start", { project_id: projectId });
+    } catch (e) {
+      // Leave the save persisted even if start fails; the operator
+      // can retry from the widget.
+      setError((e as Error).message);
+    }
+    await load();
+  };
+
+  const configured = !!status?.configured;
+  const running = !!status?.running;
+
+  return (
+    <>
+      <div className="flex flex-col border border-border">
+        <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
+          <span className="text-[11px] text-text-muted uppercase tracking-wider">Telegram Bridge</span>
+          {error && <span className="text-[10px] text-error max-w-[60%] truncate" title={error}>err: {error}</span>}
+        </div>
+        <div className="p-3 flex flex-col gap-2">
+          {!configured ? (
+            <>
+              <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                <span className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                <span>Not configured</span>
+              </div>
+              <button
+                onClick={() => setSetupOpen(true)}
+                disabled={busy}
+                className="self-start px-3 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 transition-colors"
+              >
+                Set up Telegram Bridge
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2 text-[11px]">
+                {running ? (
+                  <>
+                    <span className="relative inline-flex items-center justify-center w-2 h-2">
+                      <span className="absolute inline-flex h-full w-full rounded-full bg-accent opacity-60 animate-ping" />
+                      <span className="relative w-1.5 h-1.5 rounded-full bg-accent" />
+                    </span>
+                    <span className="text-accent">Running</span>
+                  </>
+                ) : (
+                  <>
+                    <span className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                    <span className="text-text-muted">Stopped</span>
+                  </>
+                )}
+                {status?.chat_id && (
+                  <span className="text-text-muted tabular-nums">· chat: {status.chat_id}</span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 flex-wrap">
+                {running ? (
+                  <button
+                    onClick={stop}
+                    disabled={busy}
+                    className="px-3 py-1 text-[11px] text-text-muted border border-border hover:text-error hover:border-error/40 disabled:opacity-50 transition-colors"
+                  >
+                    {busy ? "Stopping…" : "Stop"}
+                  </button>
+                ) : (
+                  <button
+                    onClick={start}
+                    disabled={busy}
+                    className="px-3 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 transition-colors"
+                  >
+                    {busy ? "Starting…" : "Start"}
+                  </button>
+                )}
+                <button
+                  onClick={() => setSetupOpen(true)}
+                  disabled={busy}
+                  className="px-3 py-1 text-[11px] text-text-muted border border-border hover:text-text disabled:opacity-50 transition-colors"
+                >
+                  How to set up
+                </button>
+                <button
+                  onClick={() => setSetupOpen(true)}
+                  disabled={busy}
+                  className="px-3 py-1 text-[11px] text-text-muted border border-border hover:text-text disabled:opacity-50 transition-colors"
+                >
+                  Edit credentials
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+      <TelegramSetupModal
+        open={setupOpen}
+        initialChatId={status?.chat_id || ""}
+        onClose={() => setSetupOpen(false)}
+        onSave={onSaveCredentials}
+      />
+    </>
+  );
+}

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -11,6 +11,7 @@ interface TelegramStatus {
   running: boolean;
   configured: boolean;
   chat_id: string;
+  bot_username: string;
   bridge_installed: boolean;
 }
 
@@ -122,7 +123,7 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
             </>
           ) : (
             <>
-              <div className="flex items-center gap-2 text-[11px]">
+              <div className="flex items-center gap-2 text-[11px] flex-wrap">
                 {running ? (
                   <>
                     <span className="relative inline-flex items-center justify-center w-2 h-2">
@@ -137,8 +138,11 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
                     <span className="text-text-muted">Stopped</span>
                   </>
                 )}
+                {status?.bot_username && (
+                  <span className="text-text-muted">· Bot: @{status.bot_username}</span>
+                )}
                 {status?.chat_id && (
-                  <span className="text-text-muted tabular-nums">· chat: {status.chat_id}</span>
+                  <span className="text-text-muted tabular-nums">· Chat: {status.chat_id}</span>
                 )}
               </div>
               <div className="flex items-center gap-2 flex-wrap">

--- a/src/components/TelegramSetupModal.tsx
+++ b/src/components/TelegramSetupModal.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface TelegramSetupModalProps {
+  open: boolean;
+  initialChatId?: string;
+  onClose: () => void;
+  onSave: (botToken: string, chatId: string) => Promise<void>;
+}
+
+/**
+ * Step-by-step setup modal for the per-project Telegram Bridge (#211).
+ *
+ * Walks a newbie through creating a bot with @BotFather, grabbing
+ * their chat id, pasting both into the form, and hitting
+ * "Save and start bridge". The save path calls the parent's
+ * `onSave` which hits POST /api/telegram?action=save-config and
+ * then POST /api/telegram?action=start.
+ */
+export default function TelegramSetupModal({ open, initialChatId = "", onClose, onSave }: TelegramSetupModalProps) {
+  const [botToken, setBotToken] = useState("");
+  const [chatId, setChatId] = useState(initialChatId);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { if (open) setChatId(initialChatId); }, [open, initialChatId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(botToken.trim(), chatId.trim());
+      onClose();
+    } catch (e) {
+      setError((e as Error).message || "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="telegram-setup-title"
+    >
+      <div
+        className="relative mx-4 max-w-xl w-full max-h-[90vh] overflow-auto rounded-lg border border-white/10 bg-neutral-950 p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded p-1 text-neutral-400 hover:bg-white/5 hover:text-white"
+        >
+          <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M4 4l12 12M16 4L4 16" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <h2 id="telegram-setup-title" className="text-base font-semibold text-white">Set up your Telegram Bridge</h2>
+        <p className="mt-2 text-[12px] leading-relaxed text-neutral-300">
+          The bridge forwards AgentChattr messages from your project to a Telegram chat, so you can read and reply on your phone.
+        </p>
+
+        <div className="mt-4 text-[12px] text-neutral-300 space-y-3">
+          <section>
+            <h3 className="text-[13px] font-semibold text-white">Step 1 — Create a Telegram bot</h3>
+            <ol className="mt-1 pl-4 list-decimal space-y-0.5 text-neutral-300">
+              <li>Open Telegram and search for <b>@BotFather</b>.</li>
+              <li>Send <code className="bg-white/5 px-1 rounded text-[11px]">/newbot</code> and follow the prompts.</li>
+              <li>Choose a name and username (must end in <code className="bg-white/5 px-1 rounded text-[11px]">bot</code>).</li>
+              <li>BotFather replies with a <b>bot token</b> that looks like <code className="bg-white/5 px-1 rounded text-[11px]">123456:ABC-DEF1234ghIkl…</code>. Copy it.</li>
+            </ol>
+          </section>
+
+          <section>
+            <h3 className="text-[13px] font-semibold text-white">Step 2 — Get your chat ID</h3>
+            <ol className="mt-1 pl-4 list-decimal space-y-0.5 text-neutral-300">
+              <li>Open Telegram and search for your new bot by username.</li>
+              <li>Click <b>Start</b> and send any message (e.g. <code className="bg-white/5 px-1 rounded text-[11px]">hello</code>).</li>
+              <li>
+                Open this URL in your browser (replace <code className="bg-white/5 px-1 rounded text-[11px]">YOUR_TOKEN</code>):
+                <pre className="mt-1 p-2 bg-white/5 rounded text-[11px] text-neutral-200 overflow-auto">https://api.telegram.org/botYOUR_TOKEN/getUpdates</pre>
+              </li>
+              <li>Look for <code className="bg-white/5 px-1 rounded text-[11px]">&quot;chat&quot;:&#123;&quot;id&quot;:&lt;NUMBER&gt;</code> in the JSON. That number is your <b>chat id</b>.</li>
+            </ol>
+            <p className="mt-1 text-neutral-400">Or use this curl command in your terminal:</p>
+            <pre className="mt-1 p-2 bg-white/5 rounded text-[11px] text-neutral-200 overflow-auto">curl -s &apos;https://api.telegram.org/bot&lt;YOUR_TOKEN&gt;/getUpdates&apos; | grep -o &apos;&quot;id&quot;:[0-9-]*&apos; | head -1</pre>
+          </section>
+
+          <section>
+            <h3 className="text-[13px] font-semibold text-white">Step 3 — Paste credentials below</h3>
+            <div className="mt-2 flex flex-col gap-2">
+              <label className="text-[11px] text-neutral-400">Bot token
+                <input
+                  type="password"
+                  value={botToken}
+                  onChange={(e) => setBotToken(e.target.value)}
+                  placeholder="123456:ABC-DEF…"
+                  className="mt-0.5 w-full bg-transparent border border-white/10 px-2 py-1 text-[12px] text-white outline-none focus:border-accent font-mono"
+                />
+              </label>
+              <label className="text-[11px] text-neutral-400">Chat id
+                <input
+                  type="text"
+                  value={chatId}
+                  onChange={(e) => setChatId(e.target.value)}
+                  placeholder="123456789"
+                  className="mt-0.5 w-full bg-transparent border border-white/10 px-2 py-1 text-[12px] text-white outline-none focus:border-accent font-mono"
+                />
+              </label>
+              {error && <div className="text-[11px] text-error">{error}</div>}
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving || !botToken.trim() || !chatId.trim()}
+                className="mt-1 self-start px-3 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {saving ? "Saving…" : "Save and start bridge"}
+              </button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 2C of Batch 25 / master #202. Adds a per-project Telegram Bridge widget to the bottom-right operator panel with a step-by-step setup modal for first-time users. Each project keeps its own bot token + chat id, so messages from different projects don't all dump into one channel.

Four files: \`server/routes.js\` (+51/−3), new \`src/components/TelegramBridgeWidget.tsx\` (+189), new \`src/components/TelegramSetupModal.tsx\` (+141), \`src/components/OperatorFeaturesPanel.tsx\` (+3/−6).

### Backend — \`server/routes.js\`
- **\`GET /api/telegram?project={id}\`** now also returns \`configured\`, \`chat_id\`, and \`bridge_installed\` so the widget knows whether to show the **Set Up** button or the Start/Stop controls. The raw bot token is **never** exposed over the API — only whether credentials are present.
- **New action \`save-config\`** (POST \`/api/telegram?action=save-config\`) accepts \`{ project_id, bot_token, chat_id }\` atomically: writes the raw token to \`~/.quadwork/.env\` (0600) via the existing \`writeEnvToken\` helper, then writes \`env:KEY\` onto the project entry's telegram block. Unlike the existing \`save-token\` action, \`save-config\` **creates the \`telegram\` block on the fly** for projects that have never been configured — so the widget can go from zero-config to running in one click.

### Frontend — \`TelegramSetupModal.tsx\`
Step-by-step modal matching the ticket copy exactly:
- BotFather walkthrough with the \`/newbot\` flow.
- Chat-id via browser URL **and** a copy-pasteable curl command.
- Token + chat-id form.
- Single **\"Save and start bridge\"** button.
- Escape + click-outside close, \`aria-modal\` + labelled heading.

### Frontend — \`TelegramBridgeWidget.tsx\`
- **Not configured** — single \"Set up Telegram Bridge\" button opens the modal.
- **Configured + stopped** — Status dot, chat id, Start / How to set up / Edit credentials buttons.
- **Running** — pulsing accent Running dot, chat id, Stop / How to set up / Edit credentials buttons.
- Polls \`GET /api/telegram\` every 5s. Start path calls \`install\` once (no-op if already installed) then \`start\`. Save path calls \`save-config\` → \`install\` → \`start\` so the modal's single button does the whole thing; save persists even if the later start fails so the operator can retry.

### \`OperatorFeaturesPanel.tsx\`
Embeds the new widget below \`ScheduledTriggerWidget\`. Drops the \"Telegram Bridge (#211) — coming soon\" placeholder.

## Acceptance criteria from #211
- ✅ Each project can configure its own bot token + chat id (stored on its own \`config.json\` entry, token via \`.env\` reference).
- ✅ Setup instructions modal walks newbies through bot creation step-by-step with the exact ticket copy.
- ✅ Curl command for getting chat id is provided.
- ✅ Start/Stop works per project (existing start/stop actions already accept \`project_id\`).
- ✅ Status shows running state + chat id.
- ✅ Multiple projects can run independent telegram bridges simultaneously (per-project PID file in \`~/.quadwork/telegram-bridge-{id}.pid\` was already in place).
- ✅ Credentials stored in \`~/.quadwork/config.json\` + \`~/.quadwork/.env\` (the \`.env\` is created with 0600 by the existing \`writeEnvToken\` helper).

### Out of scope
- The existing global Telegram section on the Settings page is left in place — sub-J (#212) handles the Settings cleanup pass.
- No changes to \`bin/quadwork.js\` wizard: the widget is the new preferred way to configure Telegram for a project after creation, and the wizard's existing flow still works for users who want to set it up at create time.

## Test plan
- [ ] Start dashboard, open a project. Bottom-right shows the new Telegram Bridge widget with "Not configured" + \"Set up Telegram Bridge\" button.
- [ ] Click setup → modal opens with Steps 1-3 and the curl command. Paste a fake token + chat id → Save and start bridge. Widget flips to Running (or shows an error if the bot token is bad — save still persists).
- [ ] \`curl http://127.0.0.1:8400/api/telegram?project=foo\` → returns \`{ running, configured, chat_id, bridge_installed }\`, **no bot token in response**.
- [ ] Stop bridge → status returns to Stopped. Click Start again → comes back up without re-entering credentials.
- [ ] Click Edit credentials → modal reopens with chat id pre-filled, token field empty (for security). Paste new token + chat id → save → new credentials persisted.
- [ ] Second project: configure a different bot token + chat id. Both projects can run independently — separate PID files, separate toml configs.
- [ ] Grep \`~/.quadwork/.env\` — contains \`TELEGRAM_BOT_TOKEN_FOO=...\` with 0600 permissions. Grep \`~/.quadwork/config.json\` — project entry has \`telegram.bot_token = \"env:TELEGRAM_BOT_TOKEN_FOO\"\`, never the raw token.

Fixes #211
Parent: #202