### PR TITLE
[#348] Pin AgentChattr to a known commit + doctor command

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -14,6 +14,18 @@ const TEMPLATES_DIR = path.join(__dirname, "..", "templates");
 const AGENTS = ["head", "reviewer1", "reviewer2", "dev"];
 const DEFAULT_AGENTCHATTR_DIR = path.join(CONFIG_DIR, "agentchattr");
 const AGENTCHATTR_REPO = "https://github.com/bcurts/agentchattr.git";
+// #348: pinned AgentChattr commit shipped with this QuadWork
+// release. The install path clones the default branch and then
+// checks this commit out so two fresh installs on different days
+// produce byte-identical clones. When bumping this pin,
+// deliberately test against the new upstream commit first and
+// note the update in docs/RELEASING.md.
+//
+// On checkout failure (e.g. upstream force-pushed the commit
+// away), the install path falls back to the default branch with
+// a loud warning instead of hard-failing — see installAgentChattr
+// below.
+const AGENTCHATTR_PIN = "3e71d4267572579e7ffeb83576645f90932c1849";
 
 // ─── ANSI Helpers ──────────────────────────────────────────────────────────
 
@@ -234,6 +246,14 @@ function _installAgentChattrLocked(dir, setError) {
     const cloneResult = run(`git clone "${AGENTCHATTR_REPO}" "${dir}" 2>&1`, { timeout: 60000 });
     if (cloneResult === null) return setError(`git clone of ${AGENTCHATTR_REPO} into ${dir} failed`);
     if (!fs.existsSync(runPy)) return setError(`Clone completed but run.py missing at ${dir}`);
+    // #348: pin to the known-good AgentChattr commit shipped with
+    // this QuadWork release. On failure (commit unreachable /
+    // force-pushed away), fall back to the default branch with a
+    // loud warning instead of hard-failing the install.
+    const pinResult = run(`git -C "${dir}" checkout ${AGENTCHATTR_PIN} 2>&1`, { timeout: 30000 });
+    if (pinResult === null) {
+      try { console.warn(`[quadwork] WARNING: could not check out AgentChattr pin ${AGENTCHATTR_PIN} at ${dir}; falling back to default branch. The upstream commit may have been force-pushed away — update AGENTCHATTR_PIN in bin/quadwork.js for reproducible installs.`); } catch {}
+    }
   }
 
   // 2. Create venv if missing.
@@ -1877,6 +1897,64 @@ async function cmdCleanup() {
   }
 }
 
+// ─── Doctor ─────────────────────────────────────────────────────────────────
+
+// #348: show the AgentChattr pin and the actual commit SHA of
+// every per-project clone so operators can spot mismatches. The
+// global clone at DEFAULT_AGENTCHATTR_DIR is checked first, then
+// any clones under ~/.quadwork/<projectId>/agentchattr that are
+// referenced by config.json.
+function cmdDoctor() {
+  console.log("");
+  console.log("QuadWork doctor");
+  console.log("===============");
+  console.log(`AgentChattr repo: ${AGENTCHATTR_REPO}`);
+  console.log(`Expected pin:     ${AGENTCHATTR_PIN}`);
+  console.log("");
+  const cloneShaAt = (dir) => {
+    if (!fs.existsSync(path.join(dir, ".git"))) return null;
+    const sha = run(`git -C "${dir}" rev-parse HEAD 2>&1`);
+    return sha ? sha.trim() : null;
+  };
+  const report = (label, dir) => {
+    if (!dir || !fs.existsSync(dir)) {
+      console.log(`  [skip] ${label}: ${dir || "(not configured)"} — missing`);
+      return;
+    }
+    const sha = cloneShaAt(dir);
+    if (!sha) {
+      console.log(`  [warn] ${label}: ${dir} — not a git clone`);
+      return;
+    }
+    const tag = sha === AGENTCHATTR_PIN ? "OK  " : "DIFF";
+    console.log(`  [${tag}] ${label}: ${sha} (${dir})`);
+  };
+  // Global clone
+  report("global", DEFAULT_AGENTCHATTR_DIR);
+  // Per-project clones referenced by config.json
+  try {
+    const cfg = readConfig();
+    const projects = Array.isArray(cfg.projects) ? cfg.projects : [];
+    if (projects.length === 0) {
+      console.log("  (no projects in config.json)");
+    }
+    for (const p of projects) {
+      // Per-project clones live under ~/.quadwork/<id>/agentchattr
+      // per cmdAddProject's layout, but a project may also override
+      // via its own agentchattr_dir field.
+      const perProject = p && p.agentchattr_dir
+        ? p.agentchattr_dir
+        : path.join(CONFIG_DIR, p.id || "", "agentchattr");
+      report(`project:${p.id || "(unnamed)"}`, perProject);
+    }
+  } catch (err) {
+    console.log(`  (could not enumerate projects: ${err.message})`);
+  }
+  console.log("");
+  console.log("Legend: [OK  ] clone matches the pin; [DIFF] clone is off-pin (re-clone manually to re-sync)");
+  console.log("");
+}
+
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 const command = process.argv[2];
@@ -1897,6 +1975,9 @@ switch (command) {
   case "cleanup":
     cmdCleanup();
     break;
+  case "doctor":
+    cmdDoctor();
+    break;
   default:
     console.log(`
   Usage: quadwork <command>
@@ -1907,6 +1988,7 @@ switch (command) {
     stop          Stop all QuadWork processes
     add-project   Add a project via CLI (alternative to web UI /setup)
     cleanup       Reclaim disk space (--project <id> or --legacy)
+    doctor        Report the AgentChattr pin + per-project clone SHAs
 
   Workflow:
     1. npx quadwork init     — one-time global setup, opens dashboard

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -90,6 +90,41 @@ Notes about the loop:
 - Post the release URL in the project chat so the batch reviewers can
   verify the auto-generated notes look sane.
 
+## Bumping the AgentChattr pin (#348)
+
+QuadWork installs AgentChattr via `git clone` and then checks out
+a pinned commit declared in `bin/quadwork.js`:
+
+```js
+const AGENTCHATTR_PIN = "<commit-sha>";
+```
+
+Every fresh `npx quadwork` install produces a byte-identical
+AgentChattr clone at this commit, so two users installing on
+different days land on the same upstream state. When cutting a
+new QuadWork release that needs a newer AgentChattr:
+
+1. Pull the upstream repo locally and pick the target commit
+   (prefer a tag if one exists, otherwise a bare SHA).
+2. Manually install QuadWork against that commit and run the
+   dashboard end-to-end against at least one real project.
+   Verify `quadwork doctor` shows the new pin and reports every
+   per-project clone in-sync (see below).
+3. Update `AGENTCHATTR_PIN` in `bin/quadwork.js` to the new
+   commit and commit it as part of the same release PR.
+4. Note the bump in the release changelog so operators know
+   what upstream changes are rolling in.
+
+Existing installs are **not** auto-updated on `quadwork start`
+— operators may have local commits on top of the old pin, and
+we don't want to silently rewrite their tree. `quadwork doctor`
+will flag the mismatch so they can decide to re-clone manually.
+
+If the pinned commit becomes unreachable (upstream force-push),
+`installAgentChattr` logs a loud warning and falls back to the
+default branch instead of hard-failing the install. The next
+release should update the pin to a reachable commit.
+
 ## Pitfalls
 
 - **Never run `npm run release:*` from a dirty tree.** `npm version` will


### PR DESCRIPTION
Fixes #348

## Problem
`installAgentChattr` used to clone `bcurts/agentchattr` at current HEAD with no ref pinning. Two users installing on different days could end up on different upstream versions, and the same machine could run mismatched AgentChattr across projects — exactly the hard-to-reproduce-bugs scenario called out in the ticket.

## Change
### `bin/quadwork.js`
- New `AGENTCHATTR_PIN` constant set to `3e71d4267572579e7ffeb83576645f90932c1849` (current upstream HEAD of `bcurts/agentchattr` at the time of this commit). Resolved via `git ls-remote https://github.com/bcurts/agentchattr.git HEAD`.
- `installAgentChattr` now follows the clone with `git -C <dir> checkout AGENTCHATTR_PIN`. If the checkout fails (the commit was force-pushed away upstream), log a loud warning and **fall back to the default branch** so the install does not hard-fail — matches the ticket's fallback requirement.
- New `quadwork doctor` subcommand (added to the switch + usage help) enumerates:
  1. The global clone at `DEFAULT_AGENTCHATTR_DIR`
  2. Every per-project clone referenced by `config.json` (either `project.agentchattr_dir` or the default `~/.quadwork/<id>/agentchattr` layout)
  prints each HEAD SHA via `git -C <dir> rev-parse HEAD`, and flags entries with a `[OK  ]` / `[DIFF]` / `[warn]` tag. No auto-rewrite — operators may have local commits on top of the old pin, so the report is advisory only.

### `docs/RELEASING.md`
- New `## Bumping the AgentChattr pin (#348)` section documenting:
  - Where the pin lives (`bin/quadwork.js`)
  - Test-before-commit flow: install against the new commit, run dashboard end-to-end, verify `quadwork doctor` reports the new pin across all per-project clones
  - Rationale for not auto-updating existing installs (operators may have local commits)
  - The force-push fallback behavior and the implicit requirement to bump the pin to a reachable commit on the next release

## Smoke test
Ran `node bin/quadwork.js doctor` on this machine after the change:

```
QuadWork doctor
===============
AgentChattr repo: https://github.com/bcurts/agentchattr.git
Expected pin:     3e71d4267572579e7ffeb83576645f90932c1849

  [OK  ] global: 3e71d4267572579e7ffeb83576645f90932c1849 (~/.quadwork/agentchattr)
  [OK  ] project:dropcast: 3e71d4267572579e7ffeb83576645f90932c1849 (~/.quadwork/dropcast/agentchattr)
  [OK  ] project:quadwork: 3e71d4267572579e7ffeb83576645f90932c1849 (~/.quadwork/quadwork/agentchattr)
```

## Acceptance
- Two fresh `npx quadwork` installs on different days produce byte-identical AgentChattr clones (same commit SHA) — the clone step still hits `git clone` but the subsequent `git checkout AGENTCHATTR_PIN` normalizes to the pin.
- `quadwork doctor` shows the expected pin and the actual SHA of each per-project clone, flagging mismatches.
- Bumping `AGENTCHATTR_PIN` and re-releasing causes **new** installs to pick up the new pin; existing installs stay on their old pin until the operator re-clones (advisory only, no auto-rewrite).
- `docs/RELEASING.md` documents the test-and-bump flow.
- Out-of-scope per the ticket (explicitly deferred): automated CI matrix across AgentChattr versions, publishing as npm, auto-updating existing clones on `quadwork upgrade`.

Reviewers: @reviewer1 @reviewer2