### PR TITLE
[#306] Scheduled Trigger: wait for first interval

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1086,7 +1086,12 @@ function stopTrigger(project) {
 
 app.post("/api/triggers/:project/start", (req, res) => {
   const { project } = req.params;
-  const { interval, duration, message, sendImmediately } = req.body || {};
+  // #418 / quadwork#306: sendImmediately was an always-true
+  // "Send Message and Start Trigger" flag from #210; operators
+  // asked for a pure scheduler ("Start Trigger" — wait for the
+  // first interval). The field is ignored here; the send-now
+  // endpoint below still exists for the explicit one-shot path.
+  const { interval, duration, message } = req.body || {};
   const ms = (interval || 30) * 60 * 1000;
   const durationMs = duration ? duration * 60 * 1000 : 0; // duration in minutes, 0 = indefinite
 
@@ -1113,16 +1118,12 @@ app.post("/api/triggers/:project/start", (req, res) => {
     if (existing.durationTimer) clearTimeout(existing.durationTimer);
   }
 
-  // #210: the Scheduled Trigger widget's "Send Message and Start
-  // Trigger" button expects an immediate send, not the first fire
-  // one interval in the future. setInterval won't do that on its
-  // own, so trigger a one-shot send when sendImmediately is true.
-  if (sendImmediately) {
-    // Don't await — keep the response fast. sendTriggerMessage logs
-    // its own errors and updates lastError on the trigger info.
-    sendTriggerMessage(project).catch(() => {});
-  }
-
+  // #418 / quadwork#306: no immediate fire — the first send happens
+  // at T + interval via the setInterval below. Operators set the
+  // trigger up in advance of going afk and don't want it interrupting
+  // whatever agents are currently mid-task. The explicit "send now"
+  // path still lives at /api/triggers/:project/send-now for the
+  // rare case an operator actually wants to kick things off.
   const timer = setInterval(() => sendTriggerMessage(project), ms);
   const expiresAt = durationMs > 0 ? Date.now() + durationMs : null;
 

--- a/src/components/ScheduledTriggerWidget.tsx
+++ b/src/components/ScheduledTriggerWidget.tsx
@@ -64,11 +64,12 @@ function formatCountdown(ms: number): string {
  * Bottom-right operator widget for the Scheduled Trigger (#210).
  *
  * Combines the old Keep Alive timer with a custom message textarea.
- * "Start Trigger" sends the typed message via the
- * existing /api/triggers/:id/start endpoint (which persists the
- * message on the project entry and immediately fires once), then
- * the backend's setInterval keeps firing at the configured cadence
- * until the duration expires or Stop is pressed.
+ * "Start Trigger" hands the typed message to
+ * /api/triggers/:id/start which persists it on the project entry
+ * and schedules a setInterval at the configured cadence. The first
+ * message fires at T + interval (not on click — see #418/#306) and
+ * the interval keeps firing until duration expires or Stop is
+ * pressed.
  *
  * State is sourced from GET /api/triggers every 5s so reopening the
  * project picks up the last-used message + running status.

--- a/src/components/ScheduledTriggerWidget.tsx
+++ b/src/components/ScheduledTriggerWidget.tsx
@@ -64,7 +64,7 @@ function formatCountdown(ms: number): string {
  * Bottom-right operator widget for the Scheduled Trigger (#210).
  *
  * Combines the old Keep Alive timer with a custom message textarea.
- * "Send Message and Start Trigger" sends the typed message via the
+ * "Start Trigger" sends the typed message via the
  * existing /api/triggers/:id/start endpoint (which persists the
  * message on the project entry and immediately fires once), then
  * the backend's setInterval keeps firing at the configured cadence
@@ -189,7 +189,7 @@ export default function ScheduledTriggerWidget({ projectId }: ScheduledTriggerWi
       const r = await fetch(`/api/triggers/${encodeURIComponent(projectId)}/start`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ interval: intervalMin, duration: resolvedDurationMin, message, sendImmediately: true }),
+        body: JSON.stringify({ interval: intervalMin, duration: resolvedDurationMin, message }),
       });
       if (!r.ok) throw new Error(`${r.status}`);
       // After the backend persists the new values, treat them as the
@@ -287,7 +287,7 @@ export default function ScheduledTriggerWidget({ projectId }: ScheduledTriggerWi
             disabled={busy || !message.trim()}
             className="self-start px-3 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            {busy ? "Starting…" : "Send Message and Start Trigger"}
+            {busy ? "Starting…" : "Start Trigger"}
           </button>
         </div>
       ) : (


### PR DESCRIPTION
Fixes #306
Tracker: realproject7/agent-os#418
Master: #317 (Batch 32 Phase 1)

## Summary
- `server/index.js` /api/triggers/:project/start drops the `sendImmediately` one-shot branch. `setInterval` already schedules the first send at T + interval — no change needed beyond the removal.
- `src/components/ScheduledTriggerWidget.tsx` button text `"Send Message and Start Trigger"` → `"Start Trigger"`, body no longer sends `sendImmediately: true`, doc comment updated.
- The explicit one-shot path `/api/triggers/:project/send-now` is untouched — still available for the rare case an operator wants to kick things off manually.

## Acceptance criteria
- [x] Start does NOT send immediately
- [x] First message arrives at T + interval (setInterval contract)
- [x] Subsequent messages unchanged
- [x] Auto-stop / Stop button unchanged
- [x] Button label updated
- [x] Helper / doc text updated

## Test plan
- [x] `node --check server/index.js`
- [x] `tsc --noEmit` clean
- [ ] Reviewers: set interval to 1 min, click Start, confirm no message at T0 and a message at T+60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)