### PR TITLE
[#343] Per-agent model + reasoning-effort settings

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -312,6 +312,32 @@ async function buildAgentArgs(projectId, agentId) {
     if (flags) args.push(...flags);
   }
 
+  // #343: per-agent model + reasoning effort overrides. Persist in
+  // project.agents[agentId].{model,reasoning_effort} via the
+  // dashboard Agent Models widget. When unset, fall back to the
+  // CLI's own default so existing projects without overrides keep
+  // their current behavior.
+  //
+  // Codex: -c model="<slug>" / -c model_reasoning_effort="<level>"
+  //   reasoning levels: minimal | low | medium | high (xhigh is
+  //   deliberately NOT offered — it's the capacity-failure hot
+  //   spot #343 was filed for).
+  // Claude: --model <slug>
+  //   reasoning_effort is not wired for Claude — Anthropic's CLI
+  //   doesn't expose an equivalent flag.
+  if (cliBase === "codex") {
+    if (agentCfg.model && typeof agentCfg.model === "string") {
+      args.push("-c", `model="${agentCfg.model}"`);
+    }
+    if (agentCfg.reasoning_effort && typeof agentCfg.reasoning_effort === "string") {
+      args.push("-c", `model_reasoning_effort="${agentCfg.reasoning_effort}"`);
+    }
+  } else if (cliBase === "claude") {
+    if (agentCfg.model && typeof agentCfg.model === "string") {
+      args.push("--model", agentCfg.model);
+    }
+  }
+
   // MCP config injection
   const mcpHttpPort = project.mcp_http_port;
   const token = project.agentchattr_token;

--- a/server/routes.js
+++ b/server/routes.js
@@ -2074,6 +2074,12 @@ router.post("/api/setup", (req, res) => {
         return res.json({ ok: true, message: "Project already in config" });
       }
       // Match CLI wizard agent structure: { cwd, command, auto_approve, mcp_inject }
+      // #343: default Codex-backed agents to reasoning_effort="medium"
+      // instead of the upstream xhigh/high default. high/xhigh is the
+      // provider-side capacity-failure hot spot; medium is the
+      // safe-default for fresh installs so new projects don't hit
+      // "Selected model is at capacity" out of the box. Operators can
+      // bump individual agents back up via the Agent Models widget.
       const agents = {};
       for (const agentId of ["head", "reviewer1", "reviewer2", "dev"]) {
         const cmd = (backends && backends[agentId]) || "claude";
@@ -2084,6 +2090,7 @@ router.post("/api/setup", (req, res) => {
           command: cmd,
           auto_approve: autoApprove,
           mcp_inject: injectMode,
+          ...(cliBase === "codex" ? { reasoning_effort: "medium" } : {}),
         };
       }
       // Use pre-assigned ports/token from agentchattr-config step if provided,
@@ -2681,6 +2688,74 @@ router.post("/api/telegram", async (req, res) => {
     }
     default:
       return res.status(400).json({ error: "Unknown action" });
+  }
+});
+
+// #343: per-agent model + reasoning-effort settings endpoint.
+// GET returns the rows the dashboard Agent Models widget needs;
+// PUT persists a single row back to config.json. Kept narrow on
+// purpose — only `model` and `reasoning_effort` are writable
+// here, and codex is the only backend that accepts
+// reasoning_effort today. The launch-time wiring lives in
+// server/index.js buildAgentArgs; this endpoint is purely
+// config storage.
+const ALLOWED_REASONING_EFFORTS = new Set(["minimal", "low", "medium", "high"]);
+
+router.get("/api/project/:projectId/agent-models", (req, res) => {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const project = cfg.projects?.find((p) => p.id === req.params.projectId);
+    if (!project) return res.status(404).json({ error: "Unknown project" });
+    const rows = ["head", "reviewer1", "reviewer2", "dev"].map((agentId) => {
+      const a = project.agents?.[agentId] || {};
+      const command = a.command || "claude";
+      const cliBase = command.split("/").pop().split(" ")[0];
+      return {
+        agent_id: agentId,
+        backend: cliBase,
+        model: a.model || "",
+        reasoning_effort: a.reasoning_effort || "",
+        reasoning_supported: cliBase === "codex",
+      };
+    });
+    return res.json({ agents: rows });
+  } catch (err) {
+    return res.status(500).json({ error: err.message || "read failed" });
+  }
+});
+
+router.put("/api/project/:projectId/agent-models/:agentId", (req, res) => {
+  const { projectId, agentId } = req.params;
+  if (!["head", "reviewer1", "reviewer2", "dev"].includes(agentId)) {
+    return res.json({ ok: false, error: "Unknown agent" });
+  }
+  const body = req.body || {};
+  // Accept empty string as "clear override → fall back to CLI default".
+  const model = typeof body.model === "string" ? body.model.trim() : undefined;
+  const reasoning = typeof body.reasoning_effort === "string" ? body.reasoning_effort.trim() : undefined;
+  if (reasoning && reasoning !== "" && !ALLOWED_REASONING_EFFORTS.has(reasoning)) {
+    return res.json({ ok: false, error: `Invalid reasoning_effort: ${reasoning}` });
+  }
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    const cfg = JSON.parse(raw);
+    const project = cfg.projects?.find((p) => p.id === projectId);
+    if (!project) return res.status(404).json({ ok: false, error: "Unknown project" });
+    if (!project.agents) project.agents = {};
+    const a = project.agents[agentId] || {};
+    if (model !== undefined) {
+      if (model === "") delete a.model;
+      else a.model = model;
+    }
+    if (reasoning !== undefined) {
+      if (reasoning === "") delete a.reasoning_effort;
+      else a.reasoning_effort = reasoning;
+    }
+    project.agents[agentId] = a;
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+    return res.json({ ok: true, agent: { agent_id: agentId, model: a.model || "", reasoning_effort: a.reasoning_effort || "" } });
+  } catch (err) {
+    return res.json({ ok: false, error: err.message || "write failed" });
   }
 });
 

--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+// #343: per-agent Model + Reasoning Effort configuration widget.
+// Lives in the Operator Features right column. Reads
+// /api/project/:id/agent-models for the current per-agent rows
+// and PUTs individual rows back to update the persisted config.
+// Each row also has a "Restart" button that hits the existing
+// POST /api/agents/:project/:agent/restart so a changed model/
+// effort picks up without needing the operator to go touch
+// ~/.codex/config.toml outside QuadWork.
+
+import { useCallback, useEffect, useState } from "react";
+
+interface AgentRow {
+  agent_id: string;
+  backend: string;
+  model: string;
+  reasoning_effort: string;
+  reasoning_supported: boolean;
+}
+
+interface AgentModelsWidgetProps {
+  projectId: string;
+}
+
+// No xhigh — explicitly excluded per #343 ("capacity-failure hot spot").
+const REASONING_LEVELS = ["minimal", "low", "medium", "high"] as const;
+
+export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps) {
+  const [rows, setRows] = useState<AgentRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch(`/api/project/${encodeURIComponent(projectId)}/agent-models`);
+      if (!r.ok) throw new Error(`${r.status}`);
+      const data = await r.json();
+      setRows(data.agents || []);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, [projectId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const update = async (agentId: string, patch: Partial<Pick<AgentRow, "model" | "reasoning_effort">>) => {
+    setBusy(agentId);
+    setError(null);
+    try {
+      const r = await fetch(`/api/project/${encodeURIComponent(projectId)}/agent-models/${agentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const data = await r.json();
+      if (!r.ok || data.ok === false) throw new Error(data.error || `${r.status}`);
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const restart = async (agentId: string) => {
+    setBusy(agentId);
+    setError(null);
+    try {
+      const r = await fetch(`/api/agents/${encodeURIComponent(projectId)}/${encodeURIComponent(agentId)}/restart`, { method: "POST" });
+      const data = await r.json();
+      if (!r.ok || data.ok === false) throw new Error(data.error || `${r.status}`);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col border border-border">
+      <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
+        <span className="text-[11px] text-text-muted uppercase tracking-wider">Agent Models</span>
+        {error && <span className="text-[10px] text-error max-w-[60%] truncate" title={error}>err: {error}</span>}
+      </div>
+      <div className="p-2 flex flex-col gap-1.5">
+        {!rows && <div className="text-[11px] text-text-muted">Loading…</div>}
+        {rows && rows.length === 0 && (
+          <div className="text-[11px] text-text-muted">No agents configured.</div>
+        )}
+        {rows && rows.map((row) => (
+          <div key={row.agent_id} className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-[11px] text-text font-semibold w-16 shrink-0">{row.agent_id}</span>
+            <span className="text-[10px] text-text-muted w-12 shrink-0">{row.backend}</span>
+            <input
+              type="text"
+              value={row.model}
+              placeholder="(CLI default)"
+              disabled={busy === row.agent_id}
+              onChange={(e) => {
+                setRows((prev) => prev?.map((r) => (r.agent_id === row.agent_id ? { ...r, model: e.target.value } : r)) || null);
+              }}
+              onBlur={(e) => {
+                if (e.target.value !== row.model || true) {
+                  // Commit the draft on blur so the model text can be retyped
+                  // without hammering the backend on every keystroke.
+                  update(row.agent_id, { model: e.target.value });
+                }
+              }}
+              className="flex-1 min-w-[100px] bg-transparent border border-border px-1.5 py-0.5 text-[11px] font-mono text-text outline-none focus:border-accent disabled:opacity-50"
+            />
+            {row.reasoning_supported ? (
+              <select
+                value={row.reasoning_effort || ""}
+                disabled={busy === row.agent_id}
+                onChange={(e) => update(row.agent_id, { reasoning_effort: e.target.value })}
+                className="bg-transparent border border-border px-1 py-0.5 text-[11px] text-text outline-none focus:border-accent cursor-pointer disabled:opacity-50"
+              >
+                <option value="" className="bg-bg-surface">(default)</option>
+                {REASONING_LEVELS.map((lvl) => (
+                  <option key={lvl} value={lvl} className="bg-bg-surface">{lvl}</option>
+                ))}
+              </select>
+            ) : (
+              <span className="text-[10px] text-text-muted w-16 text-center">—</span>
+            )}
+            <button
+              type="button"
+              onClick={() => restart(row.agent_id)}
+              disabled={busy === row.agent_id}
+              title="Restart this agent to pick up the new model / reasoning setting"
+              className="shrink-0 px-1.5 py-0.5 text-[10px] text-text-muted border border-border hover:text-accent hover:border-accent/40 disabled:opacity-50 transition-colors"
+            >
+              {busy === row.agent_id ? "…" : "Restart"}
+            </button>
+          </div>
+        ))}
+        <p className="mt-1 text-[10px] text-text-muted leading-snug">
+          Codex reasoning effort defaults to <code className="text-text">medium</code> for new projects. Blank model falls back to the CLI default. Click Restart to apply changes to a live session.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -26,10 +26,43 @@ interface AgentModelsWidgetProps {
 // No xhigh — explicitly excluded per #343 ("capacity-failure hot spot").
 const REASONING_LEVELS = ["minimal", "low", "medium", "high"] as const;
 
+// #343 follow-up: backend-specific model dropdown options.
+// Empty string = use the CLI's own default (no -c / --model flag
+// passed at all). The lists below are the known-good slugs we
+// ship with this release; operators who need something bleeding
+// edge can still override by editing ~/.quadwork/config.json
+// directly — this widget is the guided happy path.
+const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> = {
+  codex: [
+    { value: "", label: "(CLI default)" },
+    { value: "gpt-5.4", label: "gpt-5.4" },
+    { value: "gpt-5", label: "gpt-5" },
+    { value: "gpt-4o", label: "gpt-4o" },
+  ],
+  claude: [
+    { value: "", label: "(CLI default)" },
+    { value: "claude-opus-4-6", label: "claude-opus-4-6" },
+    { value: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
+    { value: "claude-haiku-4-5-20251001", label: "claude-haiku-4-5" },
+  ],
+};
+function optionsForBackend(backend: string) {
+  return MODEL_OPTIONS[backend] || [{ value: "", label: "(CLI default)" }];
+}
+
 export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps) {
   const [rows, setRows] = useState<AgentRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  // #343 follow-up: track which agents have edits that haven't
+  // yet been applied to the live session. A row is marked dirty
+  // when the operator saves a new model or reasoning setting via
+  // update(), and cleared only when the operator clicks Restart
+  // on that row (restart() succeeds). Until then the UI shows a
+  // "needs restart" badge next to the agent id so it is visually
+  // obvious which sessions are running stale config — the ticket
+  // explicitly calls this out as a required acceptance.
+  const [needsRestart, setNeedsRestart] = useState<Set<string>>(new Set());
 
   const load = useCallback(async () => {
     try {
@@ -56,6 +89,13 @@ export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps)
       });
       const data = await r.json();
       if (!r.ok || data.ok === false) throw new Error(data.error || `${r.status}`);
+      // #343: config has drifted from the running session until
+      // the operator explicitly restarts this agent.
+      setNeedsRestart((prev) => {
+        const next = new Set(prev);
+        next.add(agentId);
+        return next;
+      });
       await load();
     } catch (e) {
       setError((e as Error).message);
@@ -71,6 +111,13 @@ export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps)
       const r = await fetch(`/api/agents/${encodeURIComponent(projectId)}/${encodeURIComponent(agentId)}/restart`, { method: "POST" });
       const data = await r.json();
       if (!r.ok || data.ok === false) throw new Error(data.error || `${r.status}`);
+      // Running session is now on the new config — clear the
+      // restart-required badge.
+      setNeedsRestart((prev) => {
+        const next = new Set(prev);
+        next.delete(agentId);
+        return next;
+      });
     } catch (e) {
       setError((e as Error).message);
     } finally {
@@ -93,23 +140,34 @@ export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps)
           <div key={row.agent_id} className="flex items-center gap-1.5 flex-wrap">
             <span className="text-[11px] text-text font-semibold w-16 shrink-0">{row.agent_id}</span>
             <span className="text-[10px] text-text-muted w-12 shrink-0">{row.backend}</span>
-            <input
-              type="text"
+            {needsRestart.has(row.agent_id) && (
+              <span
+                className="text-[9px] text-[#ffcc00] border border-[#ffcc00]/40 px-1 py-[1px] shrink-0"
+                title="Config changed — running session is still on the old model/effort. Click Restart to apply."
+              >
+                restart required
+              </span>
+            )}
+            {/* #343: backend-specific model dropdown. Empty value
+                = CLI default (no override). Options come from
+                MODEL_OPTIONS[backend]; unknown backends fall
+                back to just the "(CLI default)" entry. */}
+            <select
               value={row.model}
-              placeholder="(CLI default)"
               disabled={busy === row.agent_id}
-              onChange={(e) => {
-                setRows((prev) => prev?.map((r) => (r.agent_id === row.agent_id ? { ...r, model: e.target.value } : r)) || null);
-              }}
-              onBlur={(e) => {
-                if (e.target.value !== row.model || true) {
-                  // Commit the draft on blur so the model text can be retyped
-                  // without hammering the backend on every keystroke.
-                  update(row.agent_id, { model: e.target.value });
-                }
-              }}
-              className="flex-1 min-w-[100px] bg-transparent border border-border px-1.5 py-0.5 text-[11px] font-mono text-text outline-none focus:border-accent disabled:opacity-50"
-            />
+              onChange={(e) => update(row.agent_id, { model: e.target.value })}
+              className="flex-1 min-w-[140px] bg-transparent border border-border px-1 py-0.5 text-[11px] font-mono text-text outline-none focus:border-accent cursor-pointer disabled:opacity-50"
+            >
+              {optionsForBackend(row.backend).map((opt) => (
+                <option key={opt.value} value={opt.value} className="bg-bg-surface">{opt.label}</option>
+              ))}
+              {/* If the persisted model isn't in the known list
+                  (e.g. operator hand-edited config.json), keep
+                  it selectable so their override doesn't vanish. */}
+              {row.model && !optionsForBackend(row.backend).some((o) => o.value === row.model) && (
+                <option value={row.model} className="bg-bg-surface">{row.model} (custom)</option>
+              )}
+            </select>
             {row.reasoning_supported ? (
               <select
                 value={row.reasoning_effort || ""}

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -5,6 +5,7 @@ import ScheduledTriggerWidget from "./ScheduledTriggerWidget";
 import TelegramBridgeWidget from "./TelegramBridgeWidget";
 import LoopGuardWidget from "./LoopGuardWidget";
 import ProjectHistoryWidget from "./ProjectHistoryWidget";
+import AgentModelsWidget from "./AgentModelsWidget";
 
 /**
  * Bottom-right quadrant of the project dashboard (#208).
@@ -47,6 +48,7 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
         {/* Right column: Telegram Bridge → Loop Guard → Project
             History. Scrolls independently of the left column. */}
         <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto flex flex-col gap-2">
+          <AgentModelsWidget projectId={projectId} />
           <TelegramBridgeWidget projectId={projectId} />
           <LoopGuardWidget projectId={projectId} />
           <ProjectHistoryWidget projectId={projectId} />


### PR DESCRIPTION
Fixes #343

## Problem
When a Codex or Claude backend hit an upstream 429/overload, the only workaround was hand-editing `~/.codex/config.toml` / `~/.claude/settings.json` outside QuadWork and relaunching the worktree. Concrete repro: on 2026-04-09 Reviewer1 (Codex, upstream `gpt-5.4 xhigh`) was blocked by 'Selected model is at capacity' mid-batch, and dropping to `medium` would have unblocked it instantly but required out-of-band surgery.

## Change

### Server
- **`server/index.js` `buildAgentArgs`** — after the permission flags, inject model + reasoning-effort args from `project.agents[agentId]`:
  - Codex: `-c model="<slug>"` and `-c model_reasoning_effort="<level>"`
  - Claude: `--model <slug>` (no `reasoning_effort` — Anthropic's CLI has no equivalent flag)
  Both fields are optional; when unset the launch still falls through to the CLI's own default so existing projects without overrides keep their current behavior.
- **`server/routes.js` `add-config`** — new projects created via the web wizard now default Codex-backed agents to `reasoning_effort: "medium"`. `xhigh` is deliberately **never** written by QuadWork (it's the capacity-failure hot spot this ticket was filed against).
- **`server/routes.js`** new endpoints:
  - `GET /api/project/:projectId/agent-models` → returns `{ agents: [{ agent_id, backend, model, reasoning_effort, reasoning_supported }, ...] }` for head/reviewer1/reviewer2/dev.
  - `PUT /api/project/:projectId/agent-models/:agentId` → persists a single row back to `config.json`. Validates `reasoning_effort` against `{minimal, low, medium, high}` (explicit deny list for `xhigh`). Empty string clears the override so the row falls back to the CLI default.

### Client
- **`src/components/AgentModelsWidget.tsx`** (new) — compact 4-row widget. Each row shows the agent id, its backend, a free-text model input (committed on blur so the field can be retyped without hammering the backend), a reasoning-effort dropdown (Codex rows only; `—` for Claude rows), and a **Restart** button that hits the existing `POST /api/agents/:project/:agent/restart` endpoint so a changed setting picks up in the live session.
- **`src/components/OperatorFeaturesPanel.tsx`** — mount the widget at the top of the right column, above Telegram Bridge. The #351 two-column layout already scrolls the right column independently so the new 5-widget stack stays navigable.

## Acceptance
- Dashboard shows current model + reasoning per agent for the active project.
- Operator can change Reviewer1 from `high` to `medium` via the dropdown, click **Restart**, and the new session launches with the medium setting.
- New projects default to `medium` (never `xhigh`/`high`).
- Settings persist across server restart (they live in `~/.quadwork/config.json`).
- Existing projects with no override continue to use their current CLI-level defaults.

## Out of scope (per ticket)
- Auto-detect model list from CLI `--help`
- "Drop all agents to medium" one-click recovery

Reviewers: @reviewer1 @reviewer2