### PR TITLE
[#282] Current Batch Progress panel

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -891,8 +891,17 @@ function progressForItem(repo, issueNumber) {
     };
   }
   // Count distinct APPROVED reviews per author so a stale APPROVED
-  // followed by REQUEST_CHANGES doesn't double-count.
-  const reviews = Array.isArray(prData.reviews) ? prData.reviews : [];
+  // followed by REQUEST_CHANGES doesn't double-count. Sort by
+  // submittedAt ascending first so the Map's "last write wins"
+  // genuinely lands on the freshest review per author — gh's
+  // current ordering is chronological in practice but undocumented,
+  // so the explicit sort keeps us safe if that ever changes.
+  const reviews = Array.isArray(prData.reviews) ? prData.reviews.slice() : [];
+  reviews.sort((a, b) => {
+    const ta = (a && a.submittedAt) ? Date.parse(a.submittedAt) : 0;
+    const tb = (b && b.submittedAt) ? Date.parse(b.submittedAt) : 0;
+    return ta - tb;
+  });
   const latestByAuthor = new Map();
   for (const r of reviews) {
     const author = (r && r.author && r.author.login) || "";

--- a/server/routes.js
+++ b/server/routes.js
@@ -760,6 +760,231 @@ router.get("/api/github/merged-prs", (req, res) => {
   }
 });
 
+// #413 / quadwork#282: Current Batch Progress panel.
+//
+// Reads ~/.quadwork/{project}/OVERNIGHT-QUEUE.md, parses the
+// `## Active Batch` section for `Batch: N` + issue numbers, and
+// resolves each issue against GitHub (state + linked PR + review
+// counts) to compute a progress state. The 5 progress buckets are
+// deterministic from issue/PR state — no agent inference.
+//
+// Progress mapping (from upstream issue):
+//   queued    0%   issue exists, no linked PR
+//   in_review 20%  PR open, 0 approvals
+//   approved1 50%  PR open, 1 approval
+//   ready     80%  PR open, 2+ approvals
+//   merged   100%  PR merged AND issue closed
+//
+// Cached for 10s per project to avoid hammering gh on every poll.
+
+const _batchProgressCache = new Map(); // projectId -> { ts, data }
+const BATCH_PROGRESS_TTL_MS = 10000;
+
+function parseActiveBatch(queueText) {
+  if (typeof queueText !== "string" || !queueText) {
+    return { batchNumber: null, issueNumbers: [] };
+  }
+  // Pull just the Active Batch section so a stray `#123` in Backlog
+  // or Done doesn't leak into the active list.
+  const m = queueText.match(/##\s+Active Batch[\s\S]*?(?=\n##\s|$)/i);
+  if (!m) return { batchNumber: null, issueNumbers: [] };
+  const section = m[0];
+  const batchMatch = section.match(/\*\*Batch:\*\*\s*(\d+)/i) || section.match(/Batch:\s*(\d+)/i);
+  const batchNumber = batchMatch ? parseInt(batchMatch[1], 10) : null;
+  // Collect every `#NNN` token in the section. dedup + preserve order.
+  const seen = new Set();
+  const issueNumbers = [];
+  for (const num of section.matchAll(/#(\d{1,6})\b/g)) {
+    const n = parseInt(num[1], 10);
+    if (!seen.has(n)) {
+      seen.add(n);
+      issueNumbers.push(n);
+    }
+  }
+  return { batchNumber, issueNumbers };
+}
+
+function ghJsonExec(args) {
+  try {
+    const out = execFileSync("gh", args, { encoding: "utf-8", timeout: 10000 });
+    return JSON.parse(out);
+  } catch {
+    return null;
+  }
+}
+
+function progressForItem(repo, issueNumber) {
+  // Pull issue state + linked PRs in one call. closedByPullRequestsReferences
+  // is gh's serializer for the GraphQL `closedByPullRequestsReferences`
+  // edge — only present when a PR with `Fixes #N` / `Closes #N`
+  // (or the link UI) targets the issue.
+  const issue = ghJsonExec([
+    "issue",
+    "view",
+    String(issueNumber),
+    "-R",
+    repo,
+    "--json",
+    "number,title,state,url,closedByPullRequestsReferences",
+  ]);
+  if (!issue) {
+    return {
+      issue_number: issueNumber,
+      title: `#${issueNumber} (not found)`,
+      url: null,
+      status: "unknown",
+      progress: 0,
+      label: "not found",
+    };
+  }
+  const linked = Array.isArray(issue.closedByPullRequestsReferences)
+    ? issue.closedByPullRequestsReferences
+    : [];
+  // Pick the freshest linked PR (highest number) if there are multiple.
+  const pr = linked.length > 0
+    ? linked.slice().sort((a, b) => (b.number || 0) - (a.number || 0))[0]
+    : null;
+  // No linked PR yet — queued.
+  if (!pr) {
+    return {
+      issue_number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      status: "queued",
+      progress: 0,
+      label: "Issue · queued",
+    };
+  }
+  // Re-fetch the PR to get reviewDecision + reviews + state, since
+  // the issue's closedByPullRequestsReferences edge only carries
+  // number/state/url.
+  const prData = ghJsonExec([
+    "pr",
+    "view",
+    String(pr.number),
+    "-R",
+    repo,
+    "--json",
+    "number,state,url,reviewDecision,reviews",
+  ]);
+  if (!prData) {
+    return {
+      issue_number: issue.number,
+      title: issue.title,
+      url: pr.url || issue.url,
+      pr_number: pr.number,
+      status: "in_review",
+      progress: 20,
+      label: `PR #${pr.number} · waiting on review`,
+    };
+  }
+  const merged = prData.state === "MERGED" && issue.state === "CLOSED";
+  if (merged) {
+    return {
+      issue_number: issue.number,
+      title: issue.title,
+      url: prData.url || issue.url,
+      pr_number: prData.number,
+      status: "merged",
+      progress: 100,
+      label: "Merged ✓",
+    };
+  }
+  // Count distinct APPROVED reviews per author so a stale APPROVED
+  // followed by REQUEST_CHANGES doesn't double-count.
+  const reviews = Array.isArray(prData.reviews) ? prData.reviews : [];
+  const latestByAuthor = new Map();
+  for (const r of reviews) {
+    const author = (r && r.author && r.author.login) || "";
+    if (!author) continue;
+    latestByAuthor.set(author, r.state);
+  }
+  let approvalCount = 0;
+  for (const state of latestByAuthor.values()) {
+    if (state === "APPROVED") approvalCount++;
+  }
+  if (approvalCount >= 2) {
+    return {
+      issue_number: issue.number,
+      title: issue.title,
+      url: prData.url || issue.url,
+      pr_number: prData.number,
+      status: "ready",
+      progress: 80,
+      label: `PR #${prData.number} · 2 approvals · ready`,
+    };
+  }
+  if (approvalCount === 1) {
+    return {
+      issue_number: issue.number,
+      title: issue.title,
+      url: prData.url || issue.url,
+      pr_number: prData.number,
+      status: "approved1",
+      progress: 50,
+      label: `PR #${prData.number} · 1 approval`,
+    };
+  }
+  return {
+    issue_number: issue.number,
+    title: issue.title,
+    url: prData.url || issue.url,
+    pr_number: prData.number,
+    status: "in_review",
+    progress: 20,
+    label: `PR #${prData.number} · waiting on review`,
+  };
+}
+
+function summarizeItems(items) {
+  let merged = 0, ready = 0, approved1 = 0, inReview = 0, queued = 0;
+  for (const it of items) {
+    if (it.status === "merged") merged++;
+    else if (it.status === "ready") ready++;
+    else if (it.status === "approved1") approved1++;
+    else if (it.status === "in_review") inReview++;
+    else if (it.status === "queued") queued++;
+  }
+  const parts = [`${merged}/${items.length} merged`];
+  if (ready > 0) parts.push(`${ready} ready to merge`);
+  if (approved1 > 0) parts.push(`${approved1} needs 2nd approval`);
+  if (inReview > 0) parts.push(`${inReview} in review`);
+  if (queued > 0) parts.push(`${queued} queued`);
+  return parts.join(" · ");
+}
+
+router.get("/api/batch-progress", (req, res) => {
+  const projectId = req.query.project;
+  if (!projectId) return res.status(400).json({ error: "Missing project" });
+
+  const cached = _batchProgressCache.get(projectId);
+  if (cached && Date.now() - cached.ts < BATCH_PROGRESS_TTL_MS) {
+    return res.json(cached.data);
+  }
+
+  const repo = getRepo(projectId);
+  if (!repo) return res.status(400).json({ error: "No repo configured for project" });
+
+  const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
+  let queueText = "";
+  try { queueText = fs.readFileSync(queuePath, "utf-8"); }
+  catch { /* missing file → empty active batch */ }
+
+  const { batchNumber, issueNumbers } = parseActiveBatch(queueText);
+  if (issueNumbers.length === 0) {
+    const data = { batch_number: batchNumber, items: [], summary: "", complete: false };
+    _batchProgressCache.set(projectId, { ts: Date.now(), data });
+    return res.json(data);
+  }
+
+  const items = issueNumbers.map((n) => progressForItem(repo, n));
+  const summary = summarizeItems(items);
+  const complete = items.length > 0 && items.every((it) => it.status === "merged");
+  const data = { batch_number: batchNumber, items, summary, complete };
+  _batchProgressCache.set(projectId, { ts: Date.now(), data });
+  res.json(data);
+});
+
 // ─── Memory ────────────────────────────────────────────────────────────────
 
 function getProject(projectId) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -791,11 +791,32 @@ function parseActiveBatch(queueText) {
   const section = m[0];
   const batchMatch = section.match(/\*\*Batch:\*\*\s*(\d+)/i) || section.match(/Batch:\s*(\d+)/i);
   const batchNumber = batchMatch ? parseInt(batchMatch[1], 10) : null;
-  // Collect every `#NNN` token in the section. dedup + preserve order.
+  // Only collect issue numbers from lines that look like list-item
+  // entries — i.e. lines whose first content token is either `#N`
+  // or `[#N]` after an optional list marker. This rejects prose
+  // like "Tracking umbrella: #293", "next after #294 merged", and
+  // similar dependency / commentary references that t2a flagged on
+  // realproject7/dropcast's queue.
+  //
+  // Accepted line shapes:
+  //   - #295 sub-A heartbeat
+  //   * #295 sub-A heartbeat
+  //   1. #295 sub-A heartbeat
+  //   #295 sub-A heartbeat
+  //   - [#295] sub-A heartbeat
+  //   [#295] sub-A heartbeat
+  //
+  // Rejected:
+  //   Tracking umbrella: #293
+  //   Assigned next after #294 merged.
+  //   See #295 for context.
+  const ITEM_LINE_RE = /^\s*(?:[-*]\s+|\d+\.\s+)?\[?#(\d{1,6})\]?\b/;
   const seen = new Set();
   const issueNumbers = [];
-  for (const num of section.matchAll(/#(\d{1,6})\b/g)) {
-    const n = parseInt(num[1], 10);
+  for (const line of section.split("\n")) {
+    const lineMatch = line.match(ITEM_LINE_RE);
+    if (!lineMatch) continue;
+    const n = parseInt(lineMatch[1], 10);
     if (!seen.has(n)) {
       seen.add(n);
       issueNumbers.push(n);

--- a/src/components/BatchProgressPanel.tsx
+++ b/src/components/BatchProgressPanel.tsx
@@ -25,17 +25,12 @@ interface BatchProgressPanelProps {
 
 const BAR_SEGMENTS = 20;
 
-function ProgressBar({ percent, status }: { percent: number; status: BatchProgressItem["status"] }) {
+function ProgressBar({ percent }: { percent: number }) {
   const filled = Math.round((percent / 100) * BAR_SEGMENTS);
   const empty = BAR_SEGMENTS - filled;
-  // Use the accent color for in-progress, a calmer green-ish accent
-  // for merged. Tailwind doesn't ship a green-500 in this theme, so
-  // reuse the existing accent + a slight opacity for the merged
-  // case to keep visual cohesion with the rest of the dashboard.
-  const fillClass = status === "merged" ? "text-accent" : "text-accent";
   return (
     <span className="font-mono text-[11px] tabular-nums whitespace-nowrap">
-      <span className={fillClass}>{"█".repeat(filled)}</span>
+      <span className="text-accent">{"█".repeat(filled)}</span>
       <span className="text-text-muted">{"░".repeat(empty)}</span>
     </span>
   );
@@ -122,7 +117,7 @@ export default function BatchProgressPanel({ projectId }: BatchProgressPanelProp
               <span className="text-[11px] text-text-muted w-8 shrink-0 tabular-nums">
                 #{item.issue_number}
               </span>
-              <ProgressBar percent={item.progress} status={item.status} />
+              <ProgressBar percent={item.progress} />
               <span className="text-[11px] text-text-muted tabular-nums shrink-0 w-9 text-right">
                 {item.progress}%
               </span>

--- a/src/components/BatchProgressPanel.tsx
+++ b/src/components/BatchProgressPanel.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+interface BatchProgressItem {
+  issue_number: number;
+  title: string;
+  url: string | null;
+  pr_number?: number;
+  status: "queued" | "in_review" | "approved1" | "ready" | "merged" | "unknown";
+  progress: number; // 0..100
+  label: string;
+}
+
+interface BatchProgressData {
+  batch_number: number | null;
+  items: BatchProgressItem[];
+  summary: string;
+  complete: boolean;
+}
+
+interface BatchProgressPanelProps {
+  projectId: string;
+}
+
+const BAR_SEGMENTS = 20;
+
+function ProgressBar({ percent, status }: { percent: number; status: BatchProgressItem["status"] }) {
+  const filled = Math.round((percent / 100) * BAR_SEGMENTS);
+  const empty = BAR_SEGMENTS - filled;
+  // Use the accent color for in-progress, a calmer green-ish accent
+  // for merged. Tailwind doesn't ship a green-500 in this theme, so
+  // reuse the existing accent + a slight opacity for the merged
+  // case to keep visual cohesion with the rest of the dashboard.
+  const fillClass = status === "merged" ? "text-accent" : "text-accent";
+  return (
+    <span className="font-mono text-[11px] tabular-nums whitespace-nowrap">
+      <span className={fillClass}>{"█".repeat(filled)}</span>
+      <span className="text-text-muted">{"░".repeat(empty)}</span>
+    </span>
+  );
+}
+
+/**
+ * #413 / quadwork#282: Current Batch Progress panel.
+ *
+ * Reads /api/batch-progress (which itself parses the active batch
+ * out of OVERNIGHT-QUEUE.md and resolves each issue against
+ * GitHub) and renders a row per item with a progress bar + status
+ * label. Polls every 30s on the same cadence as the rest of the
+ * GitHub panel.
+ */
+export default function BatchProgressPanel({ projectId }: BatchProgressPanelProps) {
+  const [data, setData] = useState<BatchProgressData | null>(null);
+
+  const load = useCallback(() => {
+    fetch(`/api/batch-progress?project=${encodeURIComponent(projectId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (d) setData(d); })
+      .catch(() => {});
+  }, [projectId]);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 30000);
+    return () => clearInterval(id);
+  }, [load]);
+
+  if (!data) {
+    return (
+      <div className="px-3 py-1.5 text-[11px] text-text-muted border-t border-border">
+        Loading batch progress…
+      </div>
+    );
+  }
+
+  // Empty state — no active batch in OVERNIGHT-QUEUE.md.
+  if (!data.items || data.items.length === 0) {
+    return (
+      <div className="border-t border-border">
+        <div className="px-3 py-1.5 flex items-center gap-2">
+          <span className="text-[10px] text-text-muted uppercase tracking-wider">
+            Current Batch: (none)
+          </span>
+        </div>
+        <div className="px-3 pb-2 text-[11px] text-text-muted">
+          No active batch. Ask Head to start one via the chat.
+        </div>
+      </div>
+    );
+  }
+
+  // Complete state — all items merged.
+  if (data.complete) {
+    return (
+      <div className="border-t border-border">
+        <div className="px-3 py-1.5 flex items-center gap-2">
+          <span className="text-[10px] text-text-muted uppercase tracking-wider">
+            Current Batch: Batch {data.batch_number ?? "—"}
+          </span>
+          <span className="text-[10px] text-accent">✅ COMPLETE</span>
+        </div>
+        <div className="px-3 pb-2 text-[11px] text-text-muted">
+          All {data.items.length} items merged. Waiting for the next batch.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-border">
+      <div className="px-3 py-1.5 flex items-center gap-2 border-b border-border/40">
+        <span className="text-[10px] text-text-muted uppercase tracking-wider">
+          Current Batch: Batch {data.batch_number ?? "—"}
+        </span>
+        <span className="text-[10px] text-text-muted">({data.items.length} items)</span>
+      </div>
+      <div className="max-h-40 overflow-y-auto">
+        {data.items.map((item) => {
+          const row = (
+            <div className="flex items-center gap-2 px-3 py-1 font-mono">
+              <span className="text-[11px] text-text-muted w-8 shrink-0 tabular-nums">
+                #{item.issue_number}
+              </span>
+              <ProgressBar percent={item.progress} status={item.status} />
+              <span className="text-[11px] text-text-muted tabular-nums shrink-0 w-9 text-right">
+                {item.progress}%
+              </span>
+              <span className="text-[11px] text-text truncate flex-1 min-w-0">
+                {item.label}
+              </span>
+            </div>
+          );
+          if (!item.url) {
+            return <div key={item.issue_number}>{row}</div>;
+          }
+          return (
+            <a
+              key={item.issue_number}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block hover:bg-[#1a1a1a] transition-colors border-b border-border/30"
+            >
+              {row}
+            </a>
+          );
+        })}
+      </div>
+      {data.summary && (
+        <div className="px-3 py-1.5 text-[11px] text-text-muted border-t border-border/40">
+          {data.summary}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import OvernightQueueModal from "./OvernightQueueModal";
+import BatchProgressPanel from "./BatchProgressPanel";
 
 interface Issue {
   number: number;
@@ -286,6 +287,13 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
             ))}
           </div>
         </div>
+      </div>
+
+      {/* #413 / quadwork#282: Current Batch Progress section sits
+          between the issues/PRs lists and the OVERNIGHT-QUEUE.md
+          row. Reads /api/batch-progress on its own 30s cadence. */}
+      <div className="shrink-0">
+        <BatchProgressPanel projectId={projectId} />
       </div>
 
       {/* #226: compact OVERNIGHT-QUEUE.md row at the bottom */}


### PR DESCRIPTION
Fixes #282
Tracker: realproject7/agent-os#413
Master: #283 (Batch 30 Phase 4 — final ticket)

## Summary
Backend (`server/routes.js`):
- New `GET /api/batch-progress?project=ID` (10s per-project cache).
- `parseActiveBatch()` reads `## Active Batch` from `~/.quadwork/{id}/OVERNIGHT-QUEUE.md`, extracts `Batch: N` + dedup'd ordered `#NNN` issue numbers.
- `progressForItem()` resolves each issue via `gh issue view ... closedByPullRequestsReferences`, picks the freshest linked PR, then `gh pr view` for `reviewDecision/reviews/state`. Approval count is per-author latest-state to avoid double-counting stale APPROVEDs.
- Five buckets: queued 0% / in_review 20% / approved1 50% / ready 80% / merged 100%. Merged requires both PR=MERGED and issue=CLOSED.
- `summarizeItems()` builds the "1/5 merged · …" footer.

Frontend (`BatchProgressPanel.tsx`, new):
- Polls every 30s.
- Empty / complete / in-progress states all rendered.
- Progress bar uses a 20-segment █/░ font-mono split so the panel matches the rest of the dashboard's terminal aesthetic — no chart lib.
- Rows are clickable when an issue/PR url is available.
- Embedded in `GitHubPanel.tsx` between the issues/PRs columns and the OVERNIGHT-QUEUE.md row.

## Acceptance criteria
- [x] Panel shows the current batch number from OVERNIGHT-QUEUE.md
- [x] Each issue in the active batch has its own row with progress bar
- [x] Progress is computed from GitHub state (PR existence, approval count, merged)
- [x] Status label is human-readable
- [x] Rows are clickable, open on GitHub
- [x] Summary line at the bottom
- [x] Complete state: "✅ COMPLETE" banner when all items merged
- [x] Empty state when no active batch exists
- [x] Auto-refresh every 30s

## Test plan
- [x] `node --check server/routes.js`
- [x] `tsc --noEmit` clean
- [ ] Reviewers: open dashboard, confirm panel shows the active batch with bars; verify cache (refresh within 10s returns fast); verify completion banner after all items merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)