### PR TITLE
[#223] Fix missing os import in server/index.js

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ const express = require("express");
 const http = require("http");
 const path = require("path");
 const fs = require("fs");
+const os = require("os");
 const { WebSocketServer } = require("ws");
 const pty = require("node-pty");
 const { spawn } = require("child_process");


### PR DESCRIPTION
Adds `const os = require("os")` so queuePathFor() works. Fixes #223.