### PR TITLE
[#277] Scheduled Trigger uses local /api/chat instead of /api/send

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -983,19 +983,24 @@ ALL: Communicate via this chat by tagging agents. Your terminal is NOT visible.`
 async function sendTriggerMessage(projectId) {
   const cfg = readConfig();
   const project = cfg.projects && cfg.projects.find((p) => p.id === projectId);
-  const { url: chattrUrl, token: chattrToken } = resolveProjectChattr(projectId);
-  const token = chattrToken || "";
   const message = (project && project.trigger_message) || DEFAULT_MESSAGE;
-  const headers = { "Content-Type": "application/json" };
-  if (token) headers["x-session-token"] = token;
+
+  // #401 / quadwork#277: route trigger sends through the local
+  // /api/chat path that already works for the chat panel. The old
+  // direct /api/send call required a registration token (not the
+  // session token we have on hand) and 401'd silently — agents never
+  // saw the queue-check pulse. /api/chat opens the AC ws with the
+  // session token and inherits the #230 token-resync-on-401 retry,
+  // so the trigger now gets the same proven path as the chat panel.
+  const qwPort = cfg.port || 8400;
+  const url = `http://127.0.0.1:${qwPort}/api/chat?project=${encodeURIComponent(projectId)}`;
 
   const info = triggers.get(projectId);
   try {
-    let tokenParam = token ? `?token=${encodeURIComponent(token)}` : "";
-    const res = await fetch(`${chattrUrl}/api/send${tokenParam}`, {
+    const res = await fetch(url, {
       method: "POST",
-      headers,
-      body: JSON.stringify({ text: message, channel: "general", sender: "user" }),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: message, channel: "general" }),
     });
     if (!res.ok) {
       const err = await res.text().catch(() => "");


### PR DESCRIPTION
Fixes #277
Tracker: realproject7/agent-os#401
Master: #283 (Batch 30 Phase 1)

## Summary
- `sendTriggerMessage()` (`server/index.js`) now POSTs to the local `/api/chat?project=<id>` loopback instead of AC's direct `/api/send`.
- Same proven path as the chat panel post-#231: opens the AC ws with the session token, inherits the #230 token-resync-on-401 retry. No shared module, no new plumbing.
- Removes the silent 401s that were leaving Scheduled Trigger ticking with no actual chat traffic.

## Acceptance criteria
- [x] No more direct `/api/send` calls from `sendTriggerMessage`
- [ ] Reviewers: enable Scheduled Trigger on a project, confirm message lands in chat each interval
- [ ] Reviewers: confirm trigger error display still surfaces non-2xx via `info.lastError`
- [x] Token resync on 401 inherited from `/api/chat` (no behavioural change to retry logic)

## Test plan
- [x] `node --check server/index.js`
- [ ] Reviewers: spin up a project, set a 30s trigger interval, watch the chat for the first send

🤖 Generated with [Claude Code](https://claude.com/claude-code)