### PR TITLE
[#298] Loop guard migration: handle partial [routing] section

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1515,8 +1515,17 @@ function migrateLoopGuardDefaults(config) {
     if (!fs.existsSync(tomlPath)) continue;
     let content;
     try { content = fs.readFileSync(tomlPath, "utf-8"); } catch { continue; }
-    // Case 1: key already present anywhere in the file. Idempotent.
-    if (/^\s*max_agent_hops\s*=/m.test(content)) continue;
+    // Case 1: key already present *inside* the [routing] section.
+    // We must NOT short-circuit on a same-named key in some other
+    // table (e.g. `[other]\nmax_agent_hops = 7`) because that would
+    // leave a real partial [routing] section unpatched. Slice the
+    // file to just the [routing] body before the next [section]
+    // header (or EOF) and look there.
+    const routingBody = (() => {
+      const m = content.match(/^\s*\[routing\][ \t]*\r?\n([\s\S]*?)(?=^\s*\[|\z)/m);
+      return m ? m[1] : null;
+    })();
+    if (routingBody !== null && /^\s*max_agent_hops\s*=/m.test(routingBody)) continue;
     let next;
     if (/^\s*\[routing\]/m.test(content)) {
       // Case 2: section exists, key missing. Insert the key on the

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1546,9 +1546,12 @@ function migrateLoopGuardDefaults(config) {
       // line right after the [routing] header so it's scoped to the
       // section regardless of what other keys / comments live there.
       // Anchored to ^ so a `[routing]` substring inside a string
-      // value can't false-match.
+      // value can't false-match. The header line is allowed to have
+      // a trailing inline comment ("[routing] # keep me") so the
+      // insert still lands when the operator has annotated the
+      // section.
       next = content.replace(
-        /^(\s*\[routing\][ \t]*\r?\n)/m,
+        /^(\s*\[routing\][^\r\n]*\r?\n)/m,
         `$1max_agent_hops = 30\n`,
       );
     } else {

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1546,13 +1546,19 @@ function migrateLoopGuardDefaults(config) {
       // line right after the [routing] header so it's scoped to the
       // section regardless of what other keys / comments live there.
       // Anchored to ^ so a `[routing]` substring inside a string
-      // value can't false-match. The header line is allowed to have
-      // a trailing inline comment ("[routing] # keep me") so the
-      // insert still lands when the operator has annotated the
-      // section.
+      // value can't false-match. The header line is allowed to:
+      //   - have a trailing inline comment (`[routing] # keep me`)
+      //   - end the file with no trailing newline at all
+      // The line-break group is captured separately and re-emitted,
+      // synthesizing a `\n` if the file ended exactly at the header
+      // (otherwise the new key would land glued to whatever the
+      // bracket was sitting on).
       next = content.replace(
-        /^(\s*\[routing\][^\r\n]*\r?\n)/m,
-        `$1max_agent_hops = 30\n`,
+        /^(\s*\[routing\][^\r\n]*)(\r?\n|$)/m,
+        (_match, header, lineBreak) => {
+          const lb = lineBreak || "\n";
+          return `${header}${lb}max_agent_hops = 30\n`;
+        },
       );
     } else {
       // Case 3: no section. Append a fresh one at the end of the

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1518,14 +1518,28 @@ function migrateLoopGuardDefaults(config) {
     // Case 1: key already present *inside* the [routing] section.
     // We must NOT short-circuit on a same-named key in some other
     // table (e.g. `[other]\nmax_agent_hops = 7`) because that would
-    // leave a real partial [routing] section unpatched. Slice the
-    // file to just the [routing] body before the next [section]
-    // header (or EOF) and look there.
-    const routingBody = (() => {
-      const m = content.match(/^\s*\[routing\][ \t]*\r?\n([\s\S]*?)(?=^\s*\[|\z)/m);
-      return m ? m[1] : null;
-    })();
-    if (routingBody !== null && /^\s*max_agent_hops\s*=/m.test(routingBody)) continue;
+    // leave a real partial [routing] section unpatched. Walk the
+    // file line-by-line, find the [routing] header, and collect
+    // lines until the next [section] header or EOF. JS regex has
+    // no \z anchor and no reliable EOF lookahead inside /m, so a
+    // line scan is the simplest correct approach and also keeps
+    // pathological strings ("default = \"lazy\"") from confusing
+    // anything in the matcher.
+    const lines = content.split(/\r?\n/);
+    let inRouting = false;
+    let routingKeyPresent = false;
+    for (const line of lines) {
+      const headerMatch = line.match(/^\s*\[([^\]]+)\]/);
+      if (headerMatch) {
+        inRouting = headerMatch[1].trim() === "routing";
+        continue;
+      }
+      if (inRouting && /^\s*max_agent_hops\s*=/.test(line)) {
+        routingKeyPresent = true;
+        break;
+      }
+    }
+    if (routingKeyPresent) continue;
     let next;
     if (/^\s*\[routing\]/m.test(content)) {
       // Case 2: section exists, key missing. Insert the key on the

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1489,14 +1489,21 @@ function migrateLegacyProjects(config) {
 }
 
 /**
- * #403 / quadwork#274 migration: append `[routing] max_agent_hops = 30`
- * to any per-project config.toml that's missing it. Idempotent and
- * conservative — leaves files that already have a `max_agent_hops`
- * key alone (whatever value the operator picked stays put), and
- * leaves files that have a [routing] section but no max_agent_hops
- * key alone too rather than risk patching a section we don't fully
- * understand. The web/CLI templates write the key on first run, so
- * this only catches projects created before #403.
+ * #403 / quadwork#274 migration: ensure every per-project config.toml
+ * has `[routing] max_agent_hops = 30`. Idempotent + line-based so
+ * existing comments and other keys in the [routing] section are
+ * preserved.
+ *
+ * #415 / quadwork#298: previous version skipped projects that had
+ * a [routing] section but no max_agent_hops key (e.g. only
+ * `default = "none"`). Those projects silently retained AC's
+ * default of 4 and kept firing the loop guard mid-cycle. This
+ * version handles three cases:
+ *
+ *   1. max_agent_hops already set     → no change
+ *   2. [routing] section exists,
+ *      max_agent_hops missing         → insert key under the header
+ *   3. no [routing] section at all    → append a fresh section
  */
 function migrateLoopGuardDefaults(config) {
   if (!config.projects || config.projects.length === 0) return;
@@ -1508,12 +1515,28 @@ function migrateLoopGuardDefaults(config) {
     if (!fs.existsSync(tomlPath)) continue;
     let content;
     try { content = fs.readFileSync(tomlPath, "utf-8"); } catch { continue; }
+    // Case 1: key already present anywhere in the file. Idempotent.
     if (/^\s*max_agent_hops\s*=/m.test(content)) continue;
-    if (/^\s*\[routing\]/m.test(content)) continue;
-    const trailing = content.endsWith("\n") ? "" : "\n";
-    const addition = `${trailing}\n[routing]\ndefault = "none"\nmax_agent_hops = 30\n`;
+    let next;
+    if (/^\s*\[routing\]/m.test(content)) {
+      // Case 2: section exists, key missing. Insert the key on the
+      // line right after the [routing] header so it's scoped to the
+      // section regardless of what other keys / comments live there.
+      // Anchored to ^ so a `[routing]` substring inside a string
+      // value can't false-match.
+      next = content.replace(
+        /^(\s*\[routing\][ \t]*\r?\n)/m,
+        `$1max_agent_hops = 30\n`,
+      );
+    } else {
+      // Case 3: no section. Append a fresh one at the end of the
+      // file with both default + max_agent_hops.
+      const trailing = content.endsWith("\n") ? "" : "\n";
+      next = content + `${trailing}\n[routing]\ndefault = "none"\nmax_agent_hops = 30\n`;
+    }
+    if (next === content) continue;
     try {
-      fs.writeFileSync(tomlPath, content + addition);
+      fs.writeFileSync(tomlPath, next);
       log(`  Loop guard default → ${project.id} (max_agent_hops = 30)`);
     } catch { /* non-fatal */ }
   }


### PR DESCRIPTION
Fixes #298
Tracker: realproject7/agent-os#415
Follow-up: quadwork#274, PR #286

## Summary
`migrateLoopGuardDefaults` previously skipped projects with a `[routing]` section that lacked `max_agent_hops` (e.g. only `default = "none"`). Those projects silently kept AC's default of 4. Now handles three cases idempotently with line-based edits:

1. `max_agent_hops` already set → no change
2. `[routing]` exists, key missing → insert key on the line after the header
3. No `[routing]` section → append fresh section

The case-2 insertion uses an anchored `^` regex on the header so a `[routing]` substring inside a string value can't false-match.

## Acceptance criteria
- [x] Project with no `[routing]` section → gets full section appended
- [x] Project with partial `[routing]` section → gets the key inserted into the existing section
- [x] Project with `max_agent_hops` already set → no change (idempotent)
- [x] Migration runs on `cmdStart` (existing call site untouched)
- [x] Comments preserved (line-based insert, not parse + serialize)

## Test plan
- [x] `node --check bin/quadwork.js`
- [x] Verified all three transitions against synthetic config.toml fixtures (smoke script)
- [ ] Reviewers: run `quadwork start` against a project with each of the three states, confirm the file mutates as expected and re-running is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)