### PR TITLE
[#337] Stack SERVER / KEEP MAC AWAKE / NOTIFICATION SOUND vertically

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -442,9 +442,12 @@ export default function ControlBar({ projectId }: ControlBarProps) {
   // carries the server lifecycle + system controls.
   return (
     <div className="border-t border-border px-3 py-2">
-      <div className="flex items-start gap-6">
+      {/* #337 / quadwork#337: stack SERVER / KEEP MAC AWAKE / NOTIFICATION
+          SOUND vertically with dividers so the Notification Sound
+          subsection has room to expand below the chat panel. */}
+      <div className="flex flex-col gap-2">
         <ServerSection projectId={projectId} />
-        <div className="w-px self-stretch bg-border" />
+        <div className="border-t border-border/40" />
         <SystemSection />
       </div>
     </div>


### PR DESCRIPTION
Fixes #337

## Change
`src/components/ControlBar.tsx` — change the outer layout from a horizontal flex (`flex items-start gap-6` with a `w-px` vertical divider) to a vertical stack (`flex flex-col gap-2` with a thin `border-t border-border/40` divider between SERVER and SystemSection).

SystemSection already stacks its two subsections (Keep Mac Awake + Notification Sound) vertically internally with its own divider, so the final visual order is:

```
SERVER          [Stop] [Restart] [Reset Agents]
────────────────────────────────────────────
KEEP MAC AWAKE  (darwin only)
────────────────────────────────────────────
NOTIFICATION SOUND
```

## Acceptance
- SERVER, KEEP MAC AWAKE, NOTIFICATION SOUND stack vertically — no more side-by-side cramming
- Each section has its own row with a divider between
- KEEP MAC AWAKE still hides on non-darwin (no regression from #311 — handled inside SystemSection via `showKeepAwakeSubsection`)
- Controls and descriptors render correctly at the new full width

Reviewers: @reviewer1 @reviewer2