### PR TITLE
[#368] Auto-reattach terminal panel after PTY restart

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -208,21 +208,38 @@ export default function TerminalPanel({
 
       ws.onclose = async (e) => {
         if (cancelled) return;
-        // #368: delayed probe of /api/sessions. The restart path on
-        // the server does stop→spawn sequentially, so the fresh
-        // session may need a short beat to register before we ask.
-        // A single 250ms retry window is enough in practice.
-        await new Promise((r) => setTimeout(r, 250));
-        if (cancelled) return;
-        if (reattachAttempts < MAX_REATTACH && await sessionIsLive()) {
-          reattachAttempts += 1;
-          // Clear the stale buffer so the previous session's last
-          // frame (including any "stopped" marker) doesn't linger
-          // above the new prompt.
-          term.reset();
-          term.write(`\x1b[38;2;115;115;115m[reattached to new session]\x1b[0m\r\n`);
-          connect();
-          return;
+        // #368: bounded polling probe of /api/sessions. A single
+        // fixed-delay probe is timing-fragile — if the server-side
+        // stop→spawn sequence takes longer than the delay (slow
+        // PTY spawn, busy event loop, AgentChattr re-registration
+        // stall) the probe sees "no session" and the terminal
+        // permanently falls through to [session closed] even
+        // though the new PTY came up a moment later. Instead,
+        // poll every 200ms for up to 2000ms (10 attempts) and
+        // reattach as soon as a live session appears. The loop
+        // bails immediately on any liveness hit, so the happy
+        // path still completes in ~200-400ms.
+        if (reattachAttempts < MAX_REATTACH) {
+          const PROBE_INTERVAL_MS = 200;
+          const PROBE_WINDOW_MS = 2000;
+          const probeStart = Date.now();
+          let live = false;
+          while (Date.now() - probeStart < PROBE_WINDOW_MS) {
+            await new Promise((r) => setTimeout(r, PROBE_INTERVAL_MS));
+            if (cancelled) return;
+            if (await sessionIsLive()) { live = true; break; }
+          }
+          if (cancelled) return;
+          if (live) {
+            reattachAttempts += 1;
+            // Clear the stale buffer so the previous session's
+            // last frame (including any "stopped" marker) doesn't
+            // linger above the new prompt.
+            term.reset();
+            term.write(`\x1b[38;2;115;115;115m[reattached to new session]\x1b[0m\r\n`);
+            connect();
+            return;
+          }
         }
         term.write(`\r\n\x1b[38;2;115;115;115m[session closed: ${e.reason || e.code}]\x1b[0m\r\n`);
       };

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -117,34 +117,72 @@ export default function TerminalPanel({
     const observer = new ResizeObserver(() => fit());
     observer.observe(containerRef.current);
 
+    // #368: register the xterm → client data handler ONCE up-front
+    // so reattach cycles don't stack duplicate handlers that would
+    // each try to send the same keystroke to the latest ws.
+    term.onData((data) => {
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(data);
+      }
+    });
+
     // Connect WebSocket — resolve backend URL from config if not provided
     let cancelled = false;
+    let baseUrl: string | null = null;
 
-    (async () => {
-      let base = wsUrl;
-      if (!base) {
-        // In production, WS is same-origin. In dev mode (next dev on :3000),
-        // resolve the backend port from config since WS isn't proxied by Next.js.
-        const wsProto = window.location.protocol === "https:" ? "wss:" : "ws:";
-        try {
-          const res = await fetch("/api/config");
-          if (res.ok) {
-            const cfg = await res.json();
-            const backendPort = cfg.port || 8400;
-            const currentPort = parseInt(window.location.port, 10);
-            if (currentPort && currentPort !== backendPort) {
-              // Dev mode: connect directly to Express backend
-              base = `${wsProto}//${window.location.hostname}:${backendPort}`;
-            } else {
-              base = `${wsProto}//${window.location.host}`;
-            }
+    const resolveBase = async (): Promise<string> => {
+      if (baseUrl) return baseUrl;
+      if (wsUrl) { baseUrl = wsUrl; return baseUrl; }
+      const wsProto = window.location.protocol === "https:" ? "wss:" : "ws:";
+      try {
+        const res = await fetch("/api/config");
+        if (res.ok) {
+          const cfg = await res.json();
+          const backendPort = cfg.port || 8400;
+          const currentPort = parseInt(window.location.port, 10);
+          if (currentPort && currentPort !== backendPort) {
+            baseUrl = `${wsProto}//${window.location.hostname}:${backendPort}`;
           } else {
-            base = `${wsProto}//${window.location.host}`;
+            baseUrl = `${wsProto}//${window.location.host}`;
           }
-        } catch {
-          base = `${wsProto}//${window.location.host}`;
+        } else {
+          baseUrl = `${wsProto}//${window.location.host}`;
         }
+      } catch {
+        baseUrl = `${wsProto}//${window.location.host}`;
       }
+      return baseUrl;
+    };
+
+    // #368: after a ws close (typically because the PTY was stopped
+    // by a /api/agents/:project/:agent/restart handler), check
+    // /api/sessions to see if a fresh session already exists under
+    // the same project/agent key. If it does, clear the buffer and
+    // reattach transparently so the terminal tracks the new PTY
+    // without the operator having to reload the page. If not,
+    // render the "session closed" line as before.
+    const sessionIsLive = async (): Promise<boolean> => {
+      try {
+        const res = await fetch("/api/sessions");
+        if (!res.ok) return false;
+        const list = await res.json();
+        return Array.isArray(list) && list.some(
+          (s) => s && s.projectId === projectId && s.agentId === agentId,
+        );
+      } catch {
+        return false;
+      }
+    };
+
+    // Track reattach attempts so a genuinely dead session cannot
+    // trigger an infinite reconnect loop. Resets whenever a ws
+    // successfully opens (i.e. a real session was observed).
+    let reattachAttempts = 0;
+    const MAX_REATTACH = 5;
+
+    const connect = async () => {
+      const base = await resolveBase();
       if (cancelled) return;
 
       const endpoint = `${base}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}`;
@@ -152,6 +190,7 @@ export default function TerminalPanel({
       wsRef.current = ws;
 
       ws.onopen = () => {
+        reattachAttempts = 0;
         ws.send(
           JSON.stringify({
             type: "resize",
@@ -167,16 +206,30 @@ export default function TerminalPanel({
         if (cb) cb();
       };
 
-      ws.onclose = (e) => {
+      ws.onclose = async (e) => {
+        if (cancelled) return;
+        // #368: delayed probe of /api/sessions. The restart path on
+        // the server does stop→spawn sequentially, so the fresh
+        // session may need a short beat to register before we ask.
+        // A single 250ms retry window is enough in practice.
+        await new Promise((r) => setTimeout(r, 250));
+        if (cancelled) return;
+        if (reattachAttempts < MAX_REATTACH && await sessionIsLive()) {
+          reattachAttempts += 1;
+          // Clear the stale buffer so the previous session's last
+          // frame (including any "stopped" marker) doesn't linger
+          // above the new prompt.
+          term.reset();
+          term.write(`\x1b[38;2;115;115;115m[reattached to new session]\x1b[0m\r\n`);
+          connect();
+          return;
+        }
         term.write(`\r\n\x1b[38;2;115;115;115m[session closed: ${e.reason || e.code}]\x1b[0m\r\n`);
       };
 
-      term.onData((data) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(data);
-        }
-      });
-    })();
+    };
+
+    connect();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
Fixes #368.

## Problem

After clicking Restart in Agent Models (#343), the backend correctly stops+respawns the PTY but the terminal panel shows a frozen `[session closed: stopped]`. The new session is alive in chat; only the terminal view is stale.

## Fix (Option A — client-side auto-reattach)

`src/components/TerminalPanel.tsx`:

- Factored the WebSocket open path into a `connect()` helper so `ws.onclose` can call it again.
- `ws.onclose` now waits 250ms, probes `/api/sessions` for a live entry under this `{project, agent}`, and if one exists calls `term.reset()` and reopens a fresh WebSocket against the new PTY. Writes `[reattached to new session]` so operators see the transition instead of silence.
- `term.reset()` clears the previous session's final frame so operators don't see a ghost `[session closed: stopped]` hanging above the new prompt (acceptance bullet: "No ghost stopped-session output lingers").
- Hard cap `MAX_REATTACH=5` prevents an infinite reconnect loop when the agent is genuinely dead. Counter resets on every successful `ws.onopen`.
- xterm `onData` handler is now registered once up-front against `wsRef.current` rather than inside each connect() call, so reattach cycles don't stack duplicate keystroke senders that'd each fire on every keypress.

## Scope decisions

- **No server-side broadcast** (Option B): kept out. The 250ms probe of `/api/sessions` is sufficient for the happy-path restart since `stopAgentSession` + `spawnAgentPty` are sequential on the server. A transport-level "session-restarted" event would be cleaner but is a larger surface change and the ticket marks Option A as "lighter" — taking it.
- Restart-badge clearing in AgentModelsWidget already works from #343's own `needsRestart` state — no change here.
- No change to the server restart handler. The PTY lifecycle is correct; only the client was failing to follow it.

## Verification

- `npx tsc --noEmit` clean.
- `next build` clean.

## Test plan

- [ ] Click Restart on any agent in Agent Models → terminal briefly shows `[reattached to new session]`, then the new prompt streams in, with no `[session closed]` line above.
- [ ] Stop an agent from the Stop button (not Restart) → terminal still shows `[session closed: stopped]` (no live session → probe returns false → fallthrough).
- [ ] Kill the backend process entirely → after 5 reattach attempts the terminal settles on `[session closed]` instead of looping forever.
- [ ] Type into the reattached terminal — keystrokes reach the new PTY (onData handler preserved across the reconnect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)