### PR TITLE
[#307] Home Recent Activity: widen actor column + RE1/RE2 labels

### DIFF
--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -158,8 +158,13 @@ export default function HomeDashboard() {
               <span className="text-accent shrink-0 font-semibold w-12">
                 {item.projectName}
               </span>
-              <span className="text-[#ffcc00] shrink-0 font-semibold w-6">
-                {item.actor}
+              <span className="text-[#ffcc00] shrink-0 font-semibold w-12">
+                {/* #420 / quadwork#307: widen column + mirror the
+                    RE1/RE2 short labels PR #272 (#263) already uses
+                    in the chat sender column. w-6 was 24px and
+                    overflowed reviewer1/reviewer2 into the adjacent
+                    message text column. */}
+                {item.actor === "reviewer1" ? "RE1" : item.actor === "reviewer2" ? "RE2" : item.actor}
               </span>
               <span className="text-text truncate min-w-0">
                 {item.text}


### PR DESCRIPTION
Fixes #307
Tracker: realproject7/agent-os#420
Master: #317 (Batch 32 Phase 1)

## Summary
`HomeDashboard` bound the actor column to `w-6` (24px), which fit ~4 chars and overflowed `reviewer1` / `reviewer2` into the adjacent message text column. Bump to `w-12` (48px) and inline the same `reviewer1 → RE1` / `reviewer2 → RE2` map PR #272 / #263 already uses in the chat sender column, so both surfaces stay consistent without a cross-file helper import.

## Acceptance criteria
- [x] `reviewer1` / `reviewer2` no longer overflow
- [x] RE1 / RE2 short labels consistent with chat panel
- [x] Row alignment preserved (time / project / actor / text)
- [x] No message truncation (`w-12` widens but still `shrink-0` so the text column still gets the remainder)

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Reviewers: visit home, confirm reviewer1/2 rows show RE1/RE2 and don't overlap the text column

🤖 Generated with [Claude Code](https://claude.com/claude-code)