### PR TITLE
[#342] Queue watcher: inject agent identity into prompts

### DIFF
--- a/server/queue-watcher.js
+++ b/server/queue-watcher.js
@@ -11,14 +11,57 @@
  * Reference: /Users/cho/Projects/agentchattr/wrapper.py lines 438-541
  * (`_queue_watcher`). Polling (not fs.watch) is intentional: matches
  * wrapper.py's behavior and avoids the cross-platform fs.watch
- * footguns. The role/rules/identity-hint additions from wrapper.py
- * lines 501-528 are intentionally out of scope for v1 per the issue.
+ * footguns.
+ *
+ * #342 / quadwork#342: the v1 prompt intentionally omitted the
+ * identity hints from wrapper.py lines 501-528, which broke
+ * Claude Code agent sessions. Claude's default self-concept is
+ * `@claude`, so a bare `mcp read #general - you were mentioned`
+ * causes chat_read(sender: "claude") and a filter on `@claude`
+ * mentions — both wrong when the agent is actually @dev /
+ * @reviewerN. Codex doesn't trip the same way because its init
+ * path already claims identity. The fix here is to scope the
+ * wrapper.py additions to identity only: the injected prompt
+ * now explicitly names the agent slug and tells the agent which
+ * sender to use on chat_read and which mentions to look for.
  */
 
 const fs = require("fs");
 const path = require("path");
 
 const POLL_INTERVAL_MS = 1000;
+
+/**
+ * Pure helper: build the injected prompt text for a given agent
+ * slug + trigger shape. Exported so it can be unit-tested without
+ * a PTY or a filesystem queue. Priority matches the tick() call
+ * site below: customPrompt > jobId > channel.
+ *
+ * agentName is expected to be the registered agent slug such as
+ * `dev`, `head`, `reviewer1`, `reviewer2`. The helper does not
+ * validate — upstream already controls who may register.
+ */
+function buildInjectionPrompt(agentName, { channel, jobId, customPrompt } = {}) {
+  if (customPrompt && typeof customPrompt === "string" && customPrompt.trim()) {
+    // Operator-supplied prompts already control the identity
+    // wording; leave them alone.
+    return customPrompt.trim();
+  }
+  if (jobId) {
+    return (
+      `You are @${agentName} in this AgentChattr instance. ` +
+      `mcp read job_id=${jobId} with sender: "${agentName}" — ` +
+      `you (@${agentName}) were mentioned in a job thread, take appropriate action.`
+    );
+  }
+  const ch = channel || "general";
+  return (
+    `You are @${agentName} in this AgentChattr instance. ` +
+    `mcp read #${ch} with sender: "${agentName}" — ` +
+    `look for @${agentName} mentions (NOT @claude). ` +
+    `You were mentioned, take appropriate action.`
+  );
+}
 
 /**
  * Start polling `{dataDir}/{agentName}_queue.jsonl`. When non-empty,
@@ -78,14 +121,7 @@ function startQueueWatcher(dataDir, agentName, ptyTerm) {
       }
       if (!hasTrigger) return;
 
-      let prompt;
-      if (customPrompt) {
-        prompt = customPrompt;
-      } else if (jobId) {
-        prompt = `mcp read job_id=${jobId} - you were mentioned in a job thread, take appropriate action`;
-      } else {
-        prompt = `mcp read #${channel} - you were mentioned, take appropriate action`;
-      }
+      const prompt = buildInjectionPrompt(agentName, { channel, jobId, customPrompt });
 
       // Flatten newlines: multi-line writes trigger paste detection in
       // Claude Code (shows "[Pasted text +N]") and can break injection
@@ -122,4 +158,5 @@ function stopQueueWatcher(handle) {
 module.exports = {
   startQueueWatcher,
   stopQueueWatcher,
+  buildInjectionPrompt,
 };

--- a/server/queue-watcher.test.js
+++ b/server/queue-watcher.test.js
@@ -1,0 +1,64 @@
+// #342 / quadwork#342: unit test for the identity-aware prompt
+// builder. No test runner is wired up in this repo, so this file
+// is a plain node:assert script — run it with `node server/queue-watcher.test.js`
+// and it exits non-zero on any failure.
+
+const assert = require("node:assert/strict");
+const { buildInjectionPrompt } = require("./queue-watcher");
+
+const DEFAULT_AGENT_SLUGS = ["dev", "head", "reviewer1", "reviewer2"];
+
+// 1) Channel prompt — each of the 4 default slugs must:
+//    - name the agent with @<slug>
+//    - pass sender: "<slug>" explicitly
+//    - tell the agent to look for @<slug> mentions (NOT @claude)
+for (const slug of DEFAULT_AGENT_SLUGS) {
+  const p = buildInjectionPrompt(slug, { channel: "general" });
+  assert.match(p, new RegExp(`You are @${slug} `), `channel: names @${slug}`);
+  assert.match(p, new RegExp(`sender: "${slug}"`), `channel: sender string for ${slug}`);
+  assert.match(p, new RegExp(`@${slug} mentions`), `channel: @${slug} mention filter`);
+  assert.match(p, /NOT @claude/, `channel: explicit NOT @claude guard for ${slug}`);
+  assert.match(p, /#general/, `channel: channel name for ${slug}`);
+}
+
+// 2) Channel defaults to "general" when not provided.
+{
+  const p = buildInjectionPrompt("dev", {});
+  assert.match(p, /#general/, "channel defaults to general");
+}
+
+// 3) Non-default channel is passed through.
+{
+  const p = buildInjectionPrompt("dev", { channel: "batch-33" });
+  assert.match(p, /#batch-33/, "custom channel is used");
+}
+
+// 4) Job-thread prompt — each slug must:
+//    - name the agent with @<slug>
+//    - reference the job_id
+//    - pass sender: "<slug>" explicitly
+for (const slug of DEFAULT_AGENT_SLUGS) {
+  const p = buildInjectionPrompt(slug, { jobId: "42" });
+  assert.match(p, new RegExp(`You are @${slug} `), `job: names @${slug}`);
+  assert.match(p, /job_id=42/, `job: job_id for ${slug}`);
+  assert.match(p, new RegExp(`sender: "${slug}"`), `job: sender string for ${slug}`);
+}
+
+// 5) customPrompt wins over channel and jobId and is returned as-is.
+{
+  const p = buildInjectionPrompt("dev", {
+    channel: "general",
+    jobId: "99",
+    customPrompt: "  do the thing  ",
+  });
+  assert.equal(p, "do the thing", "customPrompt overrides + trims");
+}
+
+// 6) Blank customPrompt is ignored (falls through to channel/job path).
+{
+  const p = buildInjectionPrompt("reviewer2", { customPrompt: "   ", channel: "general" });
+  assert.match(p, /You are @reviewer2 /);
+  assert.match(p, /#general/);
+}
+
+console.log(`queue-watcher.test.js: all assertions passed (${DEFAULT_AGENT_SLUGS.length * 2 + 4} cases)`);


### PR DESCRIPTION
Fixes #342

## Problem
Claude-backed agent sessions (`@dev` and `@reviewer2` in this repo, but the bug affects any project that runs Claude Code for any t-agent role) were looping. The v1 queue-watcher prompt was `mcp read #general - you were mentioned, take appropriate action` — Claude's default self-concept is `@claude`, so it called `chat_read(sender: "claude")`, filtered for `@claude` mentions, found none, and concluded "no action required". Codex sessions (`@head`, `@reviewer1`) don't trip the same way because Codex's init path claims identity.

## Change
`server/queue-watcher.js`:
- Extract a pure `buildInjectionPrompt(agentName, { channel, jobId, customPrompt })` helper and export it. tick() now delegates to the helper; the channel / job / customPrompt priority is unchanged.
- Channel path now emits:
  `You are @<slug> in this AgentChattr instance. mcp read #<ch> with sender: "<slug>" — look for @<slug> mentions (NOT @claude). You were mentioned, take appropriate action.`
- Job-thread path emits the equivalent keyed on `job_id=<id>`.
- `customPrompt` is still passed through so operator-supplied prompts retain full control.
- Newline flattening + delayed Enter (Codex TUI) are untouched.
- The stale `// identity-hint additions intentionally out of scope for v1` comment is rewritten to document the #342 scope.

`server/queue-watcher.test.js` (new): plain `node:assert` script — no test runner is wired up in this repo, so it's runnable with `node server/queue-watcher.test.js`. 12 assertions covering the 4 default slugs (dev / head / reviewer1 / reviewer2) on both the channel and job-thread paths, plus customPrompt override, blank-override fall-through, and the channel default.

## Acceptance
- Dev / Reviewer2 (Claude Code) will now receive an identity-tagged prompt naming their slug and telling them to call `chat_read(sender: "<slug>")` + filter on `@<slug>` mentions. Per the ticket, a manual follow-up verification pass on quadwork + dropcast is expected after merge — the unit test proves the text for each of the 4 default agent slugs.
- Head / Reviewer1 (Codex) behavior unchanged: they'll get a slightly longer prompt naming them, but the existing newline flattening + delayed Enter keep Codex TUI submission working.
- Operator-supplied `customPrompt` still wins — no wording change there.

## Test output
```
$ node server/queue-watcher.test.js
queue-watcher.test.js: all assertions passed (12 cases)
```

Reviewers: @reviewer1 @reviewer2