### PR TITLE
[#312] AI team work hours: activity log + stats API + top header + home hero

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -674,6 +674,137 @@ router.post("/api/project-history/restore", async (req, res) => {
   }
 });
 
+// #430 / quadwork#312: AI team work-hours tracking.
+//
+// The frontend's TerminalGrid detects per-agent activity transitions
+// (idle → active, active → idle) via the existing activity ref and
+// POSTs them to /api/activity/log. We buffer `start` events in
+// memory keyed by `${project}/${agent}`; an `end` event looks up the
+// matching buffered start, computes the duration, and appends a
+// complete session row to ~/.quadwork/{project}/activity.jsonl.
+//
+// /api/activity/stats aggregates across all projects with a 30s
+// cache so the dashboard can poll it every minute without thrashing
+// the filesystem.
+
+const _activityStarts = new Map(); // `${project}/${agent}` → startTimestamp
+const _activityStatsCache = { ts: 0, data: null };
+const ACTIVITY_STATS_TTL_MS = 30000;
+
+function activityLogPath(projectId) {
+  return path.join(CONFIG_DIR, projectId, "activity.jsonl");
+}
+
+router.post("/api/activity/log", (req, res) => {
+  const { project, agent, type, timestamp } = req.body || {};
+  if (typeof project !== "string" || !project) return res.status(400).json({ error: "Missing project" });
+  if (typeof agent !== "string" || !agent) return res.status(400).json({ error: "Missing agent" });
+  if (type !== "start" && type !== "end") return res.status(400).json({ error: "type must be start|end" });
+  const ts = typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : Date.now();
+  const key = `${project}/${agent}`;
+
+  if (type === "start") {
+    // Only remember the first start per session — duplicate starts
+    // are possible if the frontend re-mounts mid-stream; ignore
+    // them so the session duration reflects the original onset.
+    if (!_activityStarts.has(key)) _activityStarts.set(key, ts);
+    return res.json({ ok: true });
+  }
+
+  // type === "end"
+  const start = _activityStarts.get(key);
+  if (start === undefined) {
+    // Orphan end (missed start — probably happens on server
+    // restart while a session was live). Drop it silently so we
+    // don't write a row with an unknown start timestamp.
+    return res.json({ ok: true, dropped: "orphan" });
+  }
+  _activityStarts.delete(key);
+  const row = { agent, start, end: ts, duration_ms: Math.max(0, ts - start) };
+  try {
+    const p = activityLogPath(project);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.appendFileSync(p, JSON.stringify(row) + "\n");
+    // Invalidate the stats cache so the next read sees the new row.
+    _activityStatsCache.ts = 0;
+  } catch (err) {
+    console.warn(`[activity] failed to append ${project}/${agent}: ${err.message || err}`);
+  }
+  res.json({ ok: true, duration_ms: row.duration_ms });
+});
+
+// Aggregate all activity.jsonl files under ~/.quadwork/*/activity.jsonl.
+// `today`, `week`, `month` boundaries use the operator's local
+// timezone rather than UTC — "this week" should mean the week the
+// operator is living in, not a UTC-offset week that starts at
+// 16:00 local time.
+function computeActivityStats() {
+  if (Date.now() - _activityStatsCache.ts < ACTIVITY_STATS_TTL_MS && _activityStatsCache.data) {
+    return _activityStatsCache.data;
+  }
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  // Start of this week = local Monday 00:00. JS: getDay() → 0-Sun..6-Sat.
+  const day = now.getDay();
+  const mondayOffset = day === 0 ? -6 : 1 - day; // Sun → -6, Mon → 0, Tue → -1, …
+  const startOfWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() + mondayOffset).getTime();
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+
+  const totals = { today_ms: 0, week_ms: 0, month_ms: 0, total_ms: 0 };
+  const byProject = {};
+  let projectDirs = [];
+  try { projectDirs = fs.readdirSync(CONFIG_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name); } catch {}
+  for (const projectId of projectDirs) {
+    const p = activityLogPath(projectId);
+    if (!fs.existsSync(p)) continue;
+    const projectTotals = { today_ms: 0, week_ms: 0, month_ms: 0, total_ms: 0 };
+    let text;
+    try { text = fs.readFileSync(p, "utf-8"); } catch { continue; }
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      let row;
+      try { row = JSON.parse(line); } catch { continue; }
+      const d = row && typeof row.duration_ms === "number" ? row.duration_ms : 0;
+      const start = row && typeof row.start === "number" ? row.start : 0;
+      if (d <= 0 || !start) continue;
+      projectTotals.total_ms += d;
+      if (start >= startOfToday) projectTotals.today_ms += d;
+      if (start >= startOfWeek)  projectTotals.week_ms  += d;
+      if (start >= startOfMonth) projectTotals.month_ms += d;
+    }
+    byProject[projectId] = {
+      today: Math.round(projectTotals.today_ms / 3600) / 1000,
+      week:  Math.round(projectTotals.week_ms  / 3600) / 1000,
+      month: Math.round(projectTotals.month_ms / 3600) / 1000,
+      total: Math.round(projectTotals.total_ms / 3600) / 1000,
+    };
+    totals.today_ms += projectTotals.today_ms;
+    totals.week_ms  += projectTotals.week_ms;
+    totals.month_ms += projectTotals.month_ms;
+    totals.total_ms += projectTotals.total_ms;
+  }
+  const data = {
+    today: Math.round(totals.today_ms / 3600) / 1000,
+    week:  Math.round(totals.week_ms  / 3600) / 1000,
+    month: Math.round(totals.month_ms / 3600) / 1000,
+    total: Math.round(totals.total_ms / 3600) / 1000,
+    by_project: byProject,
+  };
+  _activityStatsCache.ts = Date.now();
+  _activityStatsCache.data = data;
+  return data;
+}
+
+router.get("/api/activity/stats", (_req, res) => {
+  try {
+    res.json(computeActivityStats());
+  } catch (err) {
+    res.status(500).json({ error: "Failed to compute activity stats", detail: err.message });
+  }
+});
+
 router.post("/api/chat", async (req, res) => {
   const projectId = req.query.project || req.body.project;
   const { url: base, token: sessionToken } = getChattrConfig(projectId);

--- a/server/routes.js
+++ b/server/routes.js
@@ -752,11 +752,20 @@ function computeActivityStats() {
 
   const totals = { today_ms: 0, week_ms: 0, month_ms: 0, total_ms: 0 };
   const byProject = {};
-  let projectDirs = [];
-  try { projectDirs = fs.readdirSync(CONFIG_DIR, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .map((d) => d.name); } catch {}
-  for (const projectId of projectDirs) {
+  // #430 / quadwork#312: only count projects registered in
+  // config.json, not every directory under ~/.quadwork/. Stray
+  // folders from deleted / unconfigured projects must not inflate
+  // the stats — that's explicit in #312's acceptance.
+  let projectIds = [];
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    if (Array.isArray(cfg.projects)) {
+      projectIds = cfg.projects.map((p) => p && p.id).filter((id) => typeof id === "string" && id);
+    }
+  } catch {
+    // config unreadable → no projects → empty stats (safe fallback)
+  }
+  for (const projectId of projectIds) {
     const p = activityLogPath(projectId);
     if (!fs.existsSync(p)) continue;
     const projectTotals = { today_ms: 0, week_ms: 0, month_ms: 0, total_ms: 0 };

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import HomeEmptyState from "./HomeEmptyState";
 
@@ -30,6 +30,90 @@ function timeAgo(iso: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+// #430 / quadwork#312: AI team work-hours hero — the marketing
+// surface on the home page. Big lifetime-hours number in accent,
+// rotating value-focused tagline, three-column time-window footer.
+const HERO_TAGLINES = [
+  "You've slept easier for",
+  "You've gone for runs for",
+  "You've enjoyed life for",
+  "You've had time for the people you love for",
+  "You've touched grass for",
+  "You've watched movies for",
+  "You've taken vacations for",
+  "You've gone on dates for",
+  "You've cooked dinner for",
+  "You've read books for",
+];
+
+interface HeroStats {
+  today: number;
+  week: number;
+  month: number;
+  total: number;
+}
+
+function heroFmt(h: number): string {
+  if (!Number.isFinite(h) || h <= 0) return "0h";
+  if (h < 1) return `${(h * 60).toFixed(0)}m`;
+  return `${h.toFixed(1)}h`;
+}
+
+function ActivityHero() {
+  const [stats, setStats] = useState<HeroStats | null>(null);
+  const tagline = useMemo(
+    () => HERO_TAGLINES[Math.floor(Math.random() * HERO_TAGLINES.length)],
+    [],
+  );
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      fetch("/api/activity/stats")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => { if (!cancelled && d) setStats(d); })
+        .catch(() => {});
+    };
+    load();
+    const id = setInterval(load, 60000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
+
+  // Empty state — fresh install, nothing logged yet.
+  if (stats && (!stats.total || stats.total === 0)) {
+    return (
+      <div className="mb-6 border border-accent/30 bg-accent/5 rounded p-6 text-center">
+        <div className="text-[13px] text-text-muted">
+          Your AI team hasn&apos;t started shipping yet.
+        </div>
+        <div className="text-[11px] text-text-muted mt-1">
+          Kick off a batch and come back in the morning.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 border border-accent/30 bg-accent/5 rounded p-6 text-center">
+      <div className="text-[13px] text-text-muted">{tagline}</div>
+      <div className="my-3">
+        <span className="inline-block px-4 py-1 text-5xl font-mono font-semibold text-accent border border-accent/40 rounded tabular-nums">
+          {stats ? heroFmt(stats.total) : "—"}
+        </span>
+      </div>
+      <div className="text-[13px] text-text-muted">
+        while your AI team shipped code overnight
+      </div>
+      <div className="mt-4 flex items-center justify-center gap-4 text-[11px] text-text-muted">
+        <span>Today <span className="text-text tabular-nums">{stats ? heroFmt(stats.today) : "—"}</span></span>
+        <span className="text-border">│</span>
+        <span>This week <span className="text-text tabular-nums">{stats ? heroFmt(stats.week) : "—"}</span></span>
+        <span className="text-border">│</span>
+        <span>Month <span className="text-text tabular-nums">{stats ? heroFmt(stats.month) : "—"}</span></span>
+      </div>
+    </div>
+  );
 }
 
 export default function HomeDashboard() {
@@ -74,6 +158,12 @@ export default function HomeDashboard() {
           Could not load projects from /api/projects. The dashboard may be out of date — check the server logs and reload.
         </div>
       )}
+
+      {/* #430 / quadwork#312: AI team work hours hero. Rotates the
+          value-focused tagline per page load, keeps the lifetime
+          number as the headline figure, and mirrors the three time
+          windows from the top header stat block. */}
+      <ActivityHero />
 
       {/* Header */}
       <div className="mb-6">

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -80,7 +80,9 @@ function ActivityHero() {
     return () => { cancelled = true; clearInterval(id); };
   }, []);
 
-  // Empty state — fresh install, nothing logged yet.
+  // Empty state — fresh install, nothing logged yet. Ticket
+  // explicitly requires a CTA to /setup from here so a new user
+  // can bootstrap their first project in one click.
   if (stats && (!stats.total || stats.total === 0)) {
     return (
       <div className="mb-6 border border-accent/30 bg-accent/5 rounded p-6 text-center">
@@ -89,6 +91,14 @@ function ActivityHero() {
         </div>
         <div className="text-[11px] text-text-muted mt-1">
           Kick off a batch and come back in the morning.
+        </div>
+        <div className="mt-3">
+          <Link
+            href="/setup"
+            className="inline-block px-3 py-1 text-[11px] text-accent border border-accent/40 rounded hover:bg-accent/10 transition-colors"
+          >
+            Set up your first project →
+          </Link>
         </div>
       </div>
     );

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -68,10 +68,45 @@ export default function TerminalGrid({
   const markActivity = useCallback((agentId: string) => {
     lastActivityRef.current[agentId] = Date.now();
   }, []);
+  // #430 / quadwork#312: track per-agent session transitions (idle
+  // → active → idle) and POST them to /api/activity/log so the
+  // backend can persist work-hours rows. A session starts the
+  // first tick isActive flips true and ends the first tick it
+  // flips back to false (ACTIVITY_WINDOW_MS after the last PTY
+  // write). fetch failures are best-effort — losing one session
+  // just under-counts the stat, never blocks the UI.
+  const sessionActiveRef = useRef<Record<string, boolean>>({});
+  const logActivity = useCallback((agentId: string, type: "start" | "end") => {
+    fetch("/api/activity/log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        project: projectId,
+        agent: agentId,
+        type,
+        timestamp: Date.now(),
+      }),
+    }).catch(() => {});
+  }, [projectId]);
   useEffect(() => {
-    const interval = setInterval(() => setActivityTick((t) => t + 1), 500);
+    const interval = setInterval(() => {
+      setActivityTick((t) => t + 1);
+      // On every tick, walk the known agents and detect transitions.
+      for (const agent of agents) {
+        const ts = lastActivityRef.current[agent.id];
+        const active = ts !== undefined && Date.now() - ts < ACTIVITY_WINDOW_MS;
+        const wasActive = !!sessionActiveRef.current[agent.id];
+        if (active && !wasActive) {
+          sessionActiveRef.current[agent.id] = true;
+          logActivity(agent.id, "start");
+        } else if (!active && wasActive) {
+          sessionActiveRef.current[agent.id] = false;
+          logActivity(agent.id, "end");
+        }
+      }
+    }, 500);
     return () => clearInterval(interval);
-  }, []);
+  }, [agents, logActivity]);
   const isActive = (agentId: string) => {
     const ts = lastActivityRef.current[agentId];
     return ts !== undefined && Date.now() - ts < ACTIVITY_WINDOW_MS;

--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -64,8 +64,37 @@ function useTypewriter(variants: string[], enabled: boolean) {
 
 const TAGLINE_LS_KEY = "quadwork_tagline_animation";
 
+interface ActivityStats {
+  today: number;
+  week: number;
+  month: number;
+  total: number;
+  by_project: Record<string, { today: number; week: number; month: number; total: number }>;
+}
+
+function fmtHours(h: number): string {
+  if (!Number.isFinite(h) || h <= 0) return "0h";
+  if (h < 1) return `${(h * 60).toFixed(0)}m`;
+  return `${h.toFixed(1)}h`;
+}
+
 export default function TopHeader() {
   const [aboutOpen, setAboutOpen] = useState(false);
+  // #430 / quadwork#312: work-hours stat polling. 60s cadence.
+  const [stats, setStats] = useState<ActivityStats | null>(null);
+  const [showStatsTooltip, setShowStatsTooltip] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      fetch("/api/activity/stats")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => { if (!cancelled && d) setStats(d); })
+        .catch(() => {});
+    };
+    load();
+    const id = setInterval(load, 60000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
   // #227: tagline animation toggle persisted in localStorage. Default
   // is "on" for new visitors. Initialised lazily so SSR doesn't try
   // to read window.localStorage during the first render.
@@ -150,6 +179,43 @@ export default function TopHeader() {
           )}
         </div>
         <div className="flex items-center gap-3 shrink-0">
+          {/* #430 / quadwork#312: work-hours stat block. Globally
+              aggregated across all projects. Hover/focus surfaces
+              the per-project breakdown from stats.by_project. */}
+          {stats && (
+            <div
+              className="relative hidden md:flex items-center gap-2 text-[10px] text-neutral-500"
+              onMouseEnter={() => setShowStatsTooltip(true)}
+              onMouseLeave={() => setShowStatsTooltip(false)}
+              onFocus={() => setShowStatsTooltip(true)}
+              onBlur={() => setShowStatsTooltip(false)}
+              tabIndex={0}
+            >
+              <span>Today <span className="text-neutral-200">{fmtHours(stats.today)}</span></span>
+              <span className="text-neutral-700">·</span>
+              <span>Week <span className="text-neutral-200">{fmtHours(stats.week)}</span></span>
+              <span className="text-neutral-700">·</span>
+              <span>Month <span className="text-neutral-200">{fmtHours(stats.month)}</span></span>
+              {showStatsTooltip && (
+                <div className="absolute top-6 right-0 z-50 min-w-[220px] p-2 text-[10px] leading-snug text-neutral-200 bg-neutral-900 border border-white/15 rounded shadow-lg">
+                  <div className="mb-1 text-neutral-400 uppercase tracking-wider text-[9px]">Per project</div>
+                  {Object.entries(stats.by_project).length === 0 && (
+                    <div className="text-neutral-500">No activity logged yet</div>
+                  )}
+                  {Object.entries(stats.by_project).map(([id, s]) => (
+                    <div key={id} className="flex items-baseline gap-2">
+                      <span className="text-neutral-400 truncate flex-1">{id}</span>
+                      <span className="tabular-nums text-neutral-200">{fmtHours(s.month)}</span>
+                      <span className="text-neutral-600 text-[9px]">/ mo</span>
+                    </div>
+                  ))}
+                  <div className="mt-1 pt-1 border-t border-white/10 text-neutral-500">
+                    Lifetime: <span className="text-neutral-200">{fmtHours(stats.total)}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
           <button
             type="button"
             onClick={() => setAboutOpen(true)}


### PR DESCRIPTION
Fixes #312
Tracker: realproject7/agent-os#430
Master: #317 (Batch 32 Phase 6 — final Batch 32 ticket)

## Summary
Track per-agent active processing time across projects, surface it in the top header on every page, and build a home-page hero stat block that doubles as the marketing surface.

**Backend (`server/routes.js`):**
- `POST /api/activity/log` — buffers `start` events in-memory keyed by `${project}/${agent}`, matches them to `end` events and appends `{agent, start, end, duration_ms}` to `~/.quadwork/{project}/activity.jsonl`. Orphan ends (server restart mid-session) drop silently instead of writing bogus rows.
- `GET /api/activity/stats` — aggregates every `~/.quadwork/*/activity.jsonl` into local-timezone today / this-week (Mon start) / this-month / lifetime buckets, returns hours rounded to 0.001, includes a `by_project` breakdown. Cached 30s, invalidated on every new log row.

**Frontend (`TerminalGrid.tsx`):**
- New `sessionActiveRef` mirror of the existing activity ring state. On each 500ms tick, walk all agents and detect idle→active and active→idle transitions; POST to `/api/activity/log` as `start` / `end`. Fire-and-forget — losing a session just under-counts the stat. Existing ring logic untouched.

**Frontend (`TopHeader.tsx`):**
- New inline `Today · Week · Month` stat block in the right-hand actions row, polls `/api/activity/stats` every 60s. Hover/focus tooltip shows per-project breakdown + lifetime total. Hidden below `md`.

**Frontend (`HomeDashboard.tsx`):**
- New `ActivityHero` component above the Projects header. Big lifetime-hours figure in accent color, rotating tagline picked once per mount from a 10-option list (sleep / runs / touch grass / dates / cooked dinner / …), three-column footer mirroring the top header. Empty state when `stats.total === 0`.

## Acceptance criteria
- [x] Backend activity logging + stats API
- [x] Top header shows Today/Week/Month
- [x] Home hero stat block + empty state
- [x] Tooltip includes per-project breakdown
- [x] UI/data shape matches the ticket's sketches

## Test plan
- [x] `node --check server/routes.js`
- [x] `tsc --noEmit` clean
- [ ] Reviewers: run a session, watch the activity ring trip, confirm `~/.quadwork/{id}/activity.jsonl` gets rows; wait a minute and confirm the top-header stat updates; open /home and confirm the hero renders with the lifetime figure

🤖 Generated with [Claude Code](https://claude.com/claude-code)