### PR TITLE
[#266] Head: prompt operator for kickoff after building queue

### DIFF
--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -58,8 +58,13 @@ When the operator asks you in chat to start a task or batch:
 1. Create the GitHub issue(s) if they don't already exist (`gh issue create` with scope, acceptance, and `agent/*` labels).
 2. Append the task(s) under the **Backlog** section of `OVERNIGHT-QUEUE.md`, or move them into **Active Batch** if the operator says they're ready to run.
 3. Reply in chat to confirm what you wrote to the queue file (issue numbers + which section).
-4. **Wait for the operator to trigger the batch via the Scheduled Trigger widget** before assigning the first item to `@dev`. Do NOT start assignments the moment the queue file is written — the operator controls kickoff.
-5. Once triggered, assign the first item to `@dev` following the normal workflow below.
+4. **Tell the operator the queue is ready and how to kick it off.** Send a chat message like:
+
+   > Queue is ready. To begin, click **Send Message and Start Trigger** in the Operator Features panel (bottom-right). I will start assigning Dev as soon as the trigger fires.
+
+   Without this prompt the operator has no idea what to do next and the batch sits idle indefinitely. Always send it after step 3, even if the operator only asked for a single ticket.
+5. **Wait for the operator to trigger the batch via the Scheduled Trigger widget** before assigning the first item to `@dev`. Do NOT start assignments the moment the queue file is written — the operator controls kickoff. The trigger fires the queue-check pulse to all agents and is your signal that the operator wants the batch to start.
+6. Once triggered, assign the first item to `@dev` following the normal workflow below.
 
 ### After each merge
 1. Move the merged item from **Active Batch** to **Done** in `OVERNIGHT-QUEUE.md`.


### PR DESCRIPTION
Fixes #266
Tracker: realproject7/agent-os#402
Master: #283 (Batch 30 Phase 1)

## Summary
- Add an explicit step to `templates/seeds/head.AGENTS.md` Combined Operator + Head Role flow: after queue prep, Head must send a follow-up chat message asking the operator to click "Send Message and Start Trigger".
- Step number bumped (4 → 5 → 6) to slot the new prompt before the existing trigger-wait step.
- Behaviour of "wait for trigger before assigning" is unchanged — this just makes the wait visible.

## Acceptance criteria
- [x] `templates/seeds/head.AGENTS.md` includes the new step
- [x] Head still waits for the trigger before assigning (no behavior change there)
- [ ] Reviewers: a new project's Head reads the updated seed and follows up after queue prep

## Test plan
- [x] Diff inspection — only the seed prose touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)