### PR TITLE
[#263] sub-B: Display reviewers as RE1 / RE2 in chat sender column

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -27,6 +27,17 @@ function senderColor(sender: string): string {
   return SENDER_COLORS[sender.toLowerCase()] || "#e0e0e0";
 }
 
+// #398 / quadwork#263: shorten reviewer names in the chat sender
+// column only — the underlying agent IDs (`reviewer1`, `reviewer2`)
+// must stay unchanged everywhere else (registration, MCP, queue,
+// terminal headers, etc.). Display-only.
+function senderLabel(sender: string): string {
+  const s = sender.toLowerCase();
+  if (s === "reviewer1") return "RE1";
+  if (s === "reviewer2") return "RE2";
+  return sender;
+}
+
 /**
  * Tries iframe first (uses AgentChattr's own session auth).
  * Falls back to API polling if iframe fails to load.
@@ -270,7 +281,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
               className="shrink-0 font-semibold w-10 text-right"
               style={{ color: senderColor(msg.sender) }}
             >
-              {msg.sender}
+              {senderLabel(msg.sender)}
             </span>
             <span className="text-text break-words min-w-0 whitespace-pre-wrap flex-1">
               {msg.text}


### PR DESCRIPTION
Fixes #263
Tracker: realproject7/agent-os#398
Master: #261

## Summary
- New `senderLabel()` helper in `ChatPanel.tsx` rewrites `reviewer1 → RE1` and `reviewer2 → RE2` in the message-list sender column only.
- Underlying `msg.sender` string is untouched: registration, MCP, queue files, terminal headers, AGENTS.md routing, and every other UI surface still see the full reviewer names.
- Pure display tweak — no backend or protocol changes.

## Acceptance criteria
- [x] Chat messages from `reviewer1` show `RE1`
- [x] Chat messages from `reviewer2` show `RE2`
- [x] Other senders unchanged (helper falls through)
- [x] No backend changes
- [x] Other UI areas still use full reviewer names (only `ChatPanel.tsx`'s message rendering touches `senderLabel`)

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Reviewers: open chat panel, post a message from each reviewer, confirm column shows `RE1`/`RE2` while terminal headers and Agent Terminals titles still show `Reviewer1`/`Reviewer2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)