### PR TITLE
[#267] Auto-increment batch numbers in OVERNIGHT-QUEUE.md

### DIFF
--- a/templates/OVERNIGHT-QUEUE.md
+++ b/templates/OVERNIGHT-QUEUE.md
@@ -10,7 +10,7 @@
 
 ## Active Batch
 
-(no active batch yet — operator will assign one via chat)
+(no active batch yet — operator will assign one via chat. Head will use batch number 1 for the first batch.)
 
 ---
 

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -57,6 +57,20 @@ This is an **absolute path** — read it with the full path, never a relative on
 When the operator asks you in chat to start a task or batch:
 1. Create the GitHub issue(s) if they don't already exist (`gh issue create` with scope, acceptance, and `agent/*` labels).
 2. Append the task(s) under the **Backlog** section of `OVERNIGHT-QUEUE.md`, or move them into **Active Batch** if the operator says they're ready to run.
+
+   **Batch numbering.** Each new batch you put into Active Batch gets the next sequential number. Read every `**Batch:** N` line in the file (Active Batch + Done) and use `max(N) + 1`. If no batches exist yet, start at `1`. Stamp the Active Batch section with:
+
+   ```markdown
+   ## Active Batch
+
+   **Batch:** <N>
+   **Started:** <YYYY-MM-DD HH:MM>
+   **Status:** pending kickoff
+
+   (items...)
+   ```
+
+   When you move a batch to Done, **preserve its `Batch: N` line** so the next batch's number computation stays correct.
 3. Reply in chat to confirm what you wrote to the queue file (issue numbers + which section).
 4. **Tell the operator the queue is ready and how to kick it off.** Send a chat message like:
 


### PR DESCRIPTION
Fixes #267
Tracker: realproject7/agent-os#404
Master: #283 (Batch 30 Phase 2)

## Summary
- `templates/OVERNIGHT-QUEUE.md` placeholder updated to mention that Head will use batch number 1 for the first batch.
- `templates/seeds/head.AGENTS.md` Operator → Head flow gains a Batch numbering subsection: read every `**Batch:** N` line in the file (Active Batch + Done), use `max(N) + 1`, stamp the Active Batch section with `Batch / Started / Status` fields, and preserve the `Batch: N` line when moving an entry to Done so the next computation stays correct.

## Acceptance criteria
- [x] Template includes the Active Batch section with batch number placeholder
- [x] Head's seed includes the auto-increment instruction
- [x] When Head creates a new batch, the Active Batch section gets a fresh `Batch: N` line
- [x] When a batch is moved to Done, the batch number is preserved
- [x] The next batch's number is one greater than the highest existing batch number

## Test plan
- [x] Diff inspection — only template + seed prose touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)