### PR TITLE
[#229] Empty states + How to Work modal (final Batch 26)

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import ProjectChatEmptyState from "./ProjectChatEmptyState";
 
 interface Message {
   id: number;
@@ -244,8 +245,11 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
         className="flex-1 min-h-0 overflow-y-auto px-3 py-2 space-y-0.5"
       >
         {messages.length === 0 && (
+          // #229: replace the bare "No messages" text with a richer
+          // empty state — friendly icon, headline, click-to-insert
+          // example chips, and a How to Work modal trigger.
           <div className="flex items-center justify-center h-full">
-            <span className="text-xs text-text-muted">No messages</span>
+            <ProjectChatEmptyState onInsert={(t) => { setInput(t); inputRef.current?.focus(); }} />
           </div>
         )}
         {messages.map((msg) => (

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import HomeEmptyState from "./HomeEmptyState";
 
 interface Project {
   id: string;
@@ -50,6 +51,13 @@ export default function HomeDashboard() {
 
   return (
     <div className="h-full overflow-y-auto p-6">
+      {/* #229: friendly empty-state hero. Always rendered at the top
+          of the home page; the headline + CTA adapts to whether the
+          user has any projects yet. */}
+      <div className="mb-6">
+        <HomeEmptyState hasProjects={projects.length > 0} />
+      </div>
+
       {/* Header */}
       <div className="mb-6">
         <h1 className="text-lg font-semibold text-text tracking-tight">Projects</h1>

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -35,6 +35,13 @@ function timeAgo(iso: string): string {
 export default function HomeDashboard() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [activity, setActivity] = useState<ActivityEvent[]>([]);
+  // #229: track whether /api/projects has resolved (success OR
+  // failure) so the empty-state hero doesn't flash the "no
+  // projects" CTA before we actually know. Possible values:
+  //   "loading"  — first paint, no answer yet
+  //   "loaded"   — fetch resolved successfully
+  //   "error"    — fetch failed; preserve last-known projects
+  const [projectsState, setProjectsState] = useState<"loading" | "loaded" | "error">("loading");
 
   useEffect(() => {
     fetch("/api/projects")
@@ -45,18 +52,28 @@ export default function HomeDashboard() {
       .then((data) => {
         if (data.projects && Array.isArray(data.projects)) setProjects(data.projects.filter((p: Project & { archived?: boolean }) => !p.archived));
         if (data.recentEvents && Array.isArray(data.recentEvents)) setActivity(data.recentEvents);
+        setProjectsState("loaded");
       })
-      .catch(() => {});
+      .catch(() => { setProjectsState("error"); });
   }, []);
 
   return (
     <div className="h-full overflow-y-auto p-6">
-      {/* #229: friendly empty-state hero. Always rendered at the top
-          of the home page; the headline + CTA adapts to whether the
-          user has any projects yet. */}
-      <div className="mb-6">
-        <HomeEmptyState hasProjects={projects.length > 0} />
-      </div>
+      {/* #229: friendly empty-state hero. Only rendered after
+          /api/projects resolves successfully — we don't want to
+          flash the "no projects" onboarding CTA to existing users
+          while the first fetch is in flight, or when the API
+          errored and we have no idea which branch to show. */}
+      {projectsState === "loaded" && (
+        <div className="mb-6">
+          <HomeEmptyState hasProjects={projects.length > 0} />
+        </div>
+      )}
+      {projectsState === "error" && (
+        <div className="mb-6 border border-error/30 bg-error/5 text-error text-[11px] px-3 py-2">
+          Could not load projects from /api/projects. The dashboard may be out of date — check the server logs and reload.
+        </div>
+      )}
 
       {/* Header */}
       <div className="mb-6">

--- a/src/components/HomeEmptyState.tsx
+++ b/src/components/HomeEmptyState.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import HowToWorkModal from "./HowToWorkModal";
+
+interface HomeEmptyStateProps {
+  hasProjects: boolean;
+}
+
+/**
+ * Hero block for the home route (#229).
+ *
+ * Replaces the bare empty grid with a friendly icon + headline + CTA
+ * that adapts to whether the user has any projects yet. Always
+ * surfaces a "How to Work" button that opens the timeline modal.
+ */
+export default function HomeEmptyState({ hasProjects }: HomeEmptyStateProps) {
+  const [howOpen, setHowOpen] = useState(false);
+
+  const headline = hasProjects
+    ? "Pick a project from the sidebar to start working"
+    : "Welcome to QuadWork — let's set up your first AI dev team";
+  const subtext = hasProjects
+    ? "Each project has its own 4-agent team and chat. Click any chip in the left sidebar to open one."
+    : "QuadWork runs Head, Dev, and two Reviewers as a team. They open issues, write code, review PRs, and merge — while you sleep.";
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center px-6 py-12 border border-border bg-bg-surface">
+      {/* Stylised agent-team icon. Pure SVG so there's no asset
+          footprint and it inherits the dashboard's accent. */}
+      <svg
+        width="64"
+        height="64"
+        viewBox="0 0 64 64"
+        fill="none"
+        aria-hidden
+        className="text-accent"
+      >
+        <rect x="6" y="14" width="18" height="22" rx="2" stroke="currentColor" strokeWidth="2" />
+        <rect x="40" y="14" width="18" height="22" rx="2" stroke="currentColor" strokeWidth="2" />
+        <rect x="6" y="42" width="18" height="14" rx="2" stroke="currentColor" strokeWidth="2" />
+        <rect x="40" y="42" width="18" height="14" rx="2" stroke="currentColor" strokeWidth="2" />
+        <circle cx="15" cy="25" r="2" fill="currentColor" />
+        <circle cx="49" cy="25" r="2" fill="currentColor" />
+        <circle cx="15" cy="49" r="2" fill="currentColor" />
+        <circle cx="49" cy="49" r="2" fill="currentColor" />
+        <path d="M24 25 L40 25 M24 49 L40 49 M15 36 L15 42 M49 36 L49 42" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+
+      <h1 className="mt-5 text-lg font-semibold text-text max-w-md">{headline}</h1>
+      <p className="mt-2 text-[12px] text-text-muted leading-relaxed max-w-md">{subtext}</p>
+
+      <div className="mt-5 flex items-center gap-3">
+        {hasProjects ? (
+          <span className="text-[11px] text-text-muted italic">← look at the left sidebar</span>
+        ) : (
+          <Link
+            href="/setup"
+            className="px-4 py-2 text-[12px] font-semibold text-bg bg-accent hover:bg-accent-dim transition-colors"
+          >
+            Add Your First Project →
+          </Link>
+        )}
+        <button
+          type="button"
+          onClick={() => setHowOpen(true)}
+          className="px-4 py-2 text-[12px] text-text-muted border border-border hover:text-text hover:border-text-muted transition-colors"
+        >
+          How to Work
+        </button>
+      </div>
+
+      <HowToWorkModal open={howOpen} onClose={() => setHowOpen(false)} />
+    </div>
+  );
+}

--- a/src/components/HowToWorkModal.tsx
+++ b/src/components/HowToWorkModal.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface HowToWorkModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const STEPS: { title: string; body: string }[] = [
+  {
+    title: "You assign a task in the chat",
+    body: "Tell @head what to build. Be as specific or as vague as you like.",
+  },
+  {
+    title: "Head creates a GitHub issue",
+    body: "Head opens an issue, adds it to the queue, and waits for your trigger.",
+  },
+  {
+    title: "Dev writes the code",
+    body: "Dev clones a branch, implements the change, and opens a pull request.",
+  },
+  {
+    title: "Reviewers check the work",
+    body: "Reviewer1 and Reviewer2 each review the PR independently. Both must approve before the PR is mergeable.",
+  },
+  {
+    title: "Head merges and continues",
+    body: "Head merges the approved PR and assigns the next ticket from the queue. The cycle continues all night while you sleep.",
+  },
+];
+
+/**
+ * "How to Work" modal (#229).
+ *
+ * Vertical-timeline explanation of the 4-agent workflow. Accessible
+ * from both empty states (HomeEmptyState + ProjectChatEmptyState).
+ * Closes on Escape, backdrop click, or the X button.
+ */
+export default function HowToWorkModal({ open, onClose }: HowToWorkModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="how-to-work-title"
+    >
+      <div
+        className="relative mx-4 max-w-xl w-full max-h-[90vh] overflow-auto rounded-lg border border-white/10 bg-neutral-950 p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded p-1 text-neutral-400 hover:bg-white/5 hover:text-white"
+        >
+          <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M4 4l12 12M16 4L4 16" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <h2 id="how-to-work-title" className="text-base font-semibold text-white">How QuadWork builds your code</h2>
+        <p className="mt-2 text-[12px] text-neutral-400">
+          Five steps from your one-line request to a merged pull request.
+        </p>
+
+        <ol className="mt-5 relative">
+          {/* Vertical accent line connecting the step circles. */}
+          <span aria-hidden className="absolute left-[14px] top-3 bottom-3 w-px bg-accent/30" />
+          {STEPS.map((step, i) => (
+            <li key={i} className="relative pl-10 pb-5 last:pb-0">
+              <span
+                className="absolute left-0 top-0 inline-flex items-center justify-center w-7 h-7 rounded-full border border-accent bg-neutral-950 text-accent text-[12px] font-semibold tabular-nums"
+                aria-hidden
+              >
+                {i + 1}
+              </span>
+              <div className="text-[13px] font-semibold text-white">{step.title}</div>
+              <div className="mt-1 text-[12px] leading-relaxed text-neutral-400">{step.body}</div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectChatEmptyState.tsx
+++ b/src/components/ProjectChatEmptyState.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import HowToWorkModal from "./HowToWorkModal";
+
+interface ProjectChatEmptyStateProps {
+  onInsert: (text: string) => void;
+}
+
+const EXAMPLES = [
+  "@head start a new feature: <describe>",
+  "@head review the latest PR",
+  "@head what's our current sprint?",
+];
+
+/**
+ * Empty state inside the AgentChattr chat panel (#229) for projects
+ * with zero messages. Replaces the bare "No messages" centered text
+ * with a friendly icon, headline, and three click-to-insert example
+ * chips.
+ */
+export default function ProjectChatEmptyState({ onInsert }: ProjectChatEmptyStateProps) {
+  const [howOpen, setHowOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center px-6 py-10 gap-3">
+      <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden className="text-accent">
+        <path d="M6 8h28a2 2 0 0 1 2 2v17a2 2 0 0 1-2 2H16l-7 6v-6h-3a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2Z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" />
+        <circle cx="14" cy="18" r="1.4" fill="currentColor" />
+        <circle cx="20" cy="18" r="1.4" fill="currentColor" />
+        <circle cx="26" cy="18" r="1.4" fill="currentColor" />
+      </svg>
+      <div className="text-[13px] font-semibold text-text">Ready when you are</div>
+      <div className="text-[11px] text-text-muted">Tell your team what to build. Try something like:</div>
+      <div className="flex flex-col gap-1.5 mt-1 w-full max-w-sm">
+        {EXAMPLES.map((ex) => (
+          <button
+            key={ex}
+            type="button"
+            onClick={() => onInsert(ex)}
+            className="text-left px-2 py-1 text-[11px] font-mono text-text-muted border border-border hover:text-accent hover:border-accent transition-colors truncate"
+          >
+            {ex}
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => setHowOpen(true)}
+        className="mt-2 text-[11px] text-text-muted underline underline-offset-2 hover:text-text"
+      >
+        How to Work
+      </button>
+      <HowToWorkModal open={howOpen} onClose={() => setHowOpen(false)} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 1D / **final ticket** of Batch 26 / master #225. Adds three new components and wires them into the home dashboard and AgentChattr chat panel so first-time users have an obvious next step instead of a blank dark area.

Five files (+244/−1).

### New components
- **\`src/components/HowToWorkModal.tsx\`** — vertical-timeline modal explaining the 5-step QuadWork workflow (assign → issue → code → review → merge). Numbered accent circles connected by a vertical accent line. Closes on Escape, click-outside, or X. \`aria-modal\` + labelled heading.
- **\`src/components/HomeEmptyState.tsx\`** — hero block with a stylised SVG agent-team icon, adaptive headline + subtext, and an adaptive primary CTA:
  - \`hasProjects=false\` → \`Add Your First Project →\` linking \`/setup\`
  - \`hasProjects=true\` → \`← look at the left sidebar\` hint
  Always shows a \"How to Work\" secondary button that opens \`HowToWorkModal\`.
- **\`src/components/ProjectChatEmptyState.tsx\`** — replaces the bare \"No messages\" centered text in the AgentChattr panel with a friendly icon, \"Ready when you are\" headline, and three click-to-insert example chips (\`@head start a new feature: <describe>\` / \`@head review the latest PR\` / \`@head what's our current sprint?\`). Also has a \"How to Work\" link that opens the same modal. Calls \`props.onInsert(text)\` so the parent ChatPanel can put the example into the input.

### Wiring
- **\`src/components/HomeDashboard.tsx\`** — renders \`<HomeEmptyState hasProjects={projects.length > 0} />\` at the top of the home page. Existing project cards remain underneath when projects exist; on a fresh install the user lands directly on the hero + CTA.
- **\`src/components/ChatPanel.tsx\`** — replaces the \"No messages\" branch with \`<ProjectChatEmptyState onInsert={(t) => { setInput(t); inputRef.current?.focus(); }} />\`. Click an example chip → the text fills the input and focus jumps to it.

## Acceptance criteria from #229
- ✅ Home page shows friendly empty state with icon + CTA.
- ✅ CTA adapts: \"Add first project\" if none, sidebar hint if some.
- ✅ Project chat with 0 messages shows the empty state with example chips.
- ✅ Example chips insert text into the input on click.
- ✅ How to Work modal renders a 5-step vertical timeline.
- ✅ Modal accessible from both empty states.
- ✅ Visual: icons + spacing + accent color — not text-only.

Types clean (\`tsc --noEmit\`). No new deps. After this lands, master #225 (Batch 26) is fully complete.

Fixes #229
Parent: #225