### PR TITLE
[#355] Correct Head prompt: "Start Trigger" button name

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1231,10 +1231,11 @@ function stopTrigger(project) {
 app.post("/api/triggers/:project/start", (req, res) => {
   const { project } = req.params;
   // #418 / quadwork#306: sendImmediately was an always-true
-  // "Send Message and Start Trigger" flag from #210; operators
-  // asked for a pure scheduler ("Start Trigger" — wait for the
-  // first interval). The field is ignored here; the send-now
-  // endpoint below still exists for the explicit one-shot path.
+  // send-and-start flag from the original #210 button; operators
+  // asked for a pure scheduler (the button is now just "Start
+  // Trigger" — wait for the first interval). The field is
+  // ignored here; the send-now endpoint below still exists for
+  // the explicit one-shot path.
   const { interval, duration, message } = req.body || {};
   const ms = (interval || 30) * 60 * 1000;
   const durationMs = duration ? duration * 60 * 1000 : 0; // duration in minutes, 0 = indefinite

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -74,7 +74,7 @@ When the operator asks you in chat to start a task or batch:
 3. Reply in chat to confirm what you wrote to the queue file (issue numbers + which section).
 4. **Tell the operator the queue is ready and how to kick it off.** Send a chat message like:
 
-   > Queue is ready. To begin, click **Send Message and Start Trigger** in the Operator Features panel (bottom-right). I will start assigning Dev as soon as the trigger fires.
+   > Queue is ready. To begin, type your trigger message in the **Scheduled Trigger** section of the Operator Features panel (bottom-right) and click **Start Trigger**. I will start assigning Dev as soon as the trigger fires.
 
    Without this prompt the operator has no idea what to do next and the batch sits idle indefinitely. Always send it after step 3, even if the operator only asked for a single ticket.
 5. **Wait for the operator to trigger the batch via the Scheduled Trigger widget** before assigning the first item to `@dev`. Do NOT start assignments the moment the queue file is written — the operator controls kickoff. The trigger fires the queue-check pulse to all agents and is your signal that the operator wants the batch to start.


### PR DESCRIPTION
Fixes #355.

## Problem

Head's kick-off chat template told operators to click **"Send Message and Start Trigger"** in the Operator Features panel, but that button doesn't exist. The Scheduled Trigger widget has a single **"Start Trigger"** button with the message textarea as a separate field above it.

## Fix

- `templates/seeds/head.AGENTS.md:77`: rewrite the kick-off chat template so Head says *"type your trigger message in the Scheduled Trigger section… and click Start Trigger"*, clearly separating the two steps.
- `server/index.js:1234`: scrub the same phrase from a historical comment so a repo-wide grep for `Send Message and Start Trigger` returns zero hits (ticket nice-to-have).

## Verification

- `grep -rn "Send Message and Start Trigger" .` → 0 hits outside node_modules/.next/.git.

## Test plan

- [ ] On a fresh Head reseed, Head's kick-off message reads "type your trigger message… click **Start Trigger**".
- [ ] `grep -rn "Send Message and Start Trigger"` across the repo returns no hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)