### PR TITLE
[#264] sub-C: Activity-gated status ring + center (?) icon

### DIFF
--- a/src/components/AgentTerminalsGrid.tsx
+++ b/src/components/AgentTerminalsGrid.tsx
@@ -42,7 +42,11 @@ export default function AgentTerminalsGrid({ projectId, agentStates, onStatusCha
         <div className="flex items-center gap-1.5">
           <span className="text-[11px] text-text-muted uppercase tracking-wider">Agent Terminals</span>
           <div
-            className="relative"
+            // #399 / quadwork#264: inline-flex+items-center so the
+            // (?) button vertically centers with the title text. The
+            // previous block-level wrapper let the button drop to its
+            // own baseline below the title cap-height.
+            className="relative inline-flex items-center"
             onMouseEnter={() => setTipOpen(true)}
             onMouseLeave={() => setTipOpen(false)}
             onFocus={() => setTipOpen(true)}
@@ -51,7 +55,7 @@ export default function AgentTerminalsGrid({ projectId, agentStates, onStatusCha
             <button
               type="button"
               aria-label="About agent terminals"
-              className="w-3.5 h-3.5 rounded-full border border-border text-[9px] text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
+              className="w-3.5 h-3.5 rounded-full border border-border text-[9px] leading-none text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
             >?</button>
             {tipOpen && (
               <div

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import TerminalPanel from "./TerminalPanel";
+
+// #399 / quadwork#264: how long an agent stays "active" after its
+// last PTY output before the activity ring stops pulsing.
+const ACTIVITY_WINDOW_MS = 2000;
 
 interface Agent {
   id: string;
@@ -45,6 +49,33 @@ export default function TerminalGrid({
   const [expanded, setExpanded] = useState<string | null>(null);
   const gridClasses = agents.length >= 4 ? GRID_CLASSES_4 : GRID_CLASSES_3;
 
+  // #399 / quadwork#264: derive a "currently active" signal from the
+  // PTY ws stream so the ring only pulses while the agent is actually
+  // working. The ring previously fired whenever the session was
+  // running, which meant idle live agents had a constantly-spinning
+  // ring indistinguishable from a busy one.
+  //
+  // We store the last-activity timestamp per agent in a ref (so the
+  // hot ws.onmessage path doesn't trigger a render storm) and tick a
+  // small piece of state every 500ms to re-evaluate freshness. This
+  // keeps the render budget bounded regardless of PTY chatter.
+  const lastActivityRef = useRef<Record<string, number>>({});
+  const [activityTick, setActivityTick] = useState(0);
+  const markActivity = useCallback((agentId: string) => {
+    lastActivityRef.current[agentId] = Date.now();
+  }, []);
+  useEffect(() => {
+    const interval = setInterval(() => setActivityTick((t) => t + 1), 500);
+    return () => clearInterval(interval);
+  }, []);
+  const isActive = (agentId: string) => {
+    const ts = lastActivityRef.current[agentId];
+    return ts !== undefined && Date.now() - ts < ACTIVITY_WINDOW_MS;
+  };
+  // Reference activityTick so the linter doesn't strip the dep that
+  // forces a re-render on each tick.
+  void activityTick;
+
   return (
     <div className="w-full h-full relative grid grid-rows-2 grid-cols-2">
       {agents.map((agent, i) => {
@@ -75,7 +106,7 @@ export default function TerminalGrid({
                     signals "agent is working". Idle/stopped/error
                     states omit the ring. */}
                 <span className="relative inline-flex items-center justify-center w-2 h-2">
-                  {agentStates[agent.id] === "running" && (
+                  {agentStates[agent.id] === "running" && isActive(agent.id) && (
                     <span className="absolute inline-flex h-full w-full rounded-full bg-accent opacity-60 animate-ping" />
                   )}
                   <span className={`relative w-1.5 h-1.5 rounded-full ${
@@ -147,7 +178,11 @@ export default function TerminalGrid({
               </div>
             </div>
             <div className="flex-1 min-h-0">
-              <TerminalPanel projectId={projectId} agentId={agent.id} />
+              <TerminalPanel
+                projectId={projectId}
+                agentId={agent.id}
+                onActivity={() => markActivity(agent.id)}
+              />
             </div>
           </div>
         );

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -31,6 +31,13 @@ export default function TerminalPanel({
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  // Stash onActivity in a ref so the hot ws.onmessage path can call
+  // the latest callback without becoming an effect dep — otherwise an
+  // inline arrow from the parent (re-created on every render via the
+  // 500ms activityTick) would tear down and reopen the PTY ws every
+  // tick, losing scrollback and starving the activity signal itself.
+  const onActivityRef = useRef(onActivity);
+  useEffect(() => { onActivityRef.current = onActivity; }, [onActivity]);
 
   const fit = useCallback(() => {
     if (fitRef.current && termRef.current && containerRef.current) {
@@ -151,7 +158,8 @@ export default function TerminalPanel({
 
       ws.onmessage = (e) => {
         term.write(e.data);
-        if (onActivity) onActivity();
+        const cb = onActivityRef.current;
+        if (cb) cb();
       };
 
       ws.onclose = (e) => {
@@ -174,7 +182,7 @@ export default function TerminalPanel({
       fitRef.current = null;
       wsRef.current = null;
     };
-  }, [projectId, agentId, wsUrl, fit, onActivity]);
+  }, [projectId, agentId, wsUrl, fit]);
 
   return <div ref={containerRef} className="w-full h-full" />;
 }

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -10,12 +10,22 @@ interface TerminalPanelProps {
   agentId: string;
   /** WebSocket server base URL */
   wsUrl?: string;
+  /**
+   * #399 / quadwork#264: fired whenever PTY output arrives over the
+   * WebSocket. TerminalGrid uses this to derive a "currently active"
+   * signal for the activity ring on each agent's status dot — running
+   * but idle agents must show a static dot, not a constantly-pulsing
+   * one. Kept as a fire-and-forget callback so it can't slow rendering
+   * inside the xterm write path.
+   */
+  onActivity?: () => void;
 }
 
 export default function TerminalPanel({
   projectId,
   agentId,
   wsUrl,
+  onActivity,
 }: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -141,6 +151,7 @@ export default function TerminalPanel({
 
       ws.onmessage = (e) => {
         term.write(e.data);
+        if (onActivity) onActivity();
       };
 
       ws.onclose = (e) => {
@@ -163,7 +174,7 @@ export default function TerminalPanel({
       fitRef.current = null;
       wsRef.current = null;
     };
-  }, [projectId, agentId, wsUrl, fit]);
+  }, [projectId, agentId, wsUrl, fit, onActivity]);
 
   return <div ref={containerRef} className="w-full h-full" />;
 }


### PR DESCRIPTION
Fixes #264
Tracker: realproject7/agent-os#399
Master: #261

## Summary
Two paired Agent Terminals header fixes:

1. **Activity ring (regression from #218)** — `TerminalPanel` now exposes an `onActivity` prop that fires from `ws.onmessage`. `TerminalGrid` stores per-agent last-activity timestamps in a ref (hot path) and re-evaluates freshness via a 500ms tick. The animate-ping ring renders only when `state === "running"` AND output landed in the last 2s. Idle live agents show a static dot, busy agents pulse.
2. **Question icon alignment** — wrap the tooltip `<div className="relative">` in `inline-flex items-center` and add `leading-none` on the (?) button so the glyph centers on the title's cap-height instead of dropping to its own baseline.

## Acceptance criteria
- [x] Active agents show a pulsing ring around the status dot
- [x] Idle (running but no PTY output in window) agents show a static dot
- [x] Question-mark icon is vertically centered with the "Agent Terminals" title
- [x] Tooltip behavior unchanged (mouse/focus enter/leave, position class untouched)

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Reviewers: spin up a project, watch ring pulse during agent processing, watch ring stop within ~2s of last PTY output, confirm (?) icon centers
- [ ] Reviewers: confirm tooltip still renders on hover/focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)