### PR TITLE
[#271] Color-code @mentions in chat messages

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import ProjectChatEmptyState from "./ProjectChatEmptyState";
 
 interface Message {
@@ -36,6 +36,41 @@ function senderLabel(sender: string): string {
   if (s === "reviewer1") return "RE1";
   if (s === "reviewer2") return "RE2";
   return sender;
+}
+
+// #408 / quadwork#271: render @mentions of known agents as colored
+// pills. Only the four agent IDs + "user" qualify; unknown handles
+// stay as plain text. The mention must be preceded by start-of-string
+// or whitespace so URL fragments like "https://github.com/@user"
+// don't accidentally pillify.
+const MENTION_RE = /(^|\s)(@(?:head|dev|reviewer1|reviewer2|user))\b/gi;
+function renderMessageWithMentions(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  for (const match of text.matchAll(MENTION_RE)) {
+    const fullStart = match.index ?? 0;
+    const lead = match[1];
+    const mention = match[2];
+    const mentionStart = fullStart + lead.length;
+    if (mentionStart > last) {
+      parts.push(text.slice(last, mentionStart));
+    }
+    const agentId = mention.slice(1).toLowerCase();
+    const color = senderColor(agentId);
+    parts.push(
+      <span
+        key={`m${key++}`}
+        className="inline-block px-1 py-0 rounded font-mono"
+        style={{ backgroundColor: `${color}22`, color }}
+      >
+        {mention}
+      </span>,
+    );
+    last = mentionStart + mention.length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.length > 0 ? parts : [text];
 }
 
 /**
@@ -284,7 +319,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
               {senderLabel(msg.sender)}
             </span>
             <span className="text-text break-words min-w-0 whitespace-pre-wrap flex-1">
-              {msg.text}
+              {renderMessageWithMentions(msg.text)}
             </span>
             {/* #397 / quadwork#262: reply affordance — small grey,
                 hover-revealed so it doesn't visually compete with the

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -42,8 +42,11 @@ function senderLabel(sender: string): string {
 // pills. Only the four agent IDs + "user" qualify; unknown handles
 // stay as plain text. The mention must be preceded by start-of-string
 // or whitespace so URL fragments like "https://github.com/@user"
-// don't accidentally pillify.
-const MENTION_RE = /(^|\s)(@(?:head|dev|reviewer1|reviewer2|user))\b/gi;
+// don't accidentally pillify, AND must be followed by something that
+// can't continue a handle (no word char, no hyphen) so longer
+// hyphenated handles like "@user-name" or "@head-2" don't pill the
+// known prefix and leave the rest as plain text.
+const MENTION_RE = /(^|\s)(@(?:head|dev|reviewer1|reviewer2|user))(?![\w-])/gi;
 function renderMessageWithMentions(text: string): React.ReactNode[] {
   const parts: React.ReactNode[] = [];
   let last = 0;


### PR DESCRIPTION
Fixes #271
Tracker: realproject7/agent-os#408
Master: #283 (Batch 30 Phase 3)

## Summary
- New `renderMessageWithMentions()` helper splits chat text on a regex `(^|\s)(@(?:head|dev|reviewer1|reviewer2|user))\b` (case-insensitive) and wraps each match in a small colored pill using the existing `SENDER_COLORS` map.
- Background uses a 22-alpha tint of the agent color so the text stays legible against the chat font; pills are inline-block rounded font-mono so line wrapping stays intact.
- URL safety: the mention must be preceded by start-of-string or whitespace, so `https://github.com/@user` does not pillify.
- Iframe path already inherits the same look from AC's native UI; this only touches the API fallback rendering in `ChatPanelAPI`.

## Acceptance criteria
- [x] Each agent `@mention` renders as a colored pill matching its sender color
- [x] `@user` mentions also pill (in user color)
- [x] Unknown `@whatever` mentions stay as plain text
- [x] URLs containing `@` aren't accidentally pilled (lookahead-equivalent via the leading whitespace group)
- [x] Pills look consistent with the chat font / line height

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Reviewers: post `@head ping @reviewer1` and confirm both pill, post `@somebody hi` and confirm plain, post a URL like `https://github.com/@user` and confirm no pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)