### PR TITLE
[#305] Activity indicator: color + shimmer active agent label

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,3 +75,17 @@ h1, h2, h3, h4, h5, h6 {
 .animate-qw-blink {
   animation: qw-blink 1s steps(2, start) infinite;
 }
+
+/* #421 / quadwork#305: activity-indicator text shimmer.
+   Color-only (no text-shadow, no background, no filter) so the
+   shimmer matches the "minimal aesthetic" constraint in the
+   ticket. Pulses between the accent green and a desaturated
+   mid-point so the active agent label stands out against the
+   muted sibling labels without being garish. */
+@keyframes qw-name-shimmer {
+  0%, 100% { color: var(--accent); }
+  50% { color: color-mix(in srgb, var(--accent) 55%, #e0e0e0); }
+}
+.animate-name-shimmer {
+  animation: qw-name-shimmer 1.6s ease-in-out infinite;
+}

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -5,7 +5,11 @@ import TerminalPanel from "./TerminalPanel";
 
 // #399 / quadwork#264: how long an agent stays "active" after its
 // last PTY output before the activity ring stops pulsing.
-const ACTIVITY_WINDOW_MS = 2000;
+// #421 / quadwork#305: bumped from 2000 → 5000ms. 2s felt like a
+// flicker on bursty PTY output; 5s keeps the indicator steady for
+// the duration of a typical agent working burst while still going
+// idle shortly after the agent stops producing output.
+const ACTIVITY_WINDOW_MS = 5000;
 
 interface Agent {
   id: string;
@@ -115,7 +119,18 @@ export default function TerminalGrid({
                       : "bg-text-muted"
                   }`} />
                 </span>
-                <span className="text-[11px] text-text-muted uppercase tracking-wider">
+                {/* #421 / quadwork#305: active agent's label goes
+                    accent + shimmers so the operator has a bigger
+                    visual cue than the tiny dot ring. Color-only
+                    keyframe (no shadow / background / blur) per
+                    the ticket's "minimal aesthetic" constraint. */}
+                <span
+                  className={`text-[11px] uppercase tracking-wider ${
+                    agentStates[agent.id] === "running" && isActive(agent.id)
+                      ? "text-accent animate-name-shimmer"
+                      : "text-text-muted"
+                  }`}
+                >
                   {agent.label}
                 </span>
               </div>


### PR DESCRIPTION
Fixes #305
Tracker: realproject7/agent-os#421
Master: #317 (Batch 32 Phase 1)

## Summary
- `globals.css` gains a color-only `@keyframes qw-name-shimmer` that pulses between `--accent` and a desaturated mid-point via `color-mix()`. No text-shadow, filter, or background — matches the ticket's "minimal aesthetic" constraint. Exposed as `.animate-name-shimmer`.
- `TerminalGrid` per-tile label now toggles between `text-text-muted` (idle) and `text-accent animate-name-shimmer` (running + recent PTY output, via the existing `isActive` ref).
- `ACTIVITY_WINDOW_MS` bumped 2000 → 5000 so the indicator is steady through a typical work burst instead of flickering on and off.
- Dot ring path untouched (still fires on the same `isActive` check).

## Acceptance criteria
- [x] Active agent name colors accent and shimmers
- [x] Color-only keyframe (no shadow / blur / background)
- [x] Idle label returns to muted text color
- [x] Activity window now 5s
- [x] Dot ring unchanged
- [x] Works for all 4 agents (per-tile label path is shared)

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Reviewers: open dashboard, watch an agent produce output, confirm label turns green and shimmers; idle timeout returns it to muted

🤖 Generated with [Claude Code](https://claude.com/claude-code)