### PR TITLE
[#253] sub-D: Re-register agents on heartbeat 409 (AC restart recovery)

### DIFF
--- a/server/agentchattr-registry.js
+++ b/server/agentchattr-registry.js
@@ -105,19 +105,45 @@ async function deregisterAgent(serverPort, name, token) {
  * QuadWork agent silently disappears from the channel one minute after
  * registration.
  *
- * Returns an opaque handle suitable for stopHeartbeat. Transient errors
- * (network blips, AgentChattr restart) are swallowed — the next tick
- * just tries again. The 409 "identity wiped" recovery flow is sub-D
- * (quadwork#253) and is intentionally not handled here.
+ * `getName` and `getToken` are read on every tick (either as plain
+ * values or as zero-arg functions) so the sub-D 409 recovery path can
+ * swap them in place after re-registration without restarting the
+ * interval. Pass an `onConflict` callback to handle 409 responses
+ * (AgentChattr restart wiped the in-memory registry — re-register and
+ * the next tick will use the new credentials). Other errors are
+ * swallowed.
  *
- * Reference: /Users/cho/Projects/agentchattr/wrapper.py lines 715-748.
+ * Returns an opaque handle suitable for stopHeartbeat.
+ *
+ * Reference: /Users/cho/Projects/agentchattr/wrapper.py lines 715-744.
  */
-function startHeartbeat(serverPort, name, token, intervalMs = 5000) {
-  const url = `http://127.0.0.1:${serverPort}/api/heartbeat/${encodeURIComponent(name)}`;
-  const headers = { Authorization: `Bearer ${token}` };
+function startHeartbeat(serverPort, getName, getToken, { onConflict, intervalMs = 5000 } = {}) {
+  // Sub-D guard: avoid re-entering onConflict while a previous recovery
+  // attempt is still in flight. Without this, a slow re-register would
+  // be triggered once per 5s tick and stack up duplicate registrations.
+  let recovering = false;
+  const resolve = (v) => (typeof v === "function" ? v() : v);
   const tick = async () => {
+    const name = resolve(getName);
+    const token = resolve(getToken);
+    if (!name) return;
+    const url = `http://127.0.0.1:${serverPort}/api/heartbeat/${encodeURIComponent(name)}`;
     try {
-      await fetchWithTimeout(url, { method: "POST", headers }, DEFAULT_TIMEOUT_MS);
+      const r = await fetchWithTimeout(
+        url,
+        { method: "POST", headers: token ? { Authorization: `Bearer ${token}` } : {} },
+        DEFAULT_TIMEOUT_MS,
+      );
+      if (r.status === 409 && typeof onConflict === "function" && !recovering) {
+        recovering = true;
+        try {
+          await onConflict();
+        } catch {
+          // recovery is best-effort; next tick retries on its own
+        } finally {
+          recovering = false;
+        }
+      }
     } catch {
       // swallow — next tick will retry
     }

--- a/server/index.js
+++ b/server/index.js
@@ -147,14 +147,20 @@ function startMcpProxy(projectId, agentId, upstreamUrl, token) {
   const existing = mcpProxies.get(key);
   if (existing) return Promise.resolve(`http://127.0.0.1:${existing.port}/mcp`);
 
+  // #394 / quadwork#253: token is mutable so the 409 recovery path can
+  // swap it via updateMcpProxyToken without rebinding the listener —
+  // Codex was launched with a fixed proxy URL on an ephemeral port and
+  // can't be told to use a new one mid-flight.
+  const tokenRef = { current: token };
   return new Promise((resolve, reject) => {
     const proxyServer = http.createServer((req, res) => {
       const parsedUrl = new URL(req.url, `http://127.0.0.1`);
       const targetUrl = `${upstreamUrl}${parsedUrl.pathname}${parsedUrl.search}`;
       const headers = { ...req.headers, host: new URL(upstreamUrl).host };
-      if (token) {
-        headers["authorization"] = `Bearer ${token}`;
-        headers["x-agent-token"] = token;
+      const tok = tokenRef.current;
+      if (tok) {
+        headers["authorization"] = `Bearer ${tok}`;
+        headers["x-agent-token"] = tok;
       }
       delete headers["content-length"];
 
@@ -181,10 +187,25 @@ function startMcpProxy(projectId, agentId, upstreamUrl, token) {
     proxyServer.on("error", (err) => reject(err));
     proxyServer.listen(0, "127.0.0.1", () => {
       const port = proxyServer.address().port;
-      mcpProxies.set(key, { server: proxyServer, port });
+      mcpProxies.set(key, { server: proxyServer, port, tokenRef });
       resolve(`http://127.0.0.1:${port}/mcp`);
     });
   });
+}
+
+/**
+ * Swap the bearer token of a running MCP proxy in place. Used by the
+ * sub-D 409 recovery path: rebinding the listener would change the
+ * ephemeral port and the running Codex process is pinned to the
+ * original URL, so we mutate the closure-captured tokenRef instead.
+ * Returns true if a proxy existed and was updated.
+ */
+function updateMcpProxyToken(projectId, agentId, newToken) {
+  const key = `${projectId}/${agentId}`;
+  const proxy = mcpProxies.get(key);
+  if (!proxy || !proxy.tokenRef) return false;
+  proxy.tokenRef.current = newToken;
+  return true;
 }
 
 function stopMcpProxy(projectId, agentId) {
@@ -432,12 +453,10 @@ async function recoverFrom409(projectId, agentId, session) {
   // AC with the new bearer token instead of the now-rejected one.
   if (session.acInjectMode === "flag" && session.acMcpHttpPort) {
     try { writeMcpConfigFile(projectId, agentId, session.acMcpHttpPort, replacement.token); } catch {}
-  } else if (session.acInjectMode === "proxy_flag" && session.acMcpHttpPort) {
-    try {
-      stopMcpProxy(projectId, agentId);
-      const upstreamUrl = `http://127.0.0.1:${session.acMcpHttpPort}`;
-      await startMcpProxy(projectId, agentId, upstreamUrl, replacement.token);
-    } catch {}
+  } else if (session.acInjectMode === "proxy_flag") {
+    // Codex is pinned to the original ephemeral proxy URL, so we
+    // can't tear the listener down — mutate the token in place.
+    try { updateMcpProxyToken(projectId, agentId, replacement.token); } catch {}
   }
 
   // If the assigned name changed (e.g. multi-instance slot collision)

--- a/server/index.js
+++ b/server/index.js
@@ -268,7 +268,7 @@ function writeMcpConfigFile(projectId, agentId, mcpHttpPort, token) {
 async function buildAgentArgs(projectId, agentId) {
   const cfg = readConfig();
   const project = cfg.projects?.find((p) => p.id === projectId);
-  if (!project) return { args: [], acRegistrationName: null, acServerPort: null, acRegistrationToken: null };
+  if (!project) return { args: [], acRegistrationName: null, acServerPort: null, acRegistrationToken: null, acInjectMode: null, acMcpHttpPort: null };
 
   const agentCfg = project.agents?.[agentId] || {};
   const command = agentCfg.command || "claude";
@@ -277,6 +277,7 @@ async function buildAgentArgs(projectId, agentId) {
   let acRegistrationName = null;
   let acServerPort = null;
   let acRegistrationToken = null;
+  let acInjectMode = null;
 
   // Permission bypass flags
   if (agentCfg.auto_approve !== false) {
@@ -289,6 +290,7 @@ async function buildAgentArgs(projectId, agentId) {
   const token = project.agentchattr_token;
   if (mcpHttpPort) {
     const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag");
+    acInjectMode = injectMode;
     if (injectMode === "flag") {
       // Claude/Kimi: register with AgentChattr to obtain a per-agent
       // token (#239 — session_token is browser auth, not MCP auth) and
@@ -348,7 +350,7 @@ async function buildAgentArgs(projectId, agentId) {
     }
   }
 
-  return { args, acRegistrationName, acServerPort, acRegistrationToken };
+  return { args, acRegistrationName, acServerPort, acRegistrationToken, acInjectMode, acMcpHttpPort: mcpHttpPort || null };
 }
 
 /**
@@ -387,6 +389,75 @@ function buildAgentEnv(projectId, agentId) {
   return env;
 }
 
+/**
+ * #394 / quadwork#253: recover from a heartbeat 409 (AgentChattr was
+ * restarted, in-memory registry wiped, our token is now stale). Mirrors
+ * wrapper.py:732-741. Re-registers the running agent, swaps the
+ * tracked name/token on the live session so the heartbeat interval
+ * picks up the new credentials on its next tick, refreshes whichever
+ * MCP transport this agent uses (Claude config file vs Codex proxy),
+ * and restarts the queue watcher in case the assigned name changed
+ * (multi-instance slot bump).
+ *
+ * Best-effort: any failure here just means the next 5s heartbeat will
+ * fail again and we'll re-enter recovery — no tight retry loop because
+ * startHeartbeat guards re-entry with `recovering`.
+ */
+async function recoverFrom409(projectId, agentId, session) {
+  if (!session.acServerPort) return;
+  const cfg = readConfig();
+  const project = cfg.projects?.find((p) => p.id === projectId);
+  const agentCfg = project?.agents?.[agentId] || {};
+  // AC may need a moment to come back up after a restart — wait briefly.
+  await waitForAgentChattrReady(session.acServerPort, 10000);
+
+  // Best-effort cleanup of the stale registration on disk so the
+  // fresh register isn't shoved into a slot 2 by leftover state.
+  const stale = readPersistedAgentToken(projectId, agentId);
+  if (stale) {
+    await deregisterAgent(session.acServerPort, agentId, stale).catch(() => {});
+    clearPersistedAgentToken(projectId, agentId);
+  }
+
+  const replacement = await registerAgent(session.acServerPort, agentId, agentCfg.display_name || null);
+  if (!replacement) return;
+
+  const previousName = session.acRegistrationName;
+  session.acRegistrationName = replacement.name;
+  session.acRegistrationToken = replacement.token;
+  writePersistedAgentToken(projectId, agentId, replacement.token);
+
+  // Refresh whichever MCP transport this agent uses so subsequent
+  // tool calls (and the queue-watcher's `mcp read` injections) hit
+  // AC with the new bearer token instead of the now-rejected one.
+  if (session.acInjectMode === "flag" && session.acMcpHttpPort) {
+    try { writeMcpConfigFile(projectId, agentId, session.acMcpHttpPort, replacement.token); } catch {}
+  } else if (session.acInjectMode === "proxy_flag" && session.acMcpHttpPort) {
+    try {
+      stopMcpProxy(projectId, agentId);
+      const upstreamUrl = `http://127.0.0.1:${session.acMcpHttpPort}`;
+      await startMcpProxy(projectId, agentId, upstreamUrl, replacement.token);
+    } catch {}
+  }
+
+  // If the assigned name changed (e.g. multi-instance slot collision)
+  // the queue watcher is now polling the wrong file. Restart it
+  // against the new name so chat reaches the right agent.
+  if (replacement.name !== previousName && session.term) {
+    if (session.queueWatcherHandle) {
+      stopQueueWatcher(session.queueWatcherHandle);
+      session.queueWatcherHandle = null;
+    }
+    try {
+      const { dir: acDir } = resolveProjectChattr(projectId);
+      if (acDir) {
+        const dataDir = path.join(acDir, "data");
+        session.queueWatcherHandle = startQueueWatcher(dataDir, replacement.name, session.term);
+      }
+    } catch {}
+  }
+}
+
 // Helper: spawn a PTY for a project/agent and register in agentSessions
 async function spawnAgentPty(project, agent) {
   const key = `${project}/${agent}`;
@@ -418,6 +489,8 @@ async function spawnAgentPty(project, agent) {
       acRegistrationName: built.acRegistrationName,
       acServerPort: built.acServerPort,
       acRegistrationToken: built.acRegistrationToken,
+      acInjectMode: built.acInjectMode,
+      acMcpHttpPort: built.acMcpHttpPort,
       acHeartbeatHandle: null,
       queueWatcherHandle: null,
     };
@@ -428,10 +501,16 @@ async function spawnAgentPty(project, agent) {
     // crash-detection window deregisters the agent and chat messages
     // never reach it. Mirrors wrapper.py:_heartbeat (lines 715-748).
     if (session.acRegistrationName && session.acServerPort && session.acRegistrationToken) {
+      // #394 / quadwork#253: pass getters (not raw values) so the 409
+      // recovery path below can swap acRegistrationName/Token in place
+      // and the very next heartbeat tick uses the replacement
+      // credentials without us having to tear down + restart the
+      // interval.
       session.acHeartbeatHandle = startHeartbeat(
         session.acServerPort,
-        session.acRegistrationName,
-        session.acRegistrationToken,
+        () => session.acRegistrationName,
+        () => session.acRegistrationToken,
+        { onConflict: () => recoverFrom409(project, agent, session) },
       );
     }
 


### PR DESCRIPTION
Fixes #253
Tracker: realproject7/agent-os#394
Master: #249

## Summary
- `startHeartbeat` now reads name/token via getters every tick and accepts an `onConflict` callback. Reentry guarded by a `recovering` flag so a slow re-register can't stack.
- New `recoverFrom409` helper in `server/index.js`: waits for AC, deregisters the stale slot, calls `registerAgent`, updates `session.acRegistrationName` / `acRegistrationToken` in place (next heartbeat tick uses them), refreshes Claude MCP config file or Codex MCP proxy depending on inject mode, and restarts the queue watcher if the assigned name changed.
- `buildAgentArgs` now also returns `acInjectMode` + `acMcpHttpPort` so `recoverFrom409` knows which transport to refresh without re-reading config inline.
- Mirrors `agent-os/agentchattr/wrapper.py:732-741`.

## Acceptance criteria
- [x] 409 from heartbeat triggers re-registration
- [x] Session state, MCP config, and Codex proxy auth refreshed to the replacement token
- [x] Queue watcher restarted on name change so chat still reaches the agent
- [x] Recovery failures non-fatal (try/catch around each step, no rethrow)
- [x] Re-entry guard prevents tight retry loops while AC is still down
- [ ] e2e: dashboard Restart of AC → agents auto-recover within ~10s — covered by sub-E (#254) operator-gated

## Test plan
- [x] `node --check` on both files
- [ ] Reviewers: register a project, start agents, click Restart on the AC dashboard, confirm agents reappear in chat without manual intervention
- [ ] Reviewers: confirm the persisted token file is updated and the new MCP config has the new bearer

🤖 Generated with [Claude Code](https://claude.com/claude-code)