### PR TITLE
[#314] GitHub Releases: automation + backfill runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p>
   <a href="https://www.npmjs.com/package/quadwork"><img src="https://img.shields.io/npm/v/quadwork" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/quadwork"><img src="https://img.shields.io/npm/dm/quadwork" alt="npm downloads" /></a>
-  <a href="https://github.com/realproject7/quadwork/releases"><img src="https://img.shields.io/github/v/release/realproject7/quadwork" alt="latest release" /></a>
+  <a href="https://github.com/realproject7/quadwork/releases/latest"><img src="https://img.shields.io/github/v/release/realproject7/quadwork" alt="latest release" /></a>
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey" alt="platform" />
   <img src="https://img.shields.io/badge/runs-locally-00d4aa" alt="runs locally" />
   <img src="https://img.shields.io/badge/agents-4-orange" alt="4 agents" />

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <p>
   <a href="https://www.npmjs.com/package/quadwork"><img src="https://img.shields.io/npm/v/quadwork" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/quadwork"><img src="https://img.shields.io/npm/dm/quadwork" alt="npm downloads" /></a>
+  <a href="https://github.com/realproject7/quadwork/releases"><img src="https://img.shields.io/github/v/release/realproject7/quadwork" alt="latest release" /></a>
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey" alt="platform" />
   <img src="https://img.shields.io/badge/runs-locally-00d4aa" alt="runs locally" />
   <img src="https://img.shields.io/badge/agents-4-orange" alt="4 agents" />

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,104 @@
+# Releasing QuadWork
+
+This doc describes how to cut a new QuadWork release, including the one-time
+GitHub Releases backfill for the existing v1.0.x–v1.3.x tags.
+
+## Prerequisites
+
+- `gh` authenticated against `realproject7/quadwork` with repo write access
+- `npm` logged in to the `quadwork` package (`npm whoami` should print your
+  publisher account)
+- Clean working tree on `main`, fast-forwarded from `origin/main`
+- Branch protection allows tag push (current setting allows it)
+
+## Standard release — minor / patch / major
+
+The `package.json` scripts wrap the whole chain so you never have to remember
+the order:
+
+```bash
+# Bug fix bump — v1.3.0 → v1.3.1
+npm run release:patch
+
+# Feature bump — v1.3.0 → v1.4.0
+npm run release:minor
+
+# Breaking change bump — v1.3.0 → v2.0.0
+npm run release:major
+```
+
+What the script does (`release:patch` shown, others identical except the
+`npm version` flag):
+
+1. `npm version patch` — bumps `package.json` + `package-lock.json` and
+   commits the change on `main` with a `vX.Y.Z` tag.
+2. `git push origin main --follow-tags` — pushes the bump commit **and** the
+   new tag in one go (so CI / downstream consumers see them together).
+3. `gh release create vX.Y.Z --generate-notes --latest` — creates the
+   GitHub Release. `--generate-notes` auto-writes the body from merged PRs
+   since the previous tag; `--latest` marks this release as the current
+   "Latest" on the repo landing page.
+4. `npm publish` — publishes to npm using the tarball the `prepack` script
+   built.
+
+The scripts are all one-liners so you can rerun pieces by hand if any step
+fails (e.g. if `npm publish` 409s, just rerun that step once).
+
+## One-time backfill of historical tags
+
+Before the `release:*` scripts existed, versions v1.0.x–v1.3.0 were published
+to npm and tagged in git but **no corresponding GitHub Release** was created.
+The backfill loop below creates one Release per historical tag with
+auto-generated notes. Run it **once** from the repo root (requires `gh`
+authed to `realproject7/quadwork`):
+
+```bash
+# From the repo root of realproject7/quadwork:
+git fetch --tags origin
+TAGS=$(git tag --list 'v*' | sort -V)
+PREV=""
+for TAG in $TAGS; do
+  echo "— $TAG (previous: ${PREV:-none})"
+  if [ -z "$PREV" ]; then
+    # No previous tag — first release, let gh infer notes from HEAD history
+    gh release create "$TAG" --title "$TAG" --generate-notes
+  else
+    gh release create "$TAG" --title "$TAG" --notes-start-tag "$PREV" --generate-notes
+  fi
+  PREV=$TAG
+done
+
+# Explicitly mark the newest release as "Latest"
+LATEST=$(git tag --list 'v*' | sort -V | tail -1)
+gh release edit "$LATEST" --latest
+```
+
+Notes about the loop:
+
+- If a Release for a tag already exists, `gh release create` will 422. Wrap
+  the call in `|| true` if you want to skip existing entries, or run
+  `gh release delete "$TAG" --yes` first to rebuild them.
+- `--notes-start-tag` is what tells gh to group PRs by the range between two
+  tags rather than the whole history.
+- The explicit `gh release edit ... --latest` at the end handles the case
+  where the backfill happens in chronological order — the last create would
+  already flag `--latest`, but re-setting it is idempotent.
+
+## After release
+
+- Update any external distribution channel notes (VS Code extension, etc.)
+- Post the release URL in the project chat so the batch reviewers can
+  verify the auto-generated notes look sane.
+
+## Pitfalls
+
+- **Never run `npm run release:*` from a dirty tree.** `npm version` will
+  refuse, but if you've amended an already-published commit the chain can
+  leave the git tag ahead of the npm publish. Fix order: publish, THEN fix
+  git.
+- **Don't force-push over a released tag.** Branch protection should block
+  it; if it doesn't, the release will point at a dangling commit and the
+  auto-generated notes on the next release will be wrong.
+- **`gh release create` without `--latest` leaves the previous release
+  marked as Latest** — use the `--latest` flag on every release script so
+  the repo landing page always points at the newest version.

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "lint": "eslint",
     "server": "node server/",
     "prepack": "npm run build",
-    "release:patch": "npm version patch && git push origin main --follow-tags && gh release create v$npm_package_version --generate-notes --latest && npm publish",
-    "release:minor": "npm version minor && git push origin main --follow-tags && gh release create v$npm_package_version --generate-notes --latest && npm publish",
-    "release:major": "npm version major && git push origin main --follow-tags && gh release create v$npm_package_version --generate-notes --latest && npm publish"
+    "release:patch": "npm version patch && git push origin main --follow-tags && gh release create \"v$(node -p \"require('./package.json').version\")\" --generate-notes --latest && npm publish",
+    "release:minor": "npm version minor && git push origin main --follow-tags && gh release create \"v$(node -p \"require('./package.json').version\")\" --generate-notes --latest && npm publish",
+    "release:major": "npm version major && git push origin main --follow-tags && gh release create \"v$(node -p \"require('./package.json').version\")\" --generate-notes --latest && npm publish"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "lint": "eslint",
     "server": "node server/",
     "prepack": "npm run build",
-    "release:patch": "npm version patch && git push origin main --follow-tags && gh release create \"v$(node -p \"require('./package.json').version\")\" --generate-notes --latest && npm publish",
-    "release:minor": "npm version minor && git push origin main --follow-tags && gh release create \"v$(node -p \"require('./package.json').version\")\" --generate-notes --latest && npm publish",
-    "release:major": "npm version major && git push origin main --follow-tags && gh release create \"v$(node -p \"require('./package.json').version\")\" --generate-notes --latest && npm publish"
+    "release:patch": "npm version patch && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",
+    "release:minor": "npm version minor && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",
+    "release:major": "npm version major && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "start": "node server/",
     "lint": "eslint",
     "server": "node server/",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "release:patch": "npm version patch && git push origin main --follow-tags && gh release create v$npm_package_version --generate-notes --latest && npm publish",
+    "release:minor": "npm version minor && git push origin main --follow-tags && gh release create v$npm_package_version --generate-notes --latest && npm publish",
+    "release:major": "npm version major && git push origin main --follow-tags && gh release create v$npm_package_version --generate-notes --latest && npm publish"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Fixes #314
Tracker: realproject7/agent-os#428
Master: #317 (Batch 32 Phase 5)

## Summary
Three code deliverables + one documented operator action.

**Code:**
- `package.json` — new `release:patch` / `release:minor` / `release:major` scripts that chain `npm version` → `git push --follow-tags` → `gh release create --generate-notes --latest` → `npm publish`. Future releases are now one command each.
- `docs/RELEASING.md` — full release runbook: prerequisites, the standard flow with per-step explanations, a bash loop for the one-time historical tag backfill, and pitfalls (dirty tree, force-pushing over released tags, forgetting `--latest`).
- `README.md` — new "latest release" shield next to the npm badges linking to `/releases`.

**Operator action (deliberately NOT part of this PR):**
Running `gh release create` against every historical `v*` tag is a shared-state write on the public `realproject7/quadwork` repo. Same gate as #362's operator restart — I'm not going to create ~30 public Releases unilaterally from a PR. The backfill loop is documented in `docs/RELEASING.md` under "One-time backfill of historical tags" and should be run by the operator after merge. Once run, every future release is fully automated via the new npm scripts.

## Acceptance criteria
- [x] Release scripts added (patch / minor / major)
- [x] README release badge added
- [x] `docs/RELEASING.md` added
- [ ] Operator runs the backfill loop once after merge to create historical Releases (documented but not executed here)
- [x] Future releases are one command (`npm run release:patch` etc.)

## Test plan
- [x] `package.json` parses, new scripts show in `npm run`
- [ ] Reviewers: visually check the README badge, skim `docs/RELEASING.md`, validate the backfill loop reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)