### PR TITLE
[#228] Auto-prepend @head when no known agent mentioned in chat

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -179,8 +179,14 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
 
   // Send message
   const send = () => {
-    const text = input.trim();
-    if (!text || sending) return;
+    const raw = input.trim();
+    if (!raw || sending) return;
+    // #228: if the operator didn't tag a known agent, prepend
+    // `@head ` so the message has somewhere to go. Unknown
+    // `@whatever` mentions don't count — Head is still added.
+    // Known agents: head, dev, reviewer1, reviewer2.
+    const KNOWN_AGENT_RE = /@(head|dev|reviewer1|reviewer2)\b/i;
+    const text = KNOWN_AGENT_RE.test(raw) ? raw : `@head ${raw}`;
     setSending(true);
     setSendError(null);
     fetch(`/api/chat${projectId ? `?project=${encodeURIComponent(projectId)}` : ""}`, {


### PR DESCRIPTION
## Summary
Phase 1C of Batch 26 / master #225. The chat panel's \`send()\` now prepends \`@head \` to any message that doesn't already mention a known agent. Untagged messages had no routing target before — Head needs to see them so it can act on the operator's request.

Single file: \`src/components/ChatPanel.tsx\`, +8/−2.

### Changes
- \`send()\`:
  - Capture the trimmed input as \`raw\`.
  - Test against \`/@(head|dev|reviewer1|reviewer2)\\b/i\`.
  - If no known agent matches, post \`\${"@head"} \${raw}\`; otherwise post \`raw\` unchanged.
- The textarea state is unchanged (\`setInput("")\` still clears only after a successful send), so the operator sees what they typed in the input until the message lands in the chat list with the prepended version.

### Match table from #228
| Input | Sent as |
|-------|---------|
| \`hello\` | \`@head hello\` |
| \`fix the bug\` | \`@head fix the bug\` |
| \`@head fix the bug\` | unchanged |
| \`@dev start working\` | unchanged |
| \`@reviewer1 status?\` | unchanged |
| \`@reviewer1 @reviewer2 review #100\` | unchanged |
| \`@somebody hi\` | \`@head @somebody hi\` |

The regex uses \`\\b\` so \`@reviewer1abc\` would not falsely match.

## Acceptance criteria from #228
- ✅ Message without any known agent tag → \`@head \` prepended.
- ✅ Message with at least one known agent tag → unchanged.
- ✅ Unknown \`@whatever\` tags don't count — Head still gets prepended.
- ✅ Visual: input field still shows what user typed; the message in chat shows the prepended version.

Types clean (\`tsc --noEmit\`). No new deps.

Please review.

Fixes #228
Parent: #225