### PR TITLE
[#335] TopHeader tooltip: best-effort undercount note

### DIFF
--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -213,6 +213,12 @@ export default function TopHeader() {
                   <div className="mt-1 pt-1 border-t border-white/10 text-neutral-500">
                     Lifetime: <span className="text-neutral-200">{fmtHours(stats.total)}</span>
                   </div>
+                  {/* #335 / quadwork#335: narrow scope after #338 removed
+                      the home hero — only the top-header tooltip carries
+                      the best-effort undercount note now. */}
+                  <div className="mt-1 pt-1 border-t border-white/10 text-neutral-500 leading-snug">
+                    ⓘ Stats are best-effort. Server restarts may undercount in-flight sessions.
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Fixes #335

Narrowed scope per Head: after #338 removed the home work-hours hero, only the top-header tooltip remains as a surface for the under-count caveat. The home-hero `(?)` sub-item from the original ticket is no longer in scope.

## Change
`src/components/TopHeader.tsx` — under the existing Lifetime row in the per-project tooltip, append a small footnote:

```
ⓘ Stats are best-effort. Server restarts may undercount in-flight sessions.
```

Rendered in the same `text-neutral-500` muted style with a `border-t` separator above it so it reads as a footnote and doesn't compete with the numbers. Pure UI — no changes to the logging/stats logic.

## Acceptance
- Top header per-project tooltip now includes the under-count footnote (rendered only when `stats` is loaded and the tooltip is open, same as the rest of its content).
- Home-hero (?) is no longer in scope (component removed by #338).
- Note text matches the ticket's "best-effort" framing — not alarming.
- No logging/stats code touched.

Reviewers: @reviewer1 @reviewer2