### PR TITLE
[#304] Auto-snapshot project history before AC restart

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -903,6 +903,12 @@ async function handleAgentChattr(req, res) {
       // botched git pull can still be rolled back from disk.
       // #424 / quadwork#304: best-effort.
       await snapshotProjectHistory(projectId).catch(() => {});
+      // Latch the auto-restore opt-in BEFORE stop, same as the
+      // explicit restart branch above — a config mutation during
+      // the git pull shouldn't starve the replay.
+      const updateCfgPre = readConfig();
+      const updateProjectPre = updateCfgPre.projects?.find((p) => p.id === projectId);
+      const updateShouldAutoRestore = !!(updateProjectPre && updateProjectPre.auto_restore_after_restart);
       const proc = getProc();
       const wasRunning = proc.process && proc.state === "running";
       if (wasRunning) {
@@ -927,6 +933,30 @@ async function handleAgentChattr(req, res) {
         restarted = !!child;
         if (child) {
           setTimeout(() => syncChattrToken(projectId).catch(() => {}), 2000);
+          // #424 / quadwork#304 Phase 3: auto-restore after an
+          // update-triggered restart too (t2a re-review). Same
+          //3s wait + newest-snapshot-by-mtime path as the explicit
+          // restart branch, using the pre-stop latched opt-in.
+          if (updateShouldAutoRestore) {
+            setTimeout(async () => {
+              try {
+                const snapDir = path.join(require("os").homedir(), ".quadwork", projectId, "history-snapshots");
+                if (!fs.existsSync(snapDir)) return;
+                const newest = fs.readdirSync(snapDir)
+                  .filter((f) => f.endsWith(".json"))
+                  .map((f) => ({ f, t: fs.statSync(path.join(snapDir, f)).mtimeMs }))
+                  .sort((a, b) => b.t - a.t)[0];
+                if (!newest) return;
+                const r = await fetch(`http://127.0.0.1:${PORT}/api/project-history/restore?project=${encodeURIComponent(projectId)}&name=${encodeURIComponent(newest.f)}`, {
+                  method: "POST",
+                });
+                if (r.ok) console.log(`[snapshot] ${projectId} auto-restored ${newest.f} after update`);
+                else console.warn(`[snapshot] ${projectId} post-update auto-restore returned ${r.status}`);
+              } catch (err) {
+                console.warn(`[snapshot] ${projectId} post-update auto-restore failed: ${err.message || err}`);
+              }
+            }, 3000);
+          }
         }
       }
 

--- a/server/index.js
+++ b/server/index.js
@@ -664,6 +664,55 @@ app.get("/api/agents", (_req, res) => {
   res.json(agents);
 });
 
+// #424 / quadwork#304: best-effort auto-snapshot of chat history
+// before any AgentChattr restart. Defense-in-depth against
+// destructive ops like /clear that rewrite AC's JSONL log in place
+// — per #303 the log itself IS persistent across normal restarts,
+// so the snapshot's job is to give the operator a point-in-time
+// rollback if the log gets clobbered, not to prevent history loss
+// on ordinary lifecycle events.
+//
+// Snapshot contents = the same envelope GET /api/project-history
+// returns, so an operator (or a future "restore" button) can feed
+// the file straight into POST /api/project-history for replay.
+const HISTORY_SNAPSHOT_LIMIT = 5;
+
+async function snapshotProjectHistory(projectId) {
+  try {
+    const snapDir = path.join(require("os").homedir(), ".quadwork", projectId, "history-snapshots");
+    if (!fs.existsSync(snapDir)) fs.mkdirSync(snapDir, { recursive: true });
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/project-history?project=${encodeURIComponent(projectId)}`, {
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!res.ok) {
+      console.warn(`[snapshot] ${projectId} history fetch returned ${res.status}; skipping snapshot`);
+      return false;
+    }
+    const text = await res.text();
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const outPath = path.join(snapDir, `${stamp}.json`);
+    fs.writeFileSync(outPath, text);
+    console.log(`[snapshot] ${projectId} → ${outPath}`);
+    // Prune to the newest HISTORY_SNAPSHOT_LIMIT files so the
+    // directory can't grow unbounded across weeks of restarts.
+    try {
+      const entries = fs.readdirSync(snapDir)
+        .filter((f) => f.endsWith(".json"))
+        .map((f) => ({ f, t: fs.statSync(path.join(snapDir, f)).mtimeMs }))
+        .sort((a, b) => b.t - a.t);
+      for (const old of entries.slice(HISTORY_SNAPSHOT_LIMIT)) {
+        try { fs.unlinkSync(path.join(snapDir, old.f)); } catch {}
+      }
+    } catch {
+      // non-fatal — stale snapshots just linger
+    }
+    return true;
+  } catch (err) {
+    console.warn(`[snapshot] ${projectId} snapshot failed: ${err.message || err}`);
+    return false;
+  }
+}
+
 // Per-project AgentChattr lifecycle: /api/agentchattr/:project/:action
 // Backward compat: /api/agentchattr/:action uses first project
 async function handleAgentChattr(req, res) {
@@ -785,6 +834,10 @@ async function handleAgentChattr(req, res) {
     setProc({ process: null, state: "stopped", error: null });
     res.json({ ok: true, state: "stopped" });
   } else if (action === "restart") {
+    // #424 / quadwork#304: snapshot history before killing the
+    // process. Best-effort and non-blocking-on-failure so a flaky
+    // snapshot doesn't leave the operator unable to restart AC.
+    await snapshotProjectHistory(projectId).catch(() => {});
     const proc = getProc();
     if (proc.process) {
       try { proc.process.kill("SIGTERM"); } catch {}
@@ -814,7 +867,10 @@ async function handleAgentChattr(req, res) {
     try {
       const { execSync } = require("child_process");
 
-      // Stop running process before pulling
+      // Stop running process before pulling. Snapshot first so a
+      // botched git pull can still be rolled back from disk.
+      // #424 / quadwork#304: best-effort.
+      await snapshotProjectHistory(projectId).catch(() => {});
       const proc = getProc();
       const wasRunning = proc.process && proc.state === "running";
       if (wasRunning) {

--- a/server/index.js
+++ b/server/index.js
@@ -838,6 +838,14 @@ async function handleAgentChattr(req, res) {
     // process. Best-effort and non-blocking-on-failure so a flaky
     // snapshot doesn't leave the operator unable to restart AC.
     await snapshotProjectHistory(projectId).catch(() => {});
+    // #424 / quadwork#304 Phase 3: latch the opt-in BEFORE the
+    // spawn so a restart that itself clears the flag can't starve
+    // the auto-restore. We capture the snapshot filename we just
+    // wrote + the project's auto_restore_after_restart flag and
+    // replay it in the post-spawn tick below if both are set.
+    const preRestartCfg = readConfig();
+    const preRestartProject = preRestartCfg.projects?.find((p) => p.id === projectId);
+    const shouldAutoRestore = !!(preRestartProject && preRestartProject.auto_restore_after_restart);
     const proc = getProc();
     if (proc.process) {
       try { proc.process.kill("SIGTERM"); } catch {}
@@ -852,6 +860,30 @@ async function handleAgentChattr(req, res) {
         }
         // Sync token after AgentChattr restarts
         setTimeout(() => syncChattrToken(projectId), 2000);
+        // #424 / quadwork#304 Phase 3: optional auto-restore.
+        // Fire the restore 3s after spawn so AC's ws is ready.
+        // Best-effort: never blocks the restart response or
+        // rolls back on error.
+        if (shouldAutoRestore) {
+          setTimeout(async () => {
+            try {
+              const snapDir = path.join(require("os").homedir(), ".quadwork", projectId, "history-snapshots");
+              if (!fs.existsSync(snapDir)) return;
+              const newest = fs.readdirSync(snapDir)
+                .filter((f) => f.endsWith(".json"))
+                .map((f) => ({ f, t: fs.statSync(path.join(snapDir, f)).mtimeMs }))
+                .sort((a, b) => b.t - a.t)[0];
+              if (!newest) return;
+              const r = await fetch(`http://127.0.0.1:${PORT}/api/project-history/restore?project=${encodeURIComponent(projectId)}&name=${encodeURIComponent(newest.f)}`, {
+                method: "POST",
+              });
+              if (r.ok) console.log(`[snapshot] ${projectId} auto-restored ${newest.f}`);
+              else console.warn(`[snapshot] ${projectId} auto-restore returned ${r.status}`);
+            } catch (err) {
+              console.warn(`[snapshot] ${projectId} auto-restore failed: ${err.message || err}`);
+            }
+          }, 3000);
+        }
         res.json({ ok: true, state: "running", pid: child.pid });
       } catch (err) {
         setProc({ process: null, state: "error", error: err.message });

--- a/server/routes.js
+++ b/server/routes.js
@@ -606,6 +606,74 @@ router.post("/api/project-history", async (req, res) => {
   res.json({ ok: errors.length === 0, imported, skipped, total: body.messages.length, errors });
 });
 
+// #424 / quadwork#304 Phase 4: list + restore auto-snapshots.
+// snapshotProjectHistory() in server/index.js writes envelope
+// files to ~/.quadwork/{id}/history-snapshots/{ISO}.json before
+// destructive restart/update operations. These endpoints let the
+// Project History widget surface them with a restore button so
+// the operator can roll back a bad /clear or botched update.
+router.get("/api/project-history/snapshots", (req, res) => {
+  const projectId = req.query.project;
+  if (!projectId) return res.status(400).json({ error: "Missing project" });
+  const snapDir = path.join(CONFIG_DIR, projectId, "history-snapshots");
+  if (!fs.existsSync(snapDir)) return res.json({ snapshots: [] });
+  try {
+    const entries = fs.readdirSync(snapDir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => {
+        const st = fs.statSync(path.join(snapDir, f));
+        return { name: f, size: st.size, mtime: st.mtimeMs };
+      })
+      .sort((a, b) => b.mtime - a.mtime);
+    res.json({ snapshots: entries });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to list snapshots", detail: err.message });
+  }
+});
+
+router.post("/api/project-history/restore", async (req, res) => {
+  const projectId = req.query.project;
+  const name = req.query.name || req.body?.name;
+  if (!projectId || !name) return res.status(400).json({ error: "Missing project or name" });
+  // Prevent path traversal — only allow basenames from the snapshot
+  // directory; reject anything with a separator or ".." segment.
+  if (name !== path.basename(name) || name.includes("..") || !name.endsWith(".json")) {
+    return res.status(400).json({ error: "Invalid snapshot name" });
+  }
+  const snapPath = path.join(CONFIG_DIR, projectId, "history-snapshots", name);
+  if (!fs.existsSync(snapPath)) {
+    return res.status(404).json({ error: "Snapshot not found" });
+  }
+  let body;
+  try {
+    const text = fs.readFileSync(snapPath, "utf-8");
+    body = JSON.parse(text);
+  } catch (err) {
+    return res.status(500).json({ error: "Failed to read snapshot", detail: err.message });
+  }
+  // Post the snapshot back through the existing import endpoint
+  // with both bypass flags — the snapshot contains real agent
+  // senders (so allow_agent_senders) and may match a previous
+  // restore's exported_at (so allow_duplicate). This is the
+  // legitimate disaster-recovery case the #297 denylist expected.
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const qwPort = cfg.port || 8400;
+    const r = await fetch(`http://127.0.0.1:${qwPort}/api/project-history?project=${encodeURIComponent(projectId)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...body, allow_agent_senders: true, allow_duplicate: true }),
+    });
+    const data = await r.json().catch(() => null);
+    if (!r.ok) {
+      return res.status(r.status).json(data || { error: `import returned ${r.status}` });
+    }
+    res.json({ ok: true, ...(data || {}) });
+  } catch (err) {
+    res.status(502).json({ error: "Restore failed", detail: err.message });
+  }
+});
+
 router.post("/api/chat", async (req, res) => {
   const projectId = req.query.project || req.body.project;
   const { url: base, token: sessionToken } = getChattrConfig(projectId);

--- a/src/components/ProjectHistoryWidget.tsx
+++ b/src/components/ProjectHistoryWidget.tsx
@@ -41,6 +41,41 @@ export default function ProjectHistoryWidget({ projectId }: ProjectHistoryWidget
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<ImportResult | null>(null);
   const [snapshots, setSnapshots] = useState<SnapshotEntry[]>([]);
+  // #424 / quadwork#304 Phase 3: per-project auto-restore flag.
+  // Default OFF. When enabled, the server auto-restores the newest
+  // snapshot after every restart (handleAgentChattr reads the flag
+  // pre-restart so an in-flight toggle can't starve the replay).
+  const [autoRestore, setAutoRestore] = useState<boolean>(false);
+  const [autoRestoreSaving, setAutoRestoreSaving] = useState(false);
+  useEffect(() => {
+    fetch(`/api/config`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (!cfg || !Array.isArray(cfg.projects)) return;
+        const proj = cfg.projects.find((p: { id: string }) => p.id === projectId);
+        if (proj) setAutoRestore(!!proj.auto_restore_after_restart);
+      })
+      .catch(() => {});
+  }, [projectId]);
+  const saveAutoRestore = async (next: boolean) => {
+    setAutoRestoreSaving(true);
+    try {
+      const r = await fetch(`/api/config`);
+      if (!r.ok) throw new Error(`GET /api/config ${r.status}`);
+      const cfg = await r.json();
+      const idx = cfg.projects?.findIndex((p: { id: string }) => p.id === projectId) ?? -1;
+      if (idx < 0) throw new Error("project not found");
+      cfg.projects[idx] = { ...cfg.projects[idx], auto_restore_after_restart: next };
+      const pr = await fetch(`/api/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(cfg),
+      });
+      if (!pr.ok) throw new Error(`PUT /api/config ${pr.status}`);
+    } finally {
+      setAutoRestoreSaving(false);
+    }
+  };
 
   const loadSnapshots = () => {
     fetch(`/api/project-history/snapshots?project=${encodeURIComponent(projectId)}`)
@@ -265,6 +300,19 @@ export default function ProjectHistoryWidget({ projectId }: ProjectHistoryWidget
           {result.errors.length > 0 && ` · ${result.errors.length} errors`}
         </div>
       )}
+      <label className="mt-2 flex items-center gap-1.5 text-[10px] text-text-muted cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={autoRestore}
+          disabled={autoRestoreSaving}
+          onChange={(e) => {
+            const next = e.target.checked;
+            setAutoRestore(next);
+            saveAutoRestore(next).catch(() => setAutoRestore(!next));
+          }}
+        />
+        Auto-restore newest snapshot after AC restart
+      </label>
       {snapshots.length > 0 && (
         <div className="mt-2 border-t border-border/50 pt-1.5">
           <div className="text-[9px] text-text-muted uppercase tracking-wider mb-0.5">

--- a/src/components/ProjectHistoryWidget.tsx
+++ b/src/components/ProjectHistoryWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface ProjectHistoryWidgetProps {
   projectId: string;
@@ -12,6 +12,16 @@ interface ImportResult {
   skipped: number;
   total: number;
   errors: string[];
+}
+
+// #424 / quadwork#304 Phase 4: auto-snapshot list for the restore
+// UI. Files live at ~/.quadwork/{id}/history-snapshots/{ISO}.json
+// and are created by snapshotProjectHistory() in server/index.js
+// before every restart/update.
+interface SnapshotEntry {
+  name: string;
+  size: number;
+  mtime: number;
 }
 
 const MAX_BYTES = 10 * 1024 * 1024;
@@ -27,9 +37,51 @@ const MAX_BYTES = 10 * 1024 * 1024;
  */
 export default function ProjectHistoryWidget({ projectId }: ProjectHistoryWidgetProps) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [busy, setBusy] = useState<"export" | "import" | null>(null);
+  const [busy, setBusy] = useState<"export" | "import" | "restore" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<ImportResult | null>(null);
+  const [snapshots, setSnapshots] = useState<SnapshotEntry[]>([]);
+
+  const loadSnapshots = () => {
+    fetch(`/api/project-history/snapshots?project=${encodeURIComponent(projectId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d && Array.isArray(d.snapshots)) setSnapshots(d.snapshots);
+      })
+      .catch(() => {});
+  };
+  useEffect(() => {
+    loadSnapshots();
+    // Refresh the list every 15s so a restart-triggered snapshot
+    // shows up without the operator reloading the dashboard.
+    const id = setInterval(loadSnapshots, 15000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  const restoreSnapshot = async (name: string) => {
+    const ok = window.confirm(
+      `Restore snapshot ${name}? This will replay every message through AgentChattr (tagged by the original sender) and may duplicate history already in the chat. Continue?`,
+    );
+    if (!ok) return;
+    setBusy("restore");
+    setError(null);
+    setResult(null);
+    try {
+      const r = await fetch(
+        `/api/project-history/restore?project=${encodeURIComponent(projectId)}&name=${encodeURIComponent(name)}`,
+        { method: "POST" },
+      );
+      const data = await r.json().catch(() => null);
+      if (!r.ok) throw new Error((data && data.error) || `HTTP ${r.status}`);
+      if (data && typeof data.imported === "number") setResult(data as ImportResult);
+    } catch (err) {
+      setError((err as Error).message || String(err));
+    } finally {
+      setBusy(null);
+      loadSnapshots();
+    }
+  };
 
   const exportHistory = async () => {
     setBusy("export");
@@ -211,6 +263,39 @@ export default function ProjectHistoryWidget({ projectId }: ProjectHistoryWidget
           Imported {result.imported} / {result.total}
           {result.skipped > 0 && ` · skipped ${result.skipped}`}
           {result.errors.length > 0 && ` · ${result.errors.length} errors`}
+        </div>
+      )}
+      {snapshots.length > 0 && (
+        <div className="mt-2 border-t border-border/50 pt-1.5">
+          <div className="text-[9px] text-text-muted uppercase tracking-wider mb-0.5">
+            Auto-snapshots (before restart)
+          </div>
+          {snapshots.map((s) => {
+            const date = new Date(s.mtime);
+            const label = date.toLocaleString();
+            return (
+              <div
+                key={s.name}
+                className="flex items-center gap-1.5 text-[10px] py-0.5"
+              >
+                <span className="text-text-muted tabular-nums flex-1 truncate" title={s.name}>
+                  {label}
+                </span>
+                <span className="text-text-muted tabular-nums shrink-0">
+                  {Math.round(s.size / 1024)}KB
+                </span>
+                <button
+                  type="button"
+                  onClick={() => restoreSnapshot(s.name)}
+                  disabled={busy !== null}
+                  className="px-1.5 py-0.5 text-[10px] text-accent border border-accent/40 rounded hover:bg-accent/10 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  title={`Restore ${s.name}`}
+                >
+                  {busy === "restore" ? "…" : "Restore"}
+                </button>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
Fixes #304
Tracker: realproject7/agent-os#424
Master: #317 (Batch 32 Phase 3)
Depends on: #303 investigation finding (quadwork#324)

## Summary
Defense-in-depth snapshot before any AC restart. Per #303, AC already persists its own log across ordinary restarts, so the snapshot's purpose is narrower: rollback against destructive ops like `/clear` that rewrite the in-place JSONL.

Implementation:
- New `snapshotProjectHistory()` helper in `server/index.js` — GETs `/api/project-history` via localhost loopback, writes the response verbatim to `~/.quadwork/{id}/history-snapshots/{ISO}.json`, prunes the directory to the newest 5 entries by mtime.
- Hooked into `handleAgentChattr`'s `restart` and `update` branches right before the SIGTERM so live in-memory state is captured.
- Every failure caught + logged (best-effort) — a flaky snapshot can't wedge an otherwise-fine restart.

Snapshots use the #279 import-envelope format, so future "restore" wiring can feed them back into `POST /api/project-history` with `allow_agent_senders=true` / `allow_duplicate=true`. The files are restore-ready today; a future UI (deferred phases 3 + 4) just needs to surface them.

## Acceptance criteria
- [x] Every AC restart triggers an auto-snapshot first (best-effort, non-fatal)
- [x] Snapshots stored at `~/.quadwork/{id}/history-snapshots/{ISO}.json`
- [x] Snapshot count capped at 5 per project (mtime-desc prune)
- [ ] Auto-restore after restart — **deferred** to follow-up
- [ ] UI: snapshots list with restore button — **deferred** to follow-up
- [x] AC1/AC2 investigation completed first (#303 / PR #324)

## Test plan
- [x] `node --check server/index.js`
- [ ] Reviewers: click Restart on the dashboard for a project with chat history; confirm a new file appears under `~/.quadwork/<id>/history-snapshots/`; repeat 6 times and confirm the oldest is pruned; verify the JSON payload matches the shape of a `/api/project-history` export

🤖 Generated with [Claude Code](https://claude.com/claude-code)