### PR TITLE
[#316] Batch Progress: keep merged items visible via snapshot cache

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -987,6 +987,62 @@ router.get("/api/github/merged-prs", (req, res) => {
 // Cached for 10s per project to avoid hammering gh on every poll.
 
 const _batchProgressCache = new Map(); // projectId -> { ts, data }
+
+// #429 / quadwork#316: persistent batch snapshot on disk so the
+// Batch Progress panel keeps showing merged items after Head moves
+// them from Active Batch to Done. The in-memory `_batchProgressCache`
+// above is a 10s TTL cache of the rendered rows; this new cache is
+// the *set of issue numbers* we currently consider "the active
+// batch", and it survives restarts + lives across polls.
+function batchSnapshotPath(projectId) {
+  return path.join(CONFIG_DIR, projectId, "batch-progress-cache.json");
+}
+function readBatchSnapshot(projectId) {
+  try {
+    return JSON.parse(fs.readFileSync(batchSnapshotPath(projectId), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+function writeBatchSnapshot(projectId, snapshot) {
+  try {
+    const p = batchSnapshotPath(projectId);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(snapshot));
+  } catch {
+    // Non-fatal — panel still works from the live parse.
+  }
+}
+
+// Decide which batch to render, combining the live parse of
+// OVERNIGHT-QUEUE.md with the persistent snapshot. The snapshot is
+// replaced whenever a new batch starts (explicit Batch: N bump OR
+// the live Active Batch contains items the snapshot doesn't); in
+// all other cases the snapshot wins, so items Head moved to Done
+// stay visible until the operator starts the next batch.
+function resolveDisplayedBatch(queueText, projectId) {
+  const current = parseActiveBatch(queueText);
+  const snapshot = readBatchSnapshot(projectId);
+  const hasExplicitBump =
+    current.batchNumber !== null &&
+    (!snapshot || snapshot.batchNumber === null || current.batchNumber > snapshot.batchNumber);
+  const hasNewItems =
+    current.issueNumbers.length > 0 &&
+    (!snapshot || current.issueNumbers.some((n) => !snapshot.issueNumbers.includes(n)));
+  let next;
+  if (hasExplicitBump || hasNewItems) {
+    next = { batchNumber: current.batchNumber, issueNumbers: current.issueNumbers.slice() };
+  } else if (snapshot && Array.isArray(snapshot.issueNumbers) && snapshot.issueNumbers.length > 0) {
+    next = {
+      batchNumber: snapshot.batchNumber ?? null,
+      issueNumbers: snapshot.issueNumbers.slice(),
+    };
+  } else {
+    next = { batchNumber: current.batchNumber, issueNumbers: current.issueNumbers.slice() };
+  }
+  if (next.issueNumbers.length > 0) writeBatchSnapshot(projectId, next);
+  return next;
+}
 const BATCH_PROGRESS_TTL_MS = 10000;
 
 function parseActiveBatch(queueText) {
@@ -1223,7 +1279,10 @@ router.get("/api/batch-progress", async (req, res) => {
   try { queueText = fs.readFileSync(queuePath, "utf-8"); }
   catch { /* missing file → empty active batch */ }
 
-  const { batchNumber, issueNumbers } = parseActiveBatch(queueText);
+  // #429 / quadwork#316: resolve the displayed batch through the
+  // snapshot-aware helper so merged items stay visible after Head
+  // moves them from Active Batch to Done, until a new batch starts.
+  const { batchNumber, issueNumbers } = resolveDisplayedBatch(queueText, projectId);
   if (issueNumbers.length === 0) {
     const data = { batch_number: batchNumber, items: [], summary: "", complete: false };
     _batchProgressCache.set(projectId, { ts: Date.now(), data });

--- a/server/routes.js
+++ b/server/routes.js
@@ -1020,7 +1020,13 @@ function writeBatchSnapshot(projectId, snapshot) {
 // the live Active Batch contains items the snapshot doesn't); in
 // all other cases the snapshot wins, so items Head moved to Done
 // stay visible until the operator starts the next batch.
-function resolveDisplayedBatch(queueText, projectId) {
+function resolveDisplayedBatch(queueText, projectId, { queueReadOk = true } = {}) {
+  // Queue file deleted / unreadable → fall back to empty state per
+  // #316's edge case. Returning the snapshot here would "heal" a
+  // genuinely missing file into stale data the operator can't
+  // reconcile without nuking ~/.quadwork/{id}/batch-progress-cache.json
+  // manually.
+  if (!queueReadOk) return { batchNumber: null, issueNumbers: [] };
   const current = parseActiveBatch(queueText);
   const snapshot = readBatchSnapshot(projectId);
   const hasExplicitBump =
@@ -1276,13 +1282,20 @@ router.get("/api/batch-progress", async (req, res) => {
 
   const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
   let queueText = "";
-  try { queueText = fs.readFileSync(queuePath, "utf-8"); }
-  catch { /* missing file → empty active batch */ }
+  let queueReadOk = false;
+  try {
+    queueText = fs.readFileSync(queuePath, "utf-8");
+    queueReadOk = true;
+  } catch {
+    // Missing / unreadable file — pass queueReadOk=false so the
+    // resolver bypasses the snapshot and returns the empty state
+    // per #316's edge case.
+  }
 
   // #429 / quadwork#316: resolve the displayed batch through the
   // snapshot-aware helper so merged items stay visible after Head
   // moves them from Active Batch to Done, until a new batch starts.
-  const { batchNumber, issueNumbers } = resolveDisplayedBatch(queueText, projectId);
+  const { batchNumber, issueNumbers } = resolveDisplayedBatch(queueText, projectId, { queueReadOk });
   if (issueNumbers.length === 0) {
     const data = { batch_number: batchNumber, items: [], summary: "", complete: false };
     _batchProgressCache.set(projectId, { ts: Date.now(), data });


### PR DESCRIPTION
Fixes #316
Tracker: realproject7/agent-os#429
Master: #317 (Batch 32 Phase 5)

## Summary
Persistent per-project snapshot at `~/.quadwork/{id}/batch-progress-cache.json` tracks the issue-number set currently considered "the active batch". The `batch-progress` endpoint resolves what to render through a new `resolveDisplayedBatch()` helper:

1. `parseActiveBatch()` gives the live state of `## Active Batch`.
2. **New-batch signal**: explicit `Batch: N` bump (post-#404) OR live items not in the snapshot → replace the snapshot with the live set.
3. **Else (live subset of snapshot = items moved to Done)**: keep rendering from the snapshot, so merged items stay visible.
4. Persist the resolved set for the next poll.

Net effect: when Head merges #295 and moves it to Done, the Batch Progress panel keeps the 100% `Merged ✓` row until the operator starts the next batch, which triggers the new-items branch and rolls the snapshot over cleanly.

UI / data shape unchanged — explicitly required by the ticket.

## Acceptance criteria
- [x] Panel retains merged items until a new batch starts
- [x] Most-recent-batch selection follows the batch-number guidance (explicit bump path) with a set-based fallback (new-items path) per the "Option A as primary, Option B as fallback" recommendation
- [x] Existing UI/data shape unchanged (only `resolveDisplayedBatch` swapped into the route handler)

## Test plan
- [x] `node --check server/routes.js`
- [x] Smoke test of the resolver logic against a "3 active + 1 already in Done" scenario confirms it returns the snapshot (4 items, not 3)
- [ ] Reviewers: run a batch through to a couple of merges, confirm merged items linger at 100% in the panel; start a new batch, confirm the snapshot rolls over to the new issue numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)