### PR TITLE
[#251] sub-B: Queue watcher injects 'mcp read' prompts into agent PTY

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ const { spawn } = require("child_process");
 const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH } = require("./config");
 const routes = require("./routes");
 const { waitForAgentChattrReady, registerAgent, deregisterAgent, startHeartbeat, stopHeartbeat } = require("./agentchattr-registry");
+const { startQueueWatcher, stopQueueWatcher } = require("./queue-watcher");
 
 const net = require("net");
 const config = readConfig();
@@ -418,6 +419,7 @@ async function spawnAgentPty(project, agent) {
       acServerPort: built.acServerPort,
       acRegistrationToken: built.acRegistrationToken,
       acHeartbeatHandle: null,
+      queueWatcherHandle: null,
     };
     agentSessions.set(key, session);
 
@@ -431,6 +433,27 @@ async function spawnAgentPty(project, agent) {
         session.acRegistrationName,
         session.acRegistrationToken,
       );
+    }
+
+    // #393 / quadwork#251: queue watcher — the actual mechanism by
+    // which agents pick up chat. Without this an agent can be
+    // registered + heartbeating yet still never respond, because
+    // AgentChattr only writes to {data_dir}/{name}_queue.jsonl and
+    // expects the agent side to poll + inject `mcp read`.
+    if (session.acRegistrationName && session.term) {
+      try {
+        const { dir: acDir } = resolveProjectChattr(project);
+        if (acDir) {
+          const dataDir = path.join(acDir, "data");
+          session.queueWatcherHandle = startQueueWatcher(
+            dataDir,
+            session.acRegistrationName,
+            session.term,
+          );
+        }
+      } catch {
+        // best-effort — failure here just means no chat injection
+      }
     }
 
     term.onExit(({ exitCode }) => {
@@ -452,6 +475,10 @@ async function spawnAgentPty(project, agent) {
         if (current.acHeartbeatHandle) {
           stopHeartbeat(current.acHeartbeatHandle);
           current.acHeartbeatHandle = null;
+        }
+        if (current.queueWatcherHandle) {
+          stopQueueWatcher(current.queueWatcherHandle);
+          current.queueWatcherHandle = null;
         }
         if (current.acRegistrationName && current.acServerPort) {
           deregisterAgent(current.acServerPort, current.acRegistrationName).catch(() => {});
@@ -496,6 +523,12 @@ async function stopAgentSession(key) {
   if (session.acHeartbeatHandle) {
     stopHeartbeat(session.acHeartbeatHandle);
     session.acHeartbeatHandle = null;
+  }
+  // Stop queue watcher (#393 / quadwork#251) — the PTY is gone,
+  // injecting into a dead term would throw on the next tick.
+  if (session.queueWatcherHandle) {
+    stopQueueWatcher(session.queueWatcherHandle);
+    session.queueWatcherHandle = null;
   }
   // Best-effort deregister from AgentChattr (#241) so the slot frees
   // and the next register lands at slot 1 instead of head-2.

--- a/server/queue-watcher.js
+++ b/server/queue-watcher.js
@@ -63,7 +63,14 @@ function startQueueWatcher(dataDir, agentName, ptyTerm) {
         hasTrigger = true;
         if (data && typeof data === "object") {
           if (typeof data.channel === "string") channel = data.channel;
-          if (typeof data.job_id === "string") jobId = data.job_id;
+          // AgentChattr serializes job_id as an integer (agents.py
+          // defines `job_id: int | None`), so accept both numbers and
+          // strings here. Without this, job-thread triggers fall back
+          // to the channel prompt and the agent reads the wrong
+          // conversation. Cast to string for the prompt template.
+          if (typeof data.job_id === "number" || typeof data.job_id === "string") {
+            jobId = String(data.job_id);
+          }
           if (typeof data.prompt === "string" && data.prompt.trim()) {
             customPrompt = data.prompt.trim();
           }

--- a/server/queue-watcher.js
+++ b/server/queue-watcher.js
@@ -1,0 +1,107 @@
+/**
+ * Per-agent queue watcher (#393 / quadwork#251).
+ *
+ * AgentChattr does NOT push chat to agents. When the operator types
+ * `@head` in chat, AC writes a job line to `{data_dir}/{name}_queue.jsonl`
+ * and walks away. Something on the agent side has to poll that file and
+ * inject an `mcp read` prompt into the running CLI's PTY so the agent
+ * picks up the chat. Without that injection the agent never responds,
+ * even when registration and heartbeats work.
+ *
+ * Reference: /Users/cho/Projects/agentchattr/wrapper.py lines 438-541
+ * (`_queue_watcher`). Polling (not fs.watch) is intentional: matches
+ * wrapper.py's behavior and avoids the cross-platform fs.watch
+ * footguns. The role/rules/identity-hint additions from wrapper.py
+ * lines 501-528 are intentionally out of scope for v1 per the issue.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const POLL_INTERVAL_MS = 1000;
+
+/**
+ * Start polling `{dataDir}/{agentName}_queue.jsonl`. When non-empty,
+ * read all lines, truncate the file (atomic-ish claim — same race the
+ * Python wrapper accepts), parse each JSON line, build a single
+ * injected prompt, and write it into the supplied PTY terminal.
+ *
+ * Returns an opaque interval handle. Pass it to stopQueueWatcher to
+ * cancel; safe to call with null.
+ */
+function startQueueWatcher(dataDir, agentName, ptyTerm) {
+  if (!dataDir || !agentName || !ptyTerm) return null;
+  const queueFile = path.join(dataDir, `${agentName}_queue.jsonl`);
+
+  const tick = () => {
+    try {
+      if (!fs.existsSync(queueFile)) return;
+      const stat = fs.statSync(queueFile);
+      if (stat.size === 0) return;
+
+      const content = fs.readFileSync(queueFile, "utf-8");
+      // Atomic claim: truncate immediately so the next AC write lands
+      // in an empty file and we don't double-process the same job on
+      // the next tick. There's a small race if AC writes between the
+      // read and the truncate; wrapper.py accepts the same race.
+      fs.writeFileSync(queueFile, "");
+
+      const lines = content.split("\n").map((l) => l.trim()).filter(Boolean);
+      if (lines.length === 0) return;
+
+      let channel = "general";
+      let customPrompt = "";
+      let jobId = null;
+      let hasTrigger = false;
+      for (const line of lines) {
+        let data;
+        try {
+          data = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        hasTrigger = true;
+        if (data && typeof data === "object") {
+          if (typeof data.channel === "string") channel = data.channel;
+          if (typeof data.job_id === "string") jobId = data.job_id;
+          if (typeof data.prompt === "string" && data.prompt.trim()) {
+            customPrompt = data.prompt.trim();
+          }
+        }
+      }
+      if (!hasTrigger) return;
+
+      let prompt;
+      if (customPrompt) {
+        prompt = customPrompt;
+      } else if (jobId) {
+        prompt = `mcp read job_id=${jobId} - you were mentioned in a job thread, take appropriate action`;
+      } else {
+        prompt = `mcp read #${channel} - you were mentioned, take appropriate action`;
+      }
+
+      // Flatten newlines: multi-line writes trigger paste detection in
+      // Claude Code (shows "[Pasted text +N]") and can break injection
+      // of long prompts. Mirrors wrapper.py:532.
+      const flat = prompt.replace(/\n/g, " ");
+      ptyTerm.write(flat + "\r");
+    } catch {
+      // Swallow — next tick will retry. Logging here would spam the
+      // server output once per second on a permission error.
+    }
+  };
+
+  return setInterval(tick, POLL_INTERVAL_MS);
+}
+
+/**
+ * Stop a watcher started by startQueueWatcher. Safe to call with null.
+ */
+function stopQueueWatcher(handle) {
+  if (handle) clearInterval(handle);
+}
+
+module.exports = {
+  startQueueWatcher,
+  stopQueueWatcher,
+};


### PR DESCRIPTION
Fixes #251
Tracker: realproject7/agent-os#393
Master: #249

## Summary
- New `server/queue-watcher.js` with `startQueueWatcher(dataDir, agentName, ptyTerm)` / `stopQueueWatcher(handle)`. Polls `{data_dir}/{name}_queue.jsonl` every 1s, truncates as the atomic claim, parses JSON lines for `channel` / `job_id` / `prompt`, builds the appropriate `mcp read ...` prompt, flattens newlines (paste-detection guard from wrapper.py:532), and writes it into the PTY.
- Wired into `spawnAgentPty` (start), `term.onExit` (cleanup on crash), and `stopAgentSession` (cleanup on stop) in `server/index.js`. Resolves the AC data dir via `resolveProjectChattr(project).dir + "/data"`.

## Why
This is the missing mechanism behind "agents don't respond to chat." AgentChattr only writes to `{name}_queue.jsonl` and expects the agent side to poll and inject `mcp read`. Without it, every chat mention silently piles up in a file no one reads.

## Out of scope (per issue)
- Role / rules / identity-hint injections (wrapper.py lines 501-528) — deferred follow-up
- 409 recovery — sub-D #253

## Acceptance criteria
- [x] Watcher reads queue files and injects prompts into the correct agent PTY
- [x] Queue files truncated after read so jobs are claimed once
- [x] Stopping or crashing an agent stops its queue watcher (covered in both `stopAgentSession` and `term.onExit`)
- [ ] `@head ...` in chat → injected prompt → response — covered by sub-E (#254) operator-gated e2e

## Test plan
- [x] `node --check` on both files
- [ ] Reviewers: run a project, `@head ping` in chat, watch the head terminal show the injected `mcp read #general...` line
- [ ] Reviewers: stop the head agent, confirm no further file polls in `lsof`

🤖 Generated with [Claude Code](https://claude.com/claude-code)