### PR TITLE
[#262] sub-A: Chat reply button on each message

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -185,11 +185,20 @@ router.post("/api/chat", async (req, res) => {
   // hitting QuadWork's /api/chat impersonate an agent identity (t1,
   // t3, …) over the AgentChattr ws path, which the old /api/send
   // flow could not do.
+  // #397 / quadwork#262: pass reply_to through to AgentChattr so the
+  // dashboard's reply button mirrors AC's native threaded-reply
+  // behavior. Only forward when it's a real positive integer — guards
+  // against arbitrary client payloads.
+  const replyToRaw = req.body?.reply_to;
+  const replyTo = (typeof replyToRaw === "number" && Number.isInteger(replyToRaw) && replyToRaw > 0)
+    ? replyToRaw
+    : null;
   const message = {
     text: typeof req.body?.text === "string" ? req.body.text : "",
     channel: req.body?.channel || "general",
     sender: "user",
     attachments: Array.isArray(req.body?.attachments) ? req.body.attachments : [],
+    ...(replyTo !== null ? { reply_to: replyTo } : {}),
   };
   if (!message.text && message.attachments.length === 0) {
     return res.status(400).json({ error: "text or attachments required" });

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -115,6 +115,9 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
   const [showMentions, setShowMentions] = useState(false);
   const [mentionFilter, setMentionFilter] = useState("");
   const [authError, setAuthError] = useState<string | null>(null);
+  // #397 / quadwork#262: tracks the message the next send will be a
+  // threaded reply to. Cleared after a successful send or on cancel.
+  const [replyTo, setReplyTo] = useState<{ id: number; sender: string } | null>(null);
   const cursorRef = useRef(0);
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -193,11 +196,17 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
     fetch(`/api/chat${projectId ? `?project=${encodeURIComponent(projectId)}` : ""}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text, channel, sender: "user" }),
+      body: JSON.stringify({
+        text,
+        channel,
+        sender: "user",
+        ...(replyTo ? { reply_to: replyTo.id } : {}),
+      }),
     })
       .then((r) => {
         if (!r.ok) throw new Error(`Send failed: ${r.status}`);
         setInput("");
+        setReplyTo(null);
         setTimeout(fetchMessages, 300);
       })
       .catch((err) => {
@@ -253,7 +262,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
           </div>
         )}
         {messages.map((msg) => (
-          <div key={msg.id} className="flex gap-2 text-[12px] leading-5">
+          <div key={msg.id} className="group flex gap-2 text-[12px] leading-5">
             <span className="text-text-muted shrink-0 w-12 text-right tabular-nums">
               {msg.time?.slice(0, 5) || ""}
             </span>
@@ -263,9 +272,25 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
             >
               {msg.sender}
             </span>
-            <span className="text-text break-words min-w-0 whitespace-pre-wrap">
+            <span className="text-text break-words min-w-0 whitespace-pre-wrap flex-1">
               {msg.text}
             </span>
+            {/* #397 / quadwork#262: reply affordance — small grey,
+                hover-revealed so it doesn't visually compete with the
+                message text. Mirrors AC's native reply UI. */}
+            <button
+              type="button"
+              onClick={() => {
+                setReplyTo({ id: msg.id, sender: msg.sender });
+                const prefix = `@${msg.sender} `;
+                setInput((prev) => (prev.startsWith(prefix) ? prev : prefix));
+                inputRef.current?.focus();
+              }}
+              className="shrink-0 self-start opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-[10px] text-text-muted hover:text-text px-1 py-0.5 border border-border/50 rounded"
+              title={`Reply to message #${msg.id}`}
+            >
+              reply
+            </button>
           </div>
         ))}
       </div>
@@ -292,6 +317,22 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
             {sendError}
           </div>
         )}
+        {/* #397 / quadwork#262: active reply indicator with cancel */}
+        {replyTo && (
+          <div className="flex items-center gap-2 px-3 py-1 text-[11px] text-text-muted bg-bg-surface border-b border-border/50">
+            <span>
+              Replying to <span style={{ color: senderColor(replyTo.sender) }}>@{replyTo.sender}</span> #{replyTo.id}
+            </span>
+            <button
+              type="button"
+              onClick={() => setReplyTo(null)}
+              className="ml-auto hover:text-text"
+              title="Cancel reply (Esc)"
+            >
+              ✕
+            </button>
+          </div>
+        )}
         <div className="flex items-center gap-1 px-1">
           <input
             ref={inputRef}
@@ -309,7 +350,10 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
                 e.preventDefault();
                 send();
               }
-              if (e.key === "Escape") setShowMentions(false);
+              if (e.key === "Escape") {
+                setShowMentions(false);
+                if (replyTo) setReplyTo(null);
+              }
             }}
             placeholder={`Message #${channel}...`}
             disabled={sending}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -282,8 +282,19 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
               type="button"
               onClick={() => {
                 setReplyTo({ id: msg.id, sender: msg.sender });
-                const prefix = `@${msg.sender} `;
-                setInput((prev) => (prev.startsWith(prefix) ? prev : prefix));
+                // Only prefill `@<sender>` when the sender is a real
+                // agent. Non-agent rows (user, system, …) would
+                // produce broken mentions that send() then
+                // double-routes through its auto-@head fallback,
+                // turning a reply-to-user into "@head @user …".
+                // For those rows we still set replyTo so the threaded
+                // link works in AC's native UI; we just don't poison
+                // the input with a mention that isn't routable.
+                const KNOWN_AGENTS = new Set(["head", "dev", "reviewer1", "reviewer2"]);
+                if (KNOWN_AGENTS.has(msg.sender.toLowerCase())) {
+                  const prefix = `@${msg.sender} `;
+                  setInput((prev) => (prev.startsWith(prefix) ? prev : prefix));
+                }
                 inputRef.current?.focus();
               }}
               className="shrink-0 self-start opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-[10px] text-text-muted hover:text-text px-1 py-0.5 border border-border/50 rounded"


### PR DESCRIPTION
Fixes #262
Tracker: realproject7/agent-os#397
Master: #261

## Summary
- New small grey hover-revealed reply button on each chat row in `ChatPanelAPI`.
- Click → selects the message as the active reply, focuses the input, prefills `@<sender> `.
- Active reply shows a "Replying to @<sender> #<id>" indicator above the input with a ✕ cancel (Esc also clears).
- `send()` includes `reply_to: <msg.id>` in the `/api/chat` POST body. After a successful send, replyTo is cleared.
- `server/routes.js` POST `/api/chat` accepts `reply_to`, validates as a positive integer, and spreads it into the message forwarded over the AC ws — `sendViaWebSocket` already passes `...message` through, so AC's native UI sees the threaded reply.

## Acceptance criteria
- [x] Each chat message has a small grey reply button (hover-revealed)
- [x] Click → input focuses with `@<sender>` prefix
- [x] Sent reply includes `reply_to` with the original message id
- [ ] Reviewers: open native AC UI in a tab and confirm the reply is linked to the original
- [x] Reply state cleared on send + on cancel + on Esc

## Test plan
- [x] `node --check server/routes.js`
- [x] `tsc --noEmit` clean
- [ ] Reviewers: spin up a project, send a message, hover a row, click reply, type a response, confirm AC native UI shows the threaded link

🤖 Generated with [Claude Code](https://claude.com/claude-code)