### PR TITLE
[#350] Batch Progress: treat closed-without-PR issues as complete

### DIFF
--- a/server/routes.batchProgress.test.js
+++ b/server/routes.batchProgress.test.js
@@ -1,0 +1,94 @@
+// #350 / quadwork#350: batch-progress no-linked-PR row builder +
+// summarizer tests. Plain node:assert script — run with
+// `node server/routes.batchProgress.test.js`.
+
+const assert = require("node:assert/strict");
+const { buildNoPrRow, summarizeItems } = require("./routes");
+
+// 1) #350 regression fixture: CLOSED issue with no linked PR
+//    must render as 100% complete, not 0% queued.
+{
+  const issue = {
+    number: 336,
+    title: "superseded by #338",
+    state: "CLOSED",
+    url: "https://github.com/realproject7/quadwork/issues/336",
+  };
+  const row = buildNoPrRow(issue);
+  assert.equal(row.status, "closed", "CLOSED with no PR → status=closed");
+  assert.equal(row.progress, 100, "CLOSED with no PR → 100%");
+  assert.match(row.label, /Closed.*✓/, "label has Closed and ✓ marker");
+  assert.equal(row.issue_number, 336);
+  assert.equal(row.url, issue.url);
+}
+
+// 2) OPEN issue with no linked PR still renders as queued.
+{
+  const issue = {
+    number: 400,
+    title: "still open",
+    state: "OPEN",
+    url: "https://github.com/realproject7/quadwork/issues/400",
+  };
+  const row = buildNoPrRow(issue);
+  assert.equal(row.status, "queued", "OPEN with no PR → queued");
+  assert.equal(row.progress, 0);
+  assert.equal(row.label, "Issue · queued");
+}
+
+// 3) summarizeItems with a mix of merged and closed-without-PR:
+//    should count both toward the complete total, label "complete"
+//    when closed > 0.
+{
+  const items = [
+    { status: "merged" },
+    { status: "merged" },
+    { status: "merged" },
+    { status: "merged" },
+    { status: "merged" },
+    { status: "closed" },
+    { status: "closed" },
+  ];
+  const out = summarizeItems(items);
+  assert.equal(out, "7/7 complete", "mixed merged+closed → X/N complete");
+}
+
+// 4) summarizeItems with only merged items keeps the classic
+//    "X/N merged" wording (no behavior change for PR-only batches).
+{
+  const items = [
+    { status: "merged" },
+    { status: "merged" },
+    { status: "merged" },
+  ];
+  assert.equal(summarizeItems(items), "3/3 merged");
+}
+
+// 5) summarizeItems with a queued + closed mix: done count is
+//    closed only, queued surfaces in the detail tail.
+{
+  const items = [
+    { status: "closed" },
+    { status: "queued" },
+    { status: "queued" },
+  ];
+  assert.equal(summarizeItems(items), "1/3 complete · 2 queued");
+}
+
+// 6) summarizeItems with in-flight PR states still tallies them
+//    in the detail tail and keeps the done count at merged-only.
+{
+  const items = [
+    { status: "merged" },
+    { status: "ready" },
+    { status: "approved1" },
+    { status: "in_review" },
+    { status: "queued" },
+  ];
+  assert.equal(
+    summarizeItems(items),
+    "1/5 merged · 1 ready to merge · 1 needs 2nd approval · 1 in review · 1 queued",
+  );
+}
+
+console.log("routes.batchProgress.test.js: all assertions passed (6 cases)");

--- a/server/routes.js
+++ b/server/routes.js
@@ -1118,11 +1118,13 @@ router.get("/api/github/merged-prs", (req, res) => {
 // deterministic from issue/PR state — no agent inference.
 //
 // Progress mapping (from upstream issue):
-//   queued    0%   issue exists, no linked PR
+//   queued    0%   issue OPEN, no linked PR
 //   in_review 20%  PR open, 0 approvals
 //   approved1 50%  PR open, 1 approval
 //   ready     80%  PR open, 2+ approvals
 //   merged   100%  PR merged AND issue closed
+//   closed   100%  issue CLOSED with no linked PR (superseded,
+//                  not planned, or runbook-only tasks) — #350
 //
 // Cached for 10s per project to avoid hammering gh on every poll.
 
@@ -1313,6 +1315,32 @@ async function ghJsonExecAsync(args) {
   return JSON.parse(stdout);
 }
 
+// #350: pure helper for the "no linked PR" branch of
+// progressForItemAsync. Takes the issue JSON (shape: { number,
+// title, state, url, ... }) and returns the batch-progress row
+// for an item that has no closedByPullRequestsReferences. Exported
+// from module.exports below for unit tests — no other callers.
+function buildNoPrRow(issue) {
+  if (issue && issue.state === "CLOSED") {
+    return {
+      issue_number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      status: "closed",
+      progress: 100,
+      label: "Closed (no PR) ✓",
+    };
+  }
+  return {
+    issue_number: issue.number,
+    title: issue.title,
+    url: issue.url,
+    status: "queued",
+    progress: 0,
+    label: "Issue · queued",
+  };
+}
+
 async function progressForItemAsync(repo, issueNumber) {
   // Pull issue state + linked PRs in one call. closedByPullRequestsReferences
   // is gh's serializer for the GraphQL `closedByPullRequestsReferences`
@@ -1339,16 +1367,14 @@ async function progressForItemAsync(repo, issueNumber) {
   const pr = linked.length > 0
     ? linked.slice().sort((a, b) => (b.number || 0) - (a.number || 0))[0]
     : null;
-  // No linked PR yet — queued.
+  // No linked PR. #350: before falling into the "queued" bucket,
+  // honor the issue's own state — a CLOSED issue with no linked
+  // PR is fully done (superseded, not planned, runbook-only, etc.)
+  // and should render at 100% with a ✓ label instead of a
+  // misleading "0% · queued" row. Only truly OPEN issues with no
+  // linked PR are still queued.
   if (!pr) {
-    return {
-      issue_number: issue.number,
-      title: issue.title,
-      url: issue.url,
-      status: "queued",
-      progress: 0,
-      label: "Issue · queued",
-    };
+    return buildNoPrRow(issue);
   }
   // Re-fetch the PR to get reviewDecision + reviews + state, since
   // the issue's closedByPullRequestsReferences edge only carries
@@ -1452,15 +1478,23 @@ async function progressForItemAsync(repo, issueNumber) {
 }
 
 function summarizeItems(items) {
-  let merged = 0, ready = 0, approved1 = 0, inReview = 0, queued = 0;
+  // #350: "closed" (CLOSED issue with no linked PR — superseded,
+  // not planned, runbook-only) counts toward the complete tally
+  // alongside "merged". The panel tally now reads "X/N complete"
+  // when the batch mixes both kinds of completion, otherwise
+  // "X/N merged" for the classic all-via-PR case.
+  let merged = 0, closed = 0, ready = 0, approved1 = 0, inReview = 0, queued = 0;
   for (const it of items) {
     if (it.status === "merged") merged++;
+    else if (it.status === "closed") closed++;
     else if (it.status === "ready") ready++;
     else if (it.status === "approved1") approved1++;
     else if (it.status === "in_review") inReview++;
     else if (it.status === "queued") queued++;
   }
-  const parts = [`${merged}/${items.length} merged`];
+  const done = merged + closed;
+  const doneLabel = closed > 0 ? "complete" : "merged";
+  const parts = [`${done}/${items.length} ${doneLabel}`];
   if (ready > 0) parts.push(`${ready} ready to merge`);
   if (approved1 > 0) parts.push(`${approved1} needs 2nd approval`);
   if (inReview > 0) parts.push(`${inReview} in review`);
@@ -1544,7 +1578,10 @@ router.get("/api/batch-progress", async (req, res) => {
     };
   });
   const summary = summarizeItems(items);
-  const complete = items.length > 0 && items.every((it) => it.status === "merged");
+  // #350: treat CLOSED-without-PR items as complete alongside merged
+  // so batches that mix runbook/superseded closes with real PRs
+  // still flip to the COMPLETE state once everything is done.
+  const complete = items.length > 0 && items.every((it) => it.status === "merged" || it.status === "closed");
   const data = { batch_number: batchNumber, items, summary, complete };
   _batchProgressCache.set(projectId, { ts: Date.now(), data });
   res.json(data);
@@ -2490,3 +2527,7 @@ module.exports = router;
 // outside this file; the export is strictly for the node:assert
 // script at server/routes.parseActiveBatch.test.js.
 module.exports.parseActiveBatch = parseActiveBatch;
+// #350: same pattern — expose the no-linked-PR row builder and
+// summarizeItems for the batch-progress fixture test.
+module.exports.buildNoPrRow = buildNoPrRow;
+module.exports.summarizeItems = summarizeItems;

--- a/src/components/BatchProgressPanel.tsx
+++ b/src/components/BatchProgressPanel.tsx
@@ -7,7 +7,10 @@ interface BatchProgressItem {
   title: string;
   url: string | null;
   pr_number?: number;
-  status: "queued" | "in_review" | "approved1" | "ready" | "merged" | "unknown";
+  // #350: "closed" = issue CLOSED with no linked PR (superseded,
+  // not planned, or runbook-only). Rendered at 100% like merged
+  // but with a distinct label from the server.
+  status: "queued" | "in_review" | "approved1" | "ready" | "merged" | "closed" | "unknown";
   progress: number; // 0..100
   label: string;
 }


### PR DESCRIPTION
Fixes #350

## Problem
`progressForItemAsync()` returned a `queued` row as soon as the issue had no `closedByPullRequestsReferences`, ignoring the issue's own `state` (which was already fetched in the same gh call). Concrete Batch 1 repro: #336 (closed as superseded by #338) and #333 (GitHub Releases backfill runbook) rendered as `0% · Issue · queued` after the batch was otherwise complete, and the summary line read `5/7 merged · 2 queued` instead of `7/7 complete`.

## Change
`server/routes.js`:
- Extract a pure `buildNoPrRow(issue)` helper. `CLOSED` + no linked PR → `{ status: "closed", progress: 100, label: "Closed (no PR) ✓" }`. `OPEN` + no linked PR keeps the existing queued row. Used by `progressForItemAsync()`'s `if (!pr)` branch.
- Teach `summarizeItems` to count `closed` alongside `merged` in the done tally. When any `closed` items are present the summary reads `X/N complete` (honoring the mixed-completion case); pure PR batches keep the legacy `X/N merged` wording.
- `/api/batch-progress` `complete` flag now accepts both `merged` and `closed` so mixed batches still flip to `✅ COMPLETE`.
- Update the progress-mapping comment header to document the new `closed` bucket.
- Test-only re-export of `buildNoPrRow` + `summarizeItems` (no production callers outside `routes.js`).

`src/components/BatchProgressPanel.tsx`:
- Extend `BatchProgressItem.status` union with `"closed"`. Rendering is unchanged — closed items use the same row template as merged and get the server-supplied `progress: 100` / `label: "Closed (no PR) ✓"`.

`server/routes.batchProgress.test.js` (new): plain `node:assert` script, 6 cases:
1. CLOSED + no linked PR → `status: "closed"`, `progress: 100`, label matches `/Closed.*✓/`
2. OPEN + no linked PR → classic `queued` row (unchanged)
3. 5 merged + 2 closed → `"7/7 complete"`
4. 3 merged only → `"3/3 merged"` (legacy wording preserved)
5. 1 closed + 2 queued → `"1/3 complete · 2 queued"`
6. Full in-flight fixture (merged/ready/approved1/in_review/queued) still tallies correctly

## Acceptance
- Closed-without-PR issues render at 100% with a ✓ label.
- Summary counts closed toward the complete total.
- OPEN issues with no linked PR still render queued.
- Issues closed with a linked merged PR still render merged (that path is unaffected — the PR branch is reached before `buildNoPrRow`).

## Test output
```
$ node server/routes.batchProgress.test.js
routes.batchProgress.test.js: all assertions passed (6 cases)
```

Reviewers: @reviewer1 @reviewer2