### PR TITLE
[#341] parseActiveBatch: accept GFM checkbox items

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -1253,10 +1253,11 @@ function parseActiveBatch(queueText) {
   const batchNumber = batchMatch ? parseInt(batchMatch[1], 10) : null;
   // Only collect issue numbers from lines that look like list-item
   // entries — i.e. lines whose first content token is either `#N`
-  // or `[#N]` after an optional list marker. This rejects prose
-  // like "Tracking umbrella: #293", "next after #294 merged", and
-  // similar dependency / commentary references that t2a flagged on
-  // realproject7/dropcast's queue.
+  // or `[#N]` after an optional list marker, and optionally after
+  // a GitHub-flavored markdown checkbox token `[ ]` / `[x]` / `[X]`.
+  // This rejects prose like "Tracking umbrella: #293", "next after
+  // #294 merged", and similar dependency / commentary references
+  // that t2a flagged on realproject7/dropcast's queue.
   //
   // Accepted line shapes:
   //   - #295 sub-A heartbeat
@@ -1265,12 +1266,22 @@ function parseActiveBatch(queueText) {
   //   #295 sub-A heartbeat
   //   - [#295] sub-A heartbeat
   //   [#295] sub-A heartbeat
+  //   - [ ] #295 sub-A heartbeat      (#342/quadwork#341: GFM checkbox)
+  //   - [x] #295 sub-A heartbeat      (checked)
+  //   - [X] #295 sub-A heartbeat      (checked, uppercase)
   //
   // Rejected:
   //   Tracking umbrella: #293
   //   Assigned next after #294 merged.
   //   See #295 for context.
-  const ITEM_LINE_RE = /^\s*(?:[-*]\s+|\d+\.\s+)?\[?#(\d{1,6})\]?\b/;
+  //
+  // The previous regex permitted an optional `[` *immediately*
+  // before `#`, which happened to match `[#295]` but not `[ ] #295`
+  // (a space between `[` and `#`), so Head-generated queues that
+  // used GFM checkbox syntax produced zero issue numbers and the
+  // Current Batch panel showed empty. #341 adds an explicit optional
+  // checkbox token after the list marker.
+  const ITEM_LINE_RE = /^\s*(?:[-*]\s+|\d+\.\s+)?(?:\[[ xX]\]\s+)?\[?#(\d{1,6})\]?\b/;
   const seen = new Set();
   const issueNumbers = [];
   for (const line of section.split("\n")) {
@@ -2475,3 +2486,7 @@ router.post("/api/telegram", async (req, res) => {
 });
 
 module.exports = router;
+// #341: export parseActiveBatch for unit tests. No production callers
+// outside this file; the export is strictly for the node:assert
+// script at server/routes.parseActiveBatch.test.js.
+module.exports.parseActiveBatch = parseActiveBatch;

--- a/server/routes.parseActiveBatch.test.js
+++ b/server/routes.parseActiveBatch.test.js
@@ -1,0 +1,88 @@
+// #341 / quadwork#341: parseActiveBatch regex tests. Plain
+// node:assert script — no test runner is wired up. Run with
+// `node server/routes.parseActiveBatch.test.js`.
+//
+// parseActiveBatch is re-exported from server/routes.js for this
+// test only; it has no production callers outside routes.js.
+
+const assert = require("node:assert/strict");
+const { parseActiveBatch } = require("./routes");
+
+function wrap(body, batchLine = "**Batch:** 33") {
+  return `# Overnight Queue\n\n## Active Batch\n\n${batchLine}\n\n${body}\n\n## Backlog\n\n- #999 something else\n`;
+}
+
+// 1) #341 regression: GFM checkbox items (space between `[` and `#`)
+//    must populate the list.
+{
+  const text = wrap(
+    [
+      "- [ ] #338 — Remove home hero",
+      "- [ ] #337 — Stack SERVER",
+      "- [x] #332 — Commit port drafts",
+      "- [X] #334 — Snapshot stale check",
+    ].join("\n"),
+  );
+  const { batchNumber, issueNumbers } = parseActiveBatch(text);
+  assert.equal(batchNumber, 33, "batch number parsed");
+  assert.deepEqual(issueNumbers, [338, 337, 332, 334], "checkbox items parsed in order");
+}
+
+// 2) Existing shapes keep working.
+{
+  const text = wrap(
+    [
+      "- #295 sub-A heartbeat",
+      "* #296 sub-B",
+      "1. #297 sub-C",
+      "#298 sub-D",
+      "- [#299] sub-E",
+      "[#300] sub-F",
+    ].join("\n"),
+  );
+  const { issueNumbers } = parseActiveBatch(text);
+  assert.deepEqual(issueNumbers, [295, 296, 297, 298, 299, 300], "legacy shapes still parsed");
+}
+
+// 3) Prose references still rejected.
+{
+  const text = wrap(
+    [
+      "- [ ] #400 real item",
+      "Tracking umbrella: #293",
+      "Assigned next after #294 merged.",
+      "See #295 for context.",
+    ].join("\n"),
+  );
+  const { issueNumbers } = parseActiveBatch(text);
+  assert.deepEqual(issueNumbers, [400], "prose references rejected, only real item kept");
+}
+
+// 4) De-dup: same issue number on multiple lines collapses.
+{
+  const text = wrap(
+    [
+      "- [ ] #100 first mention",
+      "- [x] #100 second mention",
+      "- [ ] #101 another",
+    ].join("\n"),
+  );
+  const { issueNumbers } = parseActiveBatch(text);
+  assert.deepEqual(issueNumbers, [100, 101], "de-dup keeps first occurrence");
+}
+
+// 5) Items in Backlog section are NOT picked up.
+{
+  const text = wrap("- [ ] #500 active item");
+  const { issueNumbers } = parseActiveBatch(text);
+  assert.deepEqual(issueNumbers, [500], "Backlog section not scanned");
+}
+
+// 6) Empty / missing Active Batch returns empty.
+{
+  const { batchNumber, issueNumbers } = parseActiveBatch("# no active batch here\n");
+  assert.equal(batchNumber, null);
+  assert.deepEqual(issueNumbers, []);
+}
+
+console.log("routes.parseActiveBatch.test.js: all assertions passed (6 cases)");


### PR DESCRIPTION
Fixes #341

## Problem
`ITEM_LINE_RE` in `parseActiveBatch()` (server/routes.js) allowed an optional `[` only *immediately* before `#`, so `[#295]` matched but `- [ ] #295` (GFM checkbox with a space between `[` and `#`) did not. Head naturally writes trackable items as `- [ ] #N ...`, so fresh queues rendered an empty Current Batch panel — the workaround in the earlier chat session was to rewrite the queue as plain list items, which this PR removes the need for.

## Change
`server/routes.js`:
- Extend `ITEM_LINE_RE` with an explicit optional checkbox token after the list marker: `(?:\[[ xX]\]\s+)?`. Accepts `[ ]` / `[x]` / `[X]`.
- Expand the accepted-shapes comment block to document the new checkbox variants and the root cause.
- Re-export `parseActiveBatch` from `module.exports` — **test-only**; no production callers outside this file.

`server/routes.parseActiveBatch.test.js` (new): plain `node:assert` script, runnable with `node server/routes.parseActiveBatch.test.js`. 6 cases covering:
1. The #341 regression — `- [ ] #N` / `- [x] #N` / `- [X] #N` items populate the list in order
2. Legacy shapes (`- #N`, `* #N`, `1. #N`, `#N`, `- [#N]`, `[#N]`) still parsed
3. Prose references (`Tracking umbrella: #293`, `See #295 for context.`) still rejected
4. De-dup keeps first occurrence
5. Backlog section not scanned
6. Empty / missing Active Batch returns `{ batchNumber: null, issueNumbers: [] }`

## Acceptance
- `- [ ] #338 — ...` populates the Current Batch panel with the correct batch number and item list
- Existing supported shapes continue to work
- Prose references still rejected

## Test output
```
$ node server/routes.parseActiveBatch.test.js
routes.parseActiveBatch.test.js: all assertions passed (6 cases)
```

Reviewers: @reviewer1 @reviewer2