### PR TITLE
[#297] Project history import: agent-name denylist + duplicate detection

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -341,6 +341,24 @@ const PROJECT_HISTORY_VERSION = 1;
 const PROJECT_HISTORY_MAX_BYTES = 10 * 1024 * 1024; // 10 MB cap per issue
 const PROJECT_HISTORY_REPLAY_DELAY_MS = 25; // pace AC ws inserts
 
+// #414 / quadwork#297: reject imports whose messages claim a
+// reserved agent / system sender by default. This closes the only
+// path in QuadWork that lets a client-supplied sender reach AC
+// (every other route hardcodes / sanitizes to operator). Mirrors
+// the RESERVED_OPERATOR_NAMES denylist from sanitizeOperatorName so
+// the same identities are blocked across the codebase.
+const RESERVED_HISTORY_SENDERS = new Set([
+  "head",
+  "dev",
+  "reviewer1",
+  "reviewer2",
+  "t1",
+  "t2a",
+  "t2b",
+  "t3",
+  "system",
+]);
+
 router.get("/api/project-history", async (req, res) => {
   const projectId = req.query.project;
   if (!projectId) return res.status(400).json({ error: "Missing project" });
@@ -417,6 +435,45 @@ router.post("/api/project-history", async (req, res) => {
     });
   }
 
+  // #414 / quadwork#297 — Issue 1: agent/system sender denylist.
+  // Pre-scan the messages array; if any line claims a reserved
+  // identity, reject the entire import unless the operator opted
+  // in via allow_agent_senders=true. Default-safe so a leaked or
+  // crafted export file can't post as Head from the dashboard.
+  if (!body.allow_agent_senders) {
+    const offenders = new Set();
+    for (const m of body.messages) {
+      if (m && typeof m === "object" && typeof m.sender === "string") {
+        if (RESERVED_HISTORY_SENDERS.has(m.sender.toLowerCase())) {
+          offenders.add(m.sender);
+          if (offenders.size >= 5) break;
+        }
+      }
+    }
+    if (offenders.size > 0) {
+      return res.status(400).json({
+        error: `Import contains messages attributed to reserved agent/system identities: ${[...offenders].join(", ")}. Resend with allow_agent_senders=true to override (e.g. legitimate disaster-recovery restore).`,
+      });
+    }
+  }
+
+  // #414 / quadwork#297 — Issue 2: duplicate import detection.
+  // Persist the most recent imported `exported_at` on the project
+  // entry in config.json. If the file's marker matches, refuse the
+  // import unless allow_duplicate=true. Re-importing the same file
+  // would otherwise replay every message a second time and double
+  // the chat history.
+  const cfg = readConfigFile();
+  const project = cfg.projects?.find((p) => p.id === projectId);
+  const incomingExportedAt = typeof body.exported_at === "string" ? body.exported_at : null;
+  if (!body.allow_duplicate && project && incomingExportedAt) {
+    if (project.history_last_imported_at === incomingExportedAt) {
+      return res.status(409).json({
+        error: `This export was already imported (exported_at=${incomingExportedAt}). Resend with allow_duplicate=true to import again.`,
+      });
+    }
+  }
+
   const { url: base, token: sessionToken } = getChattrConfig(projectId);
   if (!base) return res.status(400).json({ error: "No AgentChattr configured for project" });
 
@@ -462,6 +519,16 @@ router.post("/api/project-history", async (req, res) => {
       await new Promise((r) => setTimeout(r, PROJECT_HISTORY_REPLAY_DELAY_MS));
     }
   }
+  // #414 / quadwork#297 — Issue 2: stamp the import marker on the
+  // project so a re-import of the same file is caught next time.
+  // Only update on a successful (no errors) replay so a half-broken
+  // import can be retried without the duplicate guard tripping.
+  if (incomingExportedAt && errors.length === 0 && project) {
+    project.history_last_imported_at = incomingExportedAt;
+    try { writeConfigFile(cfg); }
+    catch (err) { console.warn(`[history] failed to persist history_last_imported_at: ${err.message || err}`); }
+  }
+
   res.json({ ok: errors.length === 0, imported, skipped, total: body.messages.length, errors });
 });
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -429,7 +429,7 @@ router.post("/api/project-history", async (req, res) => {
   // before POSTing when the IDs differ; if it didn't (e.g. curl),
   // require an explicit override flag so we can't silently merge
   // foreign chat into the wrong project.
-  if (body.project_id && body.project_id !== projectId && !body.allow_project_mismatch) {
+  if (body.project_id && body.project_id !== projectId && body.allow_project_mismatch !== true) {
     return res.status(409).json({
       error: `Project mismatch: file is from '${body.project_id}', target is '${projectId}'. Resend with allow_project_mismatch=true to override.`,
     });
@@ -440,7 +440,7 @@ router.post("/api/project-history", async (req, res) => {
   // identity, reject the entire import unless the operator opted
   // in via allow_agent_senders=true. Default-safe so a leaked or
   // crafted export file can't post as Head from the dashboard.
-  if (!body.allow_agent_senders) {
+  if (body.allow_agent_senders !== true) {
     const offenders = new Set();
     for (const m of body.messages) {
       if (m && typeof m === "object" && typeof m.sender === "string") {
@@ -466,7 +466,7 @@ router.post("/api/project-history", async (req, res) => {
   const cfg = readConfigFile();
   const project = cfg.projects?.find((p) => p.id === projectId);
   const incomingExportedAt = typeof body.exported_at === "string" ? body.exported_at : null;
-  if (!body.allow_duplicate && project && incomingExportedAt) {
+  if (body.allow_duplicate !== true && project && incomingExportedAt) {
     if (project.history_last_imported_at === incomingExportedAt) {
       return res.status(409).json({
         error: `This export was already imported (exported_at=${incomingExportedAt}). Resend with allow_duplicate=true to import again.`,

--- a/src/components/ProjectHistoryWidget.tsx
+++ b/src/components/ProjectHistoryWidget.tsx
@@ -101,13 +101,63 @@ export default function ProjectHistoryWidget({ projectId }: ProjectHistoryWidget
       }
       allowMismatch = true;
     }
-    try {
-      const r = await fetch(`/api/project-history?project=${encodeURIComponent(projectId)}`, {
+    // #414 / quadwork#297: pre-scan for reserved agent senders so
+    // we can prompt once instead of after a server 400. The same
+    // RESERVED set lives in server/routes.js — keep them in sync.
+    const RESERVED_SENDERS = new Set(["head", "dev", "reviewer1", "reviewer2", "t1", "t2a", "t2b", "t3", "system"]);
+    let allowAgentSenders = false;
+    const offenders = new Set<string>();
+    for (const m of parsed.messages) {
+      if (m && typeof m === "object") {
+        const sender = (m as { sender?: unknown }).sender;
+        if (typeof sender === "string" && RESERVED_SENDERS.has(sender.toLowerCase())) {
+          offenders.add(sender);
+          if (offenders.size >= 5) break;
+        }
+      }
+    }
+    if (offenders.size > 0) {
+      const ok = window.confirm(
+        `This export contains messages attributed to reserved agent/system identities (${[...offenders].join(", ")}). Importing will replay them as those agents — only do this for a legitimate disaster-recovery restore. Continue?`,
+      );
+      if (!ok) {
+        setBusy(null);
+        return;
+      }
+      allowAgentSenders = true;
+    }
+    // Server-side duplicate detection sends a 409 the first time;
+    // we forward allow_duplicate after asking the operator. We can't
+    // pre-check this client-side since we don't store the marker
+    // here — let the server tell us, then re-POST with the flag.
+    let allowDuplicate = false;
+    const post = (extra: Record<string, unknown>) =>
+      fetch(`/api/project-history?project=${encodeURIComponent(projectId)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...parsed, allow_project_mismatch: allowMismatch }),
+        body: JSON.stringify({
+          ...parsed,
+          allow_project_mismatch: allowMismatch,
+          allow_agent_senders: allowAgentSenders,
+          allow_duplicate: allowDuplicate,
+          ...extra,
+        }),
       });
-      const data = await r.json().catch(() => null);
+    try {
+      let r = await post({});
+      let data = await r.json().catch(() => null);
+      if (r.status === 409 && data && typeof data.error === "string" && /already imported/i.test(data.error)) {
+        const ok = window.confirm(
+          `${data.error}\n\nThis file looks like it was already imported. Re-import will duplicate every message. Continue anyway?`,
+        );
+        if (!ok) {
+          setBusy(null);
+          return;
+        }
+        allowDuplicate = true;
+        r = await post({ allow_duplicate: true });
+        data = await r.json().catch(() => null);
+      }
       if (!r.ok) {
         throw new Error((data && data.error) || `HTTP ${r.status}`);
       }


### PR DESCRIPTION
Fixes #297
Tracker: realproject7/agent-os#414
Follow-up: quadwork#279, PR #295

## Summary
Two hardening fixes to the project history import handler.

**Issue 1 — sender lockdown bypass.** The import route preserved `m.sender` for attribution but that was the only path in QuadWork letting a client-supplied sender reach AC, so a crafted file could post as `head`. New `RESERVED_HISTORY_SENDERS` set (mirrors `sanitizeOperatorName`'s denylist) is pre-scanned across the messages array; default 400 with up to 5 offenders listed. `allow_agent_senders=true` opts in.

**Issue 2 — duplicate detection.** New `project.history_last_imported_at` marker stamped on zero-error imports. Re-importing the same `exported_at` returns 409 with a clear message. `allow_duplicate=true` opts in.

`ProjectHistoryWidget` pre-scans for reserved senders client-side (avoids round-trip 400), and on a server 409 prompts the operator and re-POSTs with `allow_duplicate=true`. Both flags flow through a shared `post()` helper.

## Acceptance criteria
- [x] Importing a file with `sender: "head"` returns 400 by default
- [x] `allow_agent_senders: true` flag bypasses the agent-name check
- [x] Re-importing the same file returns 409 by default
- [x] `allow_duplicate: true` flag bypasses the duplicate check
- [x] UI shows confirmation dialog for both bypass flags before sending
- [x] Default behavior is safe (no impersonation, no double-import)

## Test plan
- [x] `node --check server/routes.js`
- [x] `tsc --noEmit` clean
- [ ] Reviewers: import a file with `sender:"head"`, confirm 400 / dialog; import a clean file twice, confirm 409 on the second / dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)