### PR TITLE
[#315] Terminal font: 11px / lineHeight 1.2

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -65,9 +65,14 @@ export default function TerminalPanel({
 
     const term = new Terminal({
       scrollback: 1000,
-      fontSize: 12,
+      // #426 / quadwork#315: fontSize 12 → 11 + lineHeight 1.4 → 1.2
+      // drops per-line height from 16.8px to 13.2px, ~20% more
+      // rows per panel without scrolling and matches the chat
+      // panel's visual density. letterSpacing stays 0.5 so the
+      // smaller glyphs don't crowd.
+      fontSize: 11,
       fontFamily: '"Geist Mono", "JetBrains Mono", "Fira Code", "Cascadia Code", monospace',
-      lineHeight: 1.4,
+      lineHeight: 1.2,
       letterSpacing: 0.5,
       cursorBlink: false,
       cursorStyle: "block",


### PR DESCRIPTION
Fixes #315
Tracker: realproject7/agent-os#426
Master: #317 (Batch 32 Phase 4)

## Summary
Single-line constructor tweak in `TerminalPanel.tsx`:
- `fontSize`: 12 → 11
- `lineHeight`: 1.4 → 1.2
- `letterSpacing` kept at 0.5

Per-line height drops from 16.8px to 13.2px (~20% more visible rows per tile without scrolling) and matches the chat panel density.

## Acceptance criteria
- [x] fontSize 12 → 11
- [x] lineHeight 1.4 → 1.2
- [x] letterSpacing preserved so smaller glyphs don't crowd
- [x] No scrollback / input / theme changes
- [ ] Reviewers: eyeball density against the chat panel + confirm `/c`, start/stop, and the activity ring still align

## Test plan
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)