### PR TITLE
[#274] Loop guard default 30 + operator widget

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1480,6 +1480,37 @@ function migrateLegacyProjects(config) {
   return true;
 }
 
+/**
+ * #403 / quadwork#274 migration: append `[routing] max_agent_hops = 30`
+ * to any per-project config.toml that's missing it. Idempotent and
+ * conservative — leaves files that already have a `max_agent_hops`
+ * key alone (whatever value the operator picked stays put), and
+ * leaves files that have a [routing] section but no max_agent_hops
+ * key alone too rather than risk patching a section we don't fully
+ * understand. The web/CLI templates write the key on first run, so
+ * this only catches projects created before #403.
+ */
+function migrateLoopGuardDefaults(config) {
+  if (!config.projects || config.projects.length === 0) return;
+  for (const project of config.projects) {
+    if (!project.id) continue;
+    const tomlPath = project.agentchattr_dir
+      ? path.join(project.agentchattr_dir, "config.toml")
+      : path.join(CONFIG_DIR, project.id, "agentchattr", "config.toml");
+    if (!fs.existsSync(tomlPath)) continue;
+    let content;
+    try { content = fs.readFileSync(tomlPath, "utf-8"); } catch { continue; }
+    if (/^\s*max_agent_hops\s*=/m.test(content)) continue;
+    if (/^\s*\[routing\]/m.test(content)) continue;
+    const trailing = content.endsWith("\n") ? "" : "\n";
+    const addition = `${trailing}\n[routing]\ndefault = "none"\nmax_agent_hops = 30\n`;
+    try {
+      fs.writeFileSync(tomlPath, content + addition);
+      log(`  Loop guard default → ${project.id} (max_agent_hops = 30)`);
+    } catch { /* non-fatal */ }
+  }
+}
+
 function cmdStart() {
   console.log("\n  QuadWork Start\n");
 
@@ -1492,6 +1523,14 @@ function cmdStart() {
   // own per-project clones before any AgentChattr spawn happens.
   // Idempotent — a no-op once every project already has a working clone.
   migrateLegacyProjects(config);
+
+  // Batch 30 / #403 / quadwork#274: ensure every existing project's
+  // AgentChattr config.toml has [routing] max_agent_hops = 30 so the
+  // loop guard doesn't fire mid-PR-cycle. Idempotent: leaves any
+  // pre-existing routing section alone (only adds the section + key
+  // when both are missing). Failures are non-fatal — the project
+  // will just keep its current loop guard.
+  migrateLoopGuardDefaults(config);
 
   const quadworkDir = path.join(__dirname, "..");
   const port = config.port || 8400;

--- a/server/routes.js
+++ b/server/routes.js
@@ -216,11 +216,21 @@ function sendWsEvent(baseUrl, sessionToken, event) {
 // Source of truth at rest is the project's config.toml [routing]
 // max_agent_hops. The PUT also pushes the value to the running AC via
 // `update_settings` so the change is live without a daemon restart.
+// Resolve the per-project config.toml path through resolveProjectChattr
+// so we honor `project.agentchattr_dir` (web wizard sets this; legacy
+// imports can have arbitrary paths) and don't drift from the rest of
+// the codebase that already goes through that helper.
+function resolveProjectConfigToml(projectId) {
+  const resolved = resolveProjectChattr(projectId);
+  if (!resolved || !resolved.dir) return null;
+  return path.join(resolved.dir, "config.toml");
+}
+
 router.get("/api/loop-guard", (req, res) => {
   const projectId = req.query.project;
   if (!projectId) return res.status(400).json({ error: "Missing project" });
-  const tomlPath = path.join(CONFIG_DIR, projectId, "agentchattr", "config.toml");
-  if (!fs.existsSync(tomlPath)) return res.json({ value: 30, source: "default" });
+  const tomlPath = resolveProjectConfigToml(projectId);
+  if (!tomlPath || !fs.existsSync(tomlPath)) return res.json({ value: 30, source: "default" });
   try {
     const content = fs.readFileSync(tomlPath, "utf-8");
     const m = content.match(/^\s*max_agent_hops\s*=\s*(\d+)/m);
@@ -243,8 +253,8 @@ router.put("/api/loop-guard", async (req, res) => {
   }
 
   // 1. Persist to config.toml so the next restart picks it up.
-  const tomlPath = path.join(CONFIG_DIR, projectId, "agentchattr", "config.toml");
-  if (!fs.existsSync(tomlPath)) {
+  const tomlPath = resolveProjectConfigToml(projectId);
+  if (!tomlPath || !fs.existsSync(tomlPath)) {
     return res.status(404).json({ error: "config.toml not found for project" });
   }
   try {

--- a/server/routes.js
+++ b/server/routes.js
@@ -275,14 +275,36 @@ router.put("/api/loop-guard", async (req, res) => {
   }
 
   // 2. Best-effort push to the running AC so the change is live.
-  // Failures here are non-fatal: the next restart still picks up
-  // the persisted value.
+  // On stale-token (4003 → EAGENTCHATTR_401) recover the same way
+  // /api/chat does (#230): re-sync the session token from AC and
+  // retry once. Other failures stay non-fatal — the persisted value
+  // still takes effect on next AC restart.
   let live = false;
   try {
     const { url: base, token: sessionToken } = getChattrConfig(projectId);
     if (base) {
-      await sendWsEvent(base, sessionToken, { type: "update_settings", data: { max_agent_hops: value } });
-      live = true;
+      const event = { type: "update_settings", data: { max_agent_hops: value } };
+      try {
+        await sendWsEvent(base, sessionToken, event);
+        live = true;
+      } catch (err) {
+        if (err && err.code === "EAGENTCHATTR_401") {
+          console.warn(`[loop-guard] ws auth failed for ${projectId}, re-syncing session token and retrying...`);
+          try { await syncChattrToken(projectId); }
+          catch (syncErr) { console.warn(`[loop-guard] syncChattrToken failed: ${syncErr.message}`); }
+          const { token: refreshed } = getChattrConfig(projectId);
+          if (refreshed && refreshed !== sessionToken) {
+            try {
+              await sendWsEvent(base, refreshed, event);
+              live = true;
+            } catch (retryErr) {
+              console.warn(`[loop-guard] retry after token resync failed: ${retryErr.message || retryErr}`);
+            }
+          }
+        } else {
+          throw err;
+        }
+      }
     }
   } catch (err) {
     console.warn(`[loop-guard] live update failed for ${projectId}: ${err.message || err}`);

--- a/server/routes.js
+++ b/server/routes.js
@@ -174,6 +174,113 @@ function sendViaWebSocket(baseUrl, sessionToken, message) {
   });
 }
 
+/**
+ * #403 / quadwork#274: send an arbitrary AC ws event (not a chat
+ * message). Used for `update_settings` so the loop guard widget can
+ * push the new max_agent_hops to the running AgentChattr without a
+ * full restart. Mirrors sendViaWebSocket but lets the caller pick
+ * the event type.
+ */
+function sendWsEvent(baseUrl, sessionToken, event) {
+  return new Promise((resolve, reject) => {
+    const wsUrl = `${baseUrl.replace(/^http/, "ws")}/ws?token=${encodeURIComponent(sessionToken || "")}`;
+    const ws = new NodeWebSocket(wsUrl);
+    let settled = false;
+    const finish = (err, value) => {
+      if (settled) return;
+      settled = true;
+      try { ws.close(); } catch {}
+      if (err) reject(err); else resolve(value);
+    };
+    const giveUp = setTimeout(() => finish(new Error("websocket send timeout")), 4000);
+    ws.on("open", () => {
+      try {
+        ws.send(JSON.stringify(event));
+        setTimeout(() => { clearTimeout(giveUp); finish(null, { ok: true }); }, 250);
+      } catch (err) { clearTimeout(giveUp); finish(err); }
+    });
+    ws.on("error", (err) => { clearTimeout(giveUp); finish(err); });
+    ws.on("close", (code, reason) => {
+      if (!settled && code === 4003) {
+        clearTimeout(giveUp);
+        const msg = (reason && reason.toString()) || "forbidden: invalid session token";
+        const e = new Error(msg);
+        e.code = "EAGENTCHATTR_401";
+        finish(e);
+      }
+    });
+  });
+}
+
+// #403 / quadwork#274: read/write the loop guard for a given project.
+// Source of truth at rest is the project's config.toml [routing]
+// max_agent_hops. The PUT also pushes the value to the running AC via
+// `update_settings` so the change is live without a daemon restart.
+router.get("/api/loop-guard", (req, res) => {
+  const projectId = req.query.project;
+  if (!projectId) return res.status(400).json({ error: "Missing project" });
+  const tomlPath = path.join(CONFIG_DIR, projectId, "agentchattr", "config.toml");
+  if (!fs.existsSync(tomlPath)) return res.json({ value: 30, source: "default" });
+  try {
+    const content = fs.readFileSync(tomlPath, "utf-8");
+    const m = content.match(/^\s*max_agent_hops\s*=\s*(\d+)/m);
+    const value = m ? parseInt(m[1], 10) : 30;
+    res.json({ value, source: m ? "toml" : "default" });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to read config.toml", detail: err.message });
+  }
+});
+
+router.put("/api/loop-guard", async (req, res) => {
+  const projectId = req.query.project || req.body?.project;
+  if (!projectId) return res.status(400).json({ error: "Missing project" });
+  const raw = req.body?.value;
+  const value = typeof raw === "number" ? raw : parseInt(raw, 10);
+  // AC's update_settings handler clamps to [1, 50]; mirror that
+  // here so we don't write a value AC will silently rewrite.
+  if (!Number.isInteger(value) || value < 4 || value > 50) {
+    return res.status(400).json({ error: "value must be an integer between 4 and 50" });
+  }
+
+  // 1. Persist to config.toml so the next restart picks it up.
+  const tomlPath = path.join(CONFIG_DIR, projectId, "agentchattr", "config.toml");
+  if (!fs.existsSync(tomlPath)) {
+    return res.status(404).json({ error: "config.toml not found for project" });
+  }
+  try {
+    let content = fs.readFileSync(tomlPath, "utf-8");
+    if (/^\s*max_agent_hops\s*=/m.test(content)) {
+      content = content.replace(/^\s*max_agent_hops\s*=.*$/m, `max_agent_hops = ${value}`);
+    } else if (/^\s*\[routing\]/m.test(content)) {
+      // Section exists but the key doesn't — append the key on the
+      // line right after the [routing] header to keep it scoped.
+      content = content.replace(/^(\s*\[routing\]\s*\n)/m, `$1max_agent_hops = ${value}\n`);
+    } else {
+      const trailing = content.endsWith("\n") ? "" : "\n";
+      content += `${trailing}\n[routing]\ndefault = "none"\nmax_agent_hops = ${value}\n`;
+    }
+    fs.writeFileSync(tomlPath, content);
+  } catch (err) {
+    return res.status(500).json({ error: "Failed to write config.toml", detail: err.message });
+  }
+
+  // 2. Best-effort push to the running AC so the change is live.
+  // Failures here are non-fatal: the next restart still picks up
+  // the persisted value.
+  let live = false;
+  try {
+    const { url: base, token: sessionToken } = getChattrConfig(projectId);
+    if (base) {
+      await sendWsEvent(base, sessionToken, { type: "update_settings", data: { max_agent_hops: value } });
+      live = true;
+    }
+  } catch (err) {
+    console.warn(`[loop-guard] live update failed for ${projectId}: ${err.message || err}`);
+  }
+
+  res.json({ ok: true, value, live });
+});
+
 router.post("/api/chat", async (req, res) => {
   const projectId = req.query.project || req.body.project;
   const { url: base, token: sessionToken } = getChattrConfig(projectId);
@@ -839,6 +946,11 @@ router.post("/api/setup", (req, res) => {
         const wtDir = path.join(parentDir, `${dirName}-${agent}`);
         content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${agent.charAt(0).toUpperCase() + agent.slice(1)} ${labels[i]}"\nmcp_inject = "flag"\n\n`;
       });
+      // #403 / quadwork#274: raise the loop guard from AC's default
+      // of 4 to 30 so autonomous PR review cycles (head→dev→re1+re2→
+      // dev→head, ~5 hops) don't fire mid-batch and force the
+      // operator to type /continue. AC clamps to [1, 50] internally.
+      content += `[routing]\ndefault = "none"\nmax_agent_hops = 30\n\n`;
       content += `[mcp]\nhttp_port = ${mcp_http}\nsse_port = ${mcp_sse}\n`;
       fs.writeFileSync(tomlPath, content);
 

--- a/src/components/LoopGuardWidget.tsx
+++ b/src/components/LoopGuardWidget.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface LoopGuardWidgetProps {
+  projectId: string;
+}
+
+/**
+ * #403 / quadwork#274: operator widget for AgentChattr's loop guard
+ * (max_agent_hops). AC's default is 4, which fires mid-cycle on a
+ * normal autonomous PR review (head→dev→re1+re2→dev→head merge ≈ 5
+ * hops). QuadWork ships with 30 by default but the operator may
+ * want to tune it. The widget reads the persisted value from the
+ * project's config.toml and writes back through /api/loop-guard,
+ * which both rewrites config.toml and live-pushes to the running AC
+ * via update_settings ws event so the change is immediate.
+ */
+export default function LoopGuardWidget({ projectId }: LoopGuardWidgetProps) {
+  const [value, setValue] = useState<number>(30);
+  const [draft, setDraft] = useState<string>("30");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [live, setLive] = useState<boolean | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
+
+  // Load on mount + when project changes.
+  useEffect(() => {
+    fetch(`/api/loop-guard?project=${encodeURIComponent(projectId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d && typeof d.value === "number") {
+          setValue(d.value);
+          setDraft(String(d.value));
+        }
+      })
+      .catch(() => {});
+  }, [projectId]);
+
+  const apply = () => {
+    const n = parseInt(draft, 10);
+    if (!Number.isInteger(n) || n < 4 || n > 50) {
+      setError("Must be an integer between 4 and 50.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    fetch(`/api/loop-guard?project=${encodeURIComponent(projectId)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: n }),
+    })
+      .then(async (r) => {
+        if (!r.ok) {
+          const body = await r.text().catch(() => "");
+          throw new Error(`${r.status}: ${body.slice(0, 120)}`);
+        }
+        return r.json();
+      })
+      .then((d) => {
+        setValue(d.value);
+        setLive(d.live);
+      })
+      .catch((err) => setError(err.message || String(err)))
+      .finally(() => setSaving(false));
+  };
+
+  return (
+    <div className="border border-border rounded p-2 text-[11px] font-mono">
+      <div className="flex items-center gap-1.5 mb-1">
+        <span className="uppercase tracking-wider text-text-muted">Loop Guard</span>
+        <button
+          type="button"
+          aria-label="About loop guard"
+          onClick={() => setShowHelp((s) => !s)}
+          className="w-3.5 h-3.5 rounded-full border border-border text-[9px] leading-none text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
+        >?</button>
+      </div>
+      {showHelp && (
+        <div className="mb-1.5 p-1.5 text-[10px] leading-snug text-text bg-bg-surface border border-border/60 rounded">
+          <b>Loop Guard</b> pauses agent-to-agent message chains after this many hops with no human reply. Higher values let agents work longer overnight; lower values add safety against runaway loops. AgentChattr accepts <b>4–50</b>; QuadWork defaults to <b>30</b> (about 5–6 full PR cycles). Posting any chat message yourself resets the counter immediately.
+        </div>
+      )}
+      <div className="flex items-center gap-1.5">
+        <span className="text-text-muted">Pause after</span>
+        <input
+          type="number"
+          min={4}
+          max={50}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          disabled={saving}
+          className="w-12 bg-transparent px-1 py-0.5 border border-border rounded text-text outline-none focus:ring-1 focus:ring-accent"
+        />
+        <span className="text-text-muted">hops</span>
+        <button
+          type="button"
+          onClick={apply}
+          disabled={saving || draft === String(value)}
+          className="ml-auto px-2 py-0.5 text-[10px] text-accent border border-accent/40 rounded hover:bg-accent/10 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          title="Apply (writes config.toml + live-pushes to AgentChattr)"
+        >
+          {saving ? "…" : "Apply"}
+        </button>
+      </div>
+      {error && (
+        <div className="mt-1 text-[10px] text-red-400">{error}</div>
+      )}
+      {live === false && !error && (
+        <div className="mt-1 text-[10px] text-text-muted">
+          Saved to config.toml — live update failed; takes effect on next AC restart.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -3,6 +3,7 @@
 import PanelHeader from "./PanelHeader";
 import ScheduledTriggerWidget from "./ScheduledTriggerWidget";
 import TelegramBridgeWidget from "./TelegramBridgeWidget";
+import LoopGuardWidget from "./LoopGuardWidget";
 
 /**
  * Bottom-right quadrant of the project dashboard (#208).
@@ -21,6 +22,7 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
       <PanelHeader label="Operator Features" />
       <div className="flex-1 min-h-0 flex flex-col gap-2 p-2 overflow-auto">
         <ScheduledTriggerWidget projectId={projectId} />
+        <LoopGuardWidget projectId={projectId} />
         <TelegramBridgeWidget projectId={projectId} />
       </div>
     </div>


### PR DESCRIPTION
Fixes #274
Tracker: realproject7/agent-os#403
Master: #283 (Batch 30 Phase 2)

## Summary
- Web wizard's `add-config` now writes `[routing] default = "none" / max_agent_hops = 30` to config.toml. (CLI wizard already shipped 30 via templates/config.toml.)
- New `migrateLoopGuardDefaults()` in `bin/quadwork.js`, called from `cmdStart` after `migrateLegacyProjects`. Idempotent — appends the section only when both are missing; never patches an operator-tuned section.
- New `GET/PUT /api/loop-guard` endpoints in `server/routes.js`:
  - GET reads `max_agent_hops` from the project's config.toml.
  - PUT validates 4–50 (matching AC's `update_settings` clamp), rewrites the key in config.toml, and best-effort live-pushes through a new `sendWsEvent()` helper that opens the AC ws and sends `{type: "update_settings", data: {max_agent_hops}}`. Live push failures are non-fatal.
- New `LoopGuardWidget.tsx`: number input + Apply + (?) explainer popover. Embedded in `OperatorFeaturesPanel` between Scheduled Trigger and Telegram Bridge.

## Acceptance criteria
- [x] New projects get `max_agent_hops = 30` automatically (web + CLI both covered)
- [x] Existing projects auto-migrate on next `quadwork start`
- [x] Loop Guard widget shows current value
- [x] Editing the value + Apply updates the running AC without restart (via ws update_settings)
- [x] Tooltip explains the concept
- [x] Setting persists across restarts (config.toml rewrite)
- [x] Min/max enforced (4–50)

## Test plan
- [x] `node --check` on server/routes.js + bin/quadwork.js
- [x] `tsc --noEmit` clean
- [ ] Reviewers: spin up a project, open the dashboard, confirm Loop Guard widget reads 30, change to 35, click Apply, verify config.toml updated and AC's room_settings.json reflects the new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)