### PR TITLE
[#252] sub-C: Auto-spawn AgentChattr after web wizard add-config

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -935,9 +935,27 @@ router.post("/api/setup", (req, res) => {
         fetch(
           `http://127.0.0.1:${qwPort}/api/agentchattr/${encodeURIComponent(id)}/restart`,
           { method: "POST" },
-        ).catch((err) => {
-          console.warn(`[setup] auto-spawn AgentChattr for ${id} failed:`, err.message || err);
-        });
+        )
+          .then(async (r) => {
+            // /restart reports spawn failures (e.g. port collision —
+            // server/index.js:650-668) as HTTP 500, so a resolved
+            // fetch is not the same thing as a successful spawn. Log
+            // non-2xx responses with status and body so the operator
+            // can see why the auto-spawn silently didn't take.
+            if (!r.ok) {
+              let detail = "";
+              try { detail = (await r.text()).slice(0, 500); } catch {}
+              console.warn(
+                `[setup] auto-spawn AgentChattr for ${id} returned HTTP ${r.status}: ${detail}`,
+              );
+            }
+          })
+          .catch((err) => {
+            console.warn(
+              `[setup] auto-spawn AgentChattr for ${id} failed:`,
+              err.message || err,
+            );
+          });
       } catch (err) {
         console.warn(`[setup] auto-spawn AgentChattr for ${id} skipped:`, err.message || err);
       }

--- a/server/routes.js
+++ b/server/routes.js
@@ -922,6 +922,26 @@ router.post("/api/setup", (req, res) => {
       // ~/.quadwork/{id}/OVERNIGHT-QUEUE.md.
       writeOvernightQueueFileSafe(id, name || id, repo);
 
+      // Batch 28 / #392 / quadwork#252: auto-spawn the per-project
+      // AgentChattr process. The CLI wizard's writeAgentChattrConfig
+      // does this; the web wizard previously left the install dormant
+      // until the user clicked Restart, so MCP fell through to a stale
+      // instance on port 8300. Mirror the loopback-restart pattern
+      // already used by the agentchattr-config branch above. Failures
+      // are non-fatal — the dashboard's Restart button is still
+      // available, and per the issue add-config must still return ok.
+      try {
+        const qwPort = cfg.port || 8400;
+        fetch(
+          `http://127.0.0.1:${qwPort}/api/agentchattr/${encodeURIComponent(id)}/restart`,
+          { method: "POST" },
+        ).catch((err) => {
+          console.warn(`[setup] auto-spawn AgentChattr for ${id} failed:`, err.message || err);
+        });
+      } catch (err) {
+        console.warn(`[setup] auto-spawn AgentChattr for ${id} skipped:`, err.message || err);
+      }
+
       return res.json({ ok: true });
     }
     default:


### PR DESCRIPTION
Fixes #252
Tracker: realproject7/agent-os#392
Master: #249

## Summary
- After `add-config` saves the project successfully, POST `/api/agentchattr/{id}/restart` over loopback to spawn the per-project AgentChattr process.
- Mirrors the existing pattern already used by the `agentchattr-config` branch (`server/routes.js:840`) and the CLI wizard's `writeAgentChattrConfig`.
- Failures are caught and logged via `console.warn` — the wizard still returns `ok: true` and the dashboard's Restart button remains a manual fallback, per the issue's "non-fatal" requirement.

## Why
Web wizard previously left the install dormant until the user clicked Restart, so the chat fell through to whatever stale AgentChattr instance happened to be on port 8300 (often from another project).

## Acceptance criteria
- [x] Creating a project via the web wizard auto-spawns its AgentChattr process
- [x] Spawn uses the per-project config (the /restart endpoint resolves config.toml + ports)
- [x] Spawn failures are logged but do not crash the wizard response
- [x] add-config still returns 200 even if spawn fails
- [ ] e2e verification — covered by sub-E (#254) operator-gated

## Test plan
- [x] node --check server/routes.js
- [ ] Reviewers: web-wizard a fresh project, confirm AC process spawned without manual Restart
- [ ] Reviewers: simulate port collision, confirm wizard still ok and warns in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)