### PR TITLE
[#310] Loop guard auto-continue (opt-in per project)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1391,6 +1391,94 @@ function syncTriggersFromConfig() {
   }
 }
 
+// #422 / quadwork#310: auto-continue after loop guard.
+//
+// Per opted-in project, poll AC's /api/status every 10s. When we see
+// a false → true transition on `paused`, wait the configured delay
+// (default 30s) and POST /continue to /api/chat — same path the
+// operator would use manually. The delay gives a human a chance to
+// intervene on an actually-runaway loop, and acts as a soft rate
+// limit against pathological loops that would otherwise just loop
+// forever under an auto-continue.
+//
+// Detection is deliberately polling rather than a long-lived ws:
+// a ws subscription per project would complicate lifecycle and
+// reconnection, and 10s polling latency is acceptable when the
+// delay is tens of seconds. Skipping projects without the opt-in
+// keeps the poller cheap for single-project setups.
+
+const _loopGuardPausedState = new Map(); // projectId -> { paused: bool, scheduled: Timeout? }
+const LOOP_GUARD_POLL_INTERVAL_MS = 10000;
+
+async function checkLoopGuardPause(project) {
+  if (!project || !project.auto_continue_loop_guard) return;
+  const { url: base, token: sessionToken } = resolveProjectChattr(project.id);
+  if (!base) return;
+  let paused = false;
+  try {
+    const r = await fetch(`${base}/api/status`, {
+      headers: sessionToken ? { "x-session-token": sessionToken } : {},
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!r.ok) return;
+    const data = await r.json();
+    paused = !!(data && data.paused);
+  } catch {
+    return;
+  }
+  const state = _loopGuardPausedState.get(project.id) || { paused: false, scheduled: null };
+  // Transition false → true: schedule an auto-continue after the delay.
+  if (paused && !state.paused && !state.scheduled) {
+    const delaySec = Number.isFinite(project.auto_continue_delay_sec) && project.auto_continue_delay_sec >= 5
+      ? project.auto_continue_delay_sec
+      : 30;
+    console.log(`[loop-guard] ${project.id} paused — auto-continue in ${delaySec}s`);
+    state.scheduled = setTimeout(async () => {
+      try {
+        // Re-check the opt-in at fire time so a checkbox disable
+        // mid-wait actually stops the auto-continue.
+        const freshCfg = readConfig();
+        const fresh = freshCfg.projects?.find((p) => p.id === project.id);
+        if (!fresh || !fresh.auto_continue_loop_guard) {
+          console.log(`[loop-guard] ${project.id} auto-continue cancelled (opt-in disabled during wait)`);
+        } else {
+          const res = await fetch(`http://127.0.0.1:${PORT}/api/chat?project=${encodeURIComponent(project.id)}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ text: "/continue", channel: "general" }),
+          });
+          if (res.ok) console.log(`[loop-guard] ${project.id} auto-continued`);
+          else console.warn(`[loop-guard] ${project.id} auto-continue POST returned ${res.status}`);
+        }
+      } catch (err) {
+        console.warn(`[loop-guard] ${project.id} auto-continue failed: ${err.message || err}`);
+      }
+      const s2 = _loopGuardPausedState.get(project.id);
+      if (s2) s2.scheduled = null;
+    }, delaySec * 1000);
+  }
+  // Transition true → false: clear any pending timer.
+  if (!paused && state.paused && state.scheduled) {
+    clearTimeout(state.scheduled);
+    state.scheduled = null;
+  }
+  state.paused = paused;
+  _loopGuardPausedState.set(project.id, state);
+}
+
+function runLoopGuardPollingTick() {
+  try {
+    const cfg = readConfig();
+    for (const p of (cfg.projects || [])) {
+      if (p && p.auto_continue_loop_guard) checkLoopGuardPause(p);
+    }
+  } catch {
+    // config unreadable — next tick will retry
+  }
+}
+
+setInterval(runLoopGuardPollingTick, LOOP_GUARD_POLL_INTERVAL_MS);
+
 // --- Start ---
 
 server.listen(PORT, "127.0.0.1", () => {

--- a/server/index.js
+++ b/server/index.js
@@ -1442,13 +1442,42 @@ async function checkLoopGuardPause(project) {
         if (!fresh || !fresh.auto_continue_loop_guard) {
           console.log(`[loop-guard] ${project.id} auto-continue cancelled (opt-in disabled during wait)`);
         } else {
-          const res = await fetch(`http://127.0.0.1:${PORT}/api/chat?project=${encodeURIComponent(project.id)}`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ text: "/continue", channel: "general" }),
-          });
-          if (res.ok) console.log(`[loop-guard] ${project.id} auto-continued`);
-          else console.warn(`[loop-guard] ${project.id} auto-continue POST returned ${res.status}`);
+          // Re-check the router's pause state at fire time too. The
+          // 10s status poller may not have seen a manual operator
+          // /continue yet when the delay window (5–9s) is shorter
+          // than the poll interval — without this, a manual resume
+          // inside a 5s wait would be followed by a stale auto
+          // /continue that clobbers hop_count on an already-running
+          // chain (router.continue_routing resets the counter
+          // unconditionally). The re-check closes the race.
+          let stillPaused = false;
+          try {
+            const { url: freshBase, token: freshToken } = resolveProjectChattr(project.id);
+            if (freshBase) {
+              const sr = await fetch(`${freshBase}/api/status`, {
+                headers: freshToken ? { "x-session-token": freshToken } : {},
+                signal: AbortSignal.timeout(5000),
+              });
+              if (sr.ok) {
+                const sd = await sr.json();
+                stillPaused = !!(sd && sd.paused);
+              }
+            }
+          } catch {
+            // Status re-check failed — fall back to "don't fire".
+            // Stuck pause will still be caught on the next 10s tick.
+          }
+          if (!stillPaused) {
+            console.log(`[loop-guard] ${project.id} auto-continue cancelled (router already resumed)`);
+          } else {
+            const res = await fetch(`http://127.0.0.1:${PORT}/api/chat?project=${encodeURIComponent(project.id)}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ text: "/continue", channel: "general" }),
+            });
+            if (res.ok) console.log(`[loop-guard] ${project.id} auto-continued`);
+            else console.warn(`[loop-guard] ${project.id} auto-continue POST returned ${res.status}`);
+          }
         }
       } catch (err) {
         console.warn(`[loop-guard] ${project.id} auto-continue failed: ${err.message || err}`);

--- a/src/components/LoopGuardWidget.tsx
+++ b/src/components/LoopGuardWidget.tsx
@@ -23,6 +23,14 @@ export default function LoopGuardWidget({ projectId }: LoopGuardWidgetProps) {
   const [error, setError] = useState<string | null>(null);
   const [live, setLive] = useState<boolean | null>(null);
   const [showHelp, setShowHelp] = useState(false);
+  // #422 / quadwork#310: per-project auto-continue opt-in. Default
+  // OFF — operators opt in knowing the trade-off (runaway loops
+  // will silently resume after the delay). Hydrated from /api/config
+  // on mount; saving flips the field and PUTs the whole config back.
+  const [autoContinue, setAutoContinue] = useState<boolean>(false);
+  const [autoContinueDelaySec, setAutoContinueDelaySec] = useState<number>(30);
+  const [autoContinueDelayDraft, setAutoContinueDelayDraft] = useState<string>("30");
+  const [autoContinueSaving, setAutoContinueSaving] = useState(false);
 
   // Load on mount + when project changes.
   useEffect(() => {
@@ -35,7 +43,53 @@ export default function LoopGuardWidget({ projectId }: LoopGuardWidgetProps) {
         }
       })
       .catch(() => {});
+    // #422 / quadwork#310: read auto-continue prefs from the whole
+    // config (they live on the project entry, not the loop-guard
+    // endpoint). Scoped to the current projectId.
+    fetch(`/api/config`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (!cfg || !Array.isArray(cfg.projects)) return;
+        const proj = cfg.projects.find((p: { id: string }) => p.id === projectId);
+        if (!proj) return;
+        setAutoContinue(!!proj.auto_continue_loop_guard);
+        const d = Number.isFinite(proj.auto_continue_delay_sec) ? proj.auto_continue_delay_sec : 30;
+        setAutoContinueDelaySec(d);
+        setAutoContinueDelayDraft(String(d));
+      })
+      .catch(() => {});
   }, [projectId]);
+
+  // Persist auto-continue prefs by fetching current config, mutating
+  // the target project's two fields, and PUT'ing back. We keep the
+  // whole-config PUT contract the SettingsPage uses so we don't
+  // have to add a new endpoint for two flags. Failures leave the
+  // in-memory checkbox out of sync with disk, which the next mount
+  // will correct.
+  const saveAutoContinue = async (nextEnabled: boolean, nextDelay: number) => {
+    setAutoContinueSaving(true);
+    try {
+      const cfgRes = await fetch(`/api/config`);
+      if (!cfgRes.ok) throw new Error(`GET /api/config ${cfgRes.status}`);
+      const cfg = await cfgRes.json();
+      if (!cfg || !Array.isArray(cfg.projects)) throw new Error("config shape");
+      const idx = cfg.projects.findIndex((p: { id: string }) => p.id === projectId);
+      if (idx < 0) throw new Error(`project ${projectId} not found`);
+      cfg.projects[idx] = {
+        ...cfg.projects[idx],
+        auto_continue_loop_guard: nextEnabled,
+        auto_continue_delay_sec: nextDelay,
+      };
+      const putRes = await fetch(`/api/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(cfg),
+      });
+      if (!putRes.ok) throw new Error(`PUT /api/config ${putRes.status}`);
+    } finally {
+      setAutoContinueSaving(false);
+    }
+  };
 
   const apply = () => {
     const n = parseInt(draft, 10);
@@ -111,6 +165,46 @@ export default function LoopGuardWidget({ projectId }: LoopGuardWidgetProps) {
           Saved to config.toml — live update failed; takes effect on next AC restart.
         </div>
       )}
+      {/* #422 / quadwork#310: auto-continue opt-in. Default OFF so
+          operators have to explicitly enable "resume the loop guard
+          for me". Delay default 30s, min 5s (prevents pathological
+          tight loops from resuming instantly). */}
+      <label className="mt-2 flex items-center gap-1.5 text-[10px] text-text-muted cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={autoContinue}
+          disabled={autoContinueSaving}
+          onChange={(e) => {
+            const next = e.target.checked;
+            setAutoContinue(next);
+            saveAutoContinue(next, autoContinueDelaySec).catch(() => {
+              // revert on failure
+              setAutoContinue(!next);
+            });
+          }}
+        />
+        Auto-continue after pause
+        <span className="text-text-muted">— wait</span>
+        <input
+          type="number"
+          min={5}
+          max={300}
+          value={autoContinueDelayDraft}
+          disabled={autoContinueSaving || !autoContinue}
+          onChange={(e) => setAutoContinueDelayDraft(e.target.value)}
+          onBlur={() => {
+            const n = parseInt(autoContinueDelayDraft, 10);
+            const clamped = Number.isFinite(n) ? Math.max(5, Math.min(300, n)) : 30;
+            setAutoContinueDelaySec(clamped);
+            setAutoContinueDelayDraft(String(clamped));
+            if (clamped !== autoContinueDelaySec) {
+              saveAutoContinue(autoContinue, clamped).catch(() => {});
+            }
+          }}
+          className="w-10 bg-transparent px-1 py-0.5 border border-border rounded text-text outline-none focus:ring-1 focus:ring-accent disabled:opacity-40 text-center"
+        />
+        <span className="text-text-muted">s before /continue</span>
+      </label>
     </div>
   );
 }


### PR DESCRIPTION
Fixes #310
Tracker: realproject7/agent-os#422
Master: #317 (Batch 32 Phase 2)
Depends on: quadwork#309 (merged as PR #318)

## Summary
Default-OFF per-project opt-in so overnight runs don't stall when AC's loop guard fires.

Backend (`server/index.js`):
- New `setInterval` polls `/api/status` every 10s per project with `auto_continue_loop_guard` enabled.
- `paused` false → true schedules `setTimeout` for the configured delay (5-300s, default 30s). On fire, re-reads the config so a checkbox disable mid-wait actually cancels, then POSTs `{text:"/continue",channel:"general"}` to `/api/chat`.
- `paused` true → false cancels any pending timer (manual operator `/continue` short-circuits the auto one).
- Every auto-continue logs to server stdout. Polling chosen over ws subscribe — 10s latency is fine given the tens-of-seconds delay, and avoids per-project ws lifecycle complications.

Frontend (`src/components/LoopGuardWidget.tsx`):
- Hydrates both prefs from `/api/config` on mount.
- New checkbox + delay input under the hops row. Saves via existing `PUT /api/config` (whole-config write) so no new endpoint.
- Delay input uses the #419 draft-string pattern and disables when auto-continue is off.

## Acceptance criteria
- [x] Widget has an "Auto-continue after pause" checkbox, default OFF
- [x] Delay configurable 5–300s (draft-string input)
- [x] Auto-continue logged to server stdout
- [x] Setting persists per-project in config.json
- [x] Disabling the checkbox mid-wait cancels a pending auto-continue
- [x] Manual /continue from the operator cancels the timer via the true→false transition
- [ ] Reviewers: trigger the loop guard, confirm auto-continue fires after the delay; also confirm disabling the checkbox during the wait stops it

## Test plan
- [x] `node --check server/index.js`
- [x] `tsc --noEmit` clean
- [ ] Reviewers: enable auto-continue with a small delay (say 10s), force the loop guard via a tight hop config, confirm resume; then repeat with checkbox disabled mid-wait and confirm no /continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)