### PR TITLE
[#278] Operator display name in chat (replace hardcoded 'user')

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1172,6 +1172,14 @@ function writeQuadWorkConfig(setup) {
   header("Writing QuadWork Config");
 
   const config = readConfig();
+  // #405 / quadwork#278: ensure the global config has an
+  // operator_name slot. /api/chat reads this on every send and
+  // sanitizes empty/missing values back to "user", so leaving it
+  // unset is safe — but writing the default explicitly makes the
+  // setting discoverable in the on-disk file.
+  if (typeof config.operator_name !== "string") {
+    config.operator_name = "user";
+  }
 
   const project = {
     id: setup.projectName,

--- a/server/config.js
+++ b/server/config.js
@@ -8,8 +8,25 @@ const DEFAULT_CONFIG = {
   port: 8400,
   agentchattr_url: "http://127.0.0.1:8300",
   agentchattr_dir: path.join(os.homedir(), ".quadwork", "agentchattr"),
+  // #405 / quadwork#278: display name used as the chat sender for
+  // messages posted from the dashboard. AC's registry name validator
+  // accepts 1–32 alphanumeric + dash + underscore characters; mirror
+  // that here so the sanitized value matches what AC will accept.
+  operator_name: "user",
   projects: [],
 };
+
+// Sanitize an operator-supplied display name to match AC's name
+// validator (registry.py: 1–32 alnum + dash + underscore). Empty or
+// non-string input falls back to "user". Used both when reading the
+// config (in case the file was hand-edited) and on /api/chat sends
+// (so even a stale on-disk value can't impersonate an agent).
+function sanitizeOperatorName(value) {
+  if (typeof value !== "string") return "user";
+  const cleaned = value.trim().replace(/[^A-Za-z0-9_-]/g, "");
+  if (!cleaned) return "user";
+  return cleaned.slice(0, 32);
+}
 
 // Migration: rename old agent keys to new ones
 const AGENT_KEY_MAP = { t1: "head", t2a: "reviewer1", t2b: "reviewer2", t3: "dev" };
@@ -160,4 +177,4 @@ async function syncChattrToken(projectId) {
   } catch {}
 }
 
-module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH };
+module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, sanitizeOperatorName, CONFIG_PATH };

--- a/server/config.js
+++ b/server/config.js
@@ -16,16 +16,41 @@ const DEFAULT_CONFIG = {
   projects: [],
 };
 
+// Reserved sender names that the operator must NOT be able to claim
+// — these are the registered agent identities (current + legacy
+// aliases) plus AC's own "system" sender. Without this denylist a
+// hand-edited or PUT /api/config'd `operator_name = "head"` would
+// post chat messages with sender:"head", reopening the impersonation
+// vector #230 closed. Case-insensitive match.
+const RESERVED_OPERATOR_NAMES = new Set([
+  "head",
+  "dev",
+  "reviewer1",
+  "reviewer2",
+  // Legacy agent aliases — preserved in routing logic in a few
+  // places, so block them too even though new projects no longer
+  // register under these names.
+  "t1",
+  "t2a",
+  "t2b",
+  "t3",
+  // AC's own broadcast / housekeeping sender.
+  "system",
+]);
+
 // Sanitize an operator-supplied display name to match AC's name
-// validator (registry.py: 1–32 alnum + dash + underscore). Empty or
-// non-string input falls back to "user". Used both when reading the
-// config (in case the file was hand-edited) and on /api/chat sends
-// (so even a stale on-disk value can't impersonate an agent).
+// validator (registry.py: 1–32 alnum + dash + underscore) AND to
+// reject any reserved agent identity. Empty / non-string / reserved
+// input falls back to "user". Used both when reading the config (in
+// case the file was hand-edited) and on /api/chat sends (so even a
+// stale on-disk value can't impersonate an agent).
 function sanitizeOperatorName(value) {
   if (typeof value !== "string") return "user";
   const cleaned = value.trim().replace(/[^A-Za-z0-9_-]/g, "");
   if (!cleaned) return "user";
-  return cleaned.slice(0, 32);
+  const truncated = cleaned.slice(0, 32);
+  if (RESERVED_OPERATOR_NAMES.has(truncated.toLowerCase())) return "user";
+  return truncated;
 }
 
 // Migration: rename old agent keys to new ones

--- a/server/routes.js
+++ b/server/routes.js
@@ -68,7 +68,7 @@ router.put("/api/config", (req, res) => {
 
 // ─── Chat (AgentChattr proxy) ──────────────────────────────────────────────
 
-const { resolveProjectChattr } = require("./config");
+const { resolveProjectChattr, sanitizeOperatorName } = require("./config");
 const { installAgentChattr, findAgentChattr } = require("./install-agentchattr");
 
 /**
@@ -320,10 +320,24 @@ router.post("/api/chat", async (req, res) => {
 
   // #230: ignore any client-supplied sender. /api/chat is the
   // dashboard's send path, so the message must always be attributed
-  // to "user". Forwarding `req.body.sender` would let any caller
-  // hitting QuadWork's /api/chat impersonate an agent identity (t1,
-  // t3, …) over the AgentChattr ws path, which the old /api/send
-  // flow could not do.
+  // to a server-controlled value. Forwarding `req.body.sender` would
+  // let any caller hitting QuadWork's /api/chat impersonate an agent
+  // identity (t1, t3, …) over the AgentChattr ws path, which the
+  // old /api/send flow could not do.
+  //
+  // #405 / quadwork#278: read the operator's display name from the
+  // server-side config file rather than hardcoding "user". The
+  // sanitizer matches AC's registry name validator (1–32 alnum +
+  // dash + underscore) so even a hand-edited config can't post a
+  // value AC will reject (or impersonate an agent), and an empty /
+  // missing value falls back to "user".
+  let operatorSender = "user";
+  try {
+    const cfg = readConfigFile();
+    operatorSender = sanitizeOperatorName(cfg.operator_name);
+  } catch {
+    // non-fatal — fall through to "user"
+  }
   // #397 / quadwork#262: pass reply_to through to AgentChattr so the
   // dashboard's reply button mirrors AC's native threaded-reply
   // behavior. Only forward when it's a real positive integer — guards
@@ -335,7 +349,7 @@ router.post("/api/chat", async (req, res) => {
   const message = {
     text: typeof req.body?.text === "string" ? req.body.text : "",
     channel: req.body?.channel || "general",
-    sender: "user",
+    sender: operatorSender,
     attachments: Array.isArray(req.body?.attachments) ? req.body.attachments : [],
     ...(replyTo !== null ? { reply_to: replyTo } : {}),
   };

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -34,6 +34,9 @@ interface Config {
   agentchattr_token: string;
   default_backend?: string;
   reviewer_github_user?: string;
+  // #405 / quadwork#278: display name used as the chat sender for
+  // dashboard-originated messages. Defaults to "user" server-side.
+  operator_name?: string;
   projects: ProjectConfig[];
 }
 
@@ -118,6 +121,7 @@ export default function SettingsPage() {
         agentchattr_token: data.agentchattr_token || "",
         default_backend: data.default_backend || "claude",
         reviewer_github_user: data.reviewer_github_user || "",
+        operator_name: data.operator_name || "user",
         projects: data.projects || [],
       }))
       .catch(() => {});
@@ -369,6 +373,25 @@ export default function SettingsPage() {
           {saving ? "Saving..." : saved ? "Saved" : "Save"}
         </button>
       </div>
+
+      {/* #405 / quadwork#278: operator identity — name shown next to
+          dashboard chat messages. Server-side validated to AC's
+          registry name rules (1–32 alnum + dash + underscore). */}
+      <section className="mb-8">
+        <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">Operator Identity</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <Input
+            label="Your name in chat"
+            value={config.operator_name || "user"}
+            onChange={(v) => updateGlobal("operator_name" as keyof Config, v)}
+            placeholder="user"
+          />
+        </div>
+        <p className="mt-2 text-[10px] text-text-muted leading-snug">
+          Shows next to your messages in the AgentChattr chat panel. Defaults to <code>user</code> if blank.
+          Allowed: 1–32 letters, digits, dash, underscore (matches AgentChattr&apos;s name rules; other characters are stripped server-side).
+        </p>
+      </section>
 
       {/* Global Settings (#212: full-width grid, every section visible) */}
       <section className="mb-8">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -390,6 +390,7 @@ export default function SettingsPage() {
         <p className="mt-2 text-[10px] text-text-muted leading-snug">
           Shows next to your messages in the AgentChattr chat panel. Defaults to <code>user</code> if blank.
           Allowed: 1–32 letters, digits, dash, underscore (matches AgentChattr&apos;s name rules; other characters are stripped server-side).
+          Reserved agent names like <code>head</code>, <code>dev</code>, <code>reviewer1</code>, <code>reviewer2</code>, and <code>system</code> are rejected and fall back to <code>user</code>.
         </p>
       </section>
 


### PR DESCRIPTION
Fixes #278
Tracker: realproject7/agent-os#405
Master: #283 (Batch 30 Phase 3)

## Summary
- New `operator_name` field on the global config (default `user`).
- `server/config.js` exports `sanitizeOperatorName()` matching AC's registry name rules (1–32 alnum + dash + underscore); empty / missing / invalid → `user`.
- `server/routes.js` POST `/api/chat` reads + sanitizes `operator_name` and uses it as the AC ws sender. Client-supplied sender is still ignored — #230's anti-impersonation guarantee holds.
- `src/components/SettingsPage.tsx`: new "Operator Identity" section above Global with a "Your name in chat" input + helper text describing the allowed character set.
- `bin/quadwork.js` `writeQuadWorkConfig` stamps `operator_name = "user"` when missing so the field is discoverable on first init.

## Acceptance criteria
- [x] Settings page has an "Your name in chat" input, defaults to `user`
- [x] Saving the config persists `operator_name` (existing PUT /api/config wiring)
- [x] New chat messages send with the configured operator name as sender
- [x] Validation: 1-32 chars, alphanumeric + dash + underscore (server-side strip)
- [x] Empty string falls back to `"user"`
- [x] Client-supplied `sender` field is still ignored
- [ ] Reviewers: confirm AC's UI shows the new name correctly when viewing the chat

## Test plan
- [x] `node --check` on server/routes.js, server/config.js, bin/quadwork.js
- [x] `tsc --noEmit` clean
- [ ] Reviewers: set name to "alice", post a message, confirm `alice` appears in chat (and AC's native UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)