### PR TITLE
[#367] AgentModelsWidget: collapse to button + modal

### DIFF
--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -8,6 +8,16 @@
 // POST /api/agents/:project/:agent/restart so a changed model/
 // effort picks up without needing the operator to go touch
 // ~/.codex/config.toml outside QuadWork.
+//
+// #367: this file now exports a default `AgentModelsButton` that
+// renders a single-row collapsed entry in the Operator Features
+// right column. Clicking the Configure button opens
+// `AgentModelsModal`, which contains the full configuration body
+// (rows, dropdowns, restart buttons, needs-restart badges,
+// footer help). Operators rarely touch this widget mid-run, so
+// the modal pattern frees ~5 rows of vertical space for the more
+// frequently used Telegram Bridge / Loop Guard / Project History
+// widgets — see #367 for the rationale.
 
 import { useCallback, useEffect, useState } from "react";
 
@@ -50,7 +60,12 @@ function optionsForBackend(backend: string) {
   return MODEL_OPTIONS[backend] || [{ value: "", label: "(CLI default)" }];
 }
 
-export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps) {
+// #367: modal body — the full configuration UI from the original
+// AgentModelsWidget, unchanged except for being wrapped in a
+// modal shell. Owns its own data fetch + dirty tracking + restart
+// state. Mounted only when the modal is open so we don't run the
+// fetch until the operator actually wants to configure something.
+function AgentModelsModal({ projectId, onClose }: { projectId: string; onClose: () => void }) {
   const [rows, setRows] = useState<AgentRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -60,8 +75,7 @@ export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps)
   // update(), and cleared only when the operator clicks Restart
   // on that row (restart() succeeds). Until then the UI shows a
   // "needs restart" badge next to the agent id so it is visually
-  // obvious which sessions are running stale config — the ticket
-  // explicitly calls this out as a required acceptance.
+  // obvious which sessions are running stale config.
   const [needsRestart, setNeedsRestart] = useState<Set<string>>(new Set());
 
   const load = useCallback(async () => {
@@ -77,6 +91,13 @@ export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps)
   }, [projectId]);
 
   useEffect(() => { load(); }, [load]);
+
+  // #367: Escape closes the modal, matching TelegramSetupModal.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
 
   const update = async (agentId: string, patch: Partial<Pick<AgentRow, "model" | "reasoning_effort">>) => {
     setBusy(agentId);
@@ -126,78 +147,156 @@ export default function AgentModelsWidget({ projectId }: AgentModelsWidgetProps)
   };
 
   return (
-    <div className="flex flex-col border border-border">
-      <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
-        <span className="text-[11px] text-text-muted uppercase tracking-wider">Agent Models</span>
-        {error && <span className="text-[10px] text-error max-w-[60%] truncate" title={error}>err: {error}</span>}
-      </div>
-      <div className="p-2 flex flex-col gap-1.5">
-        {!rows && <div className="text-[11px] text-text-muted">Loading…</div>}
-        {rows && rows.length === 0 && (
-          <div className="text-[11px] text-text-muted">No agents configured.</div>
-        )}
-        {rows && rows.map((row) => (
-          <div key={row.agent_id} className="flex items-center gap-1.5 flex-wrap">
-            <span className="text-[11px] text-text font-semibold w-16 shrink-0">{row.agent_id}</span>
-            <span className="text-[10px] text-text-muted w-12 shrink-0">{row.backend}</span>
-            {needsRestart.has(row.agent_id) && (
-              <span
-                className="text-[9px] text-[#ffcc00] border border-[#ffcc00]/40 px-1 py-[1px] shrink-0"
-                title="Config changed — running session is still on the old model/effort. Click Restart to apply."
-              >
-                restart required
-              </span>
-            )}
-            {/* #343: backend-specific model dropdown. Empty value
-                = CLI default (no override). Options come from
-                MODEL_OPTIONS[backend]; unknown backends fall
-                back to just the "(CLI default)" entry. */}
-            <select
-              value={row.model}
-              disabled={busy === row.agent_id}
-              onChange={(e) => update(row.agent_id, { model: e.target.value })}
-              className="flex-1 min-w-[140px] bg-transparent border border-border px-1 py-0.5 text-[11px] font-mono text-text outline-none focus:border-accent cursor-pointer disabled:opacity-50"
-            >
-              {optionsForBackend(row.backend).map((opt) => (
-                <option key={opt.value} value={opt.value} className="bg-bg-surface">{opt.label}</option>
-              ))}
-              {/* If the persisted model isn't in the known list
-                  (e.g. operator hand-edited config.json), keep
-                  it selectable so their override doesn't vanish. */}
-              {row.model && !optionsForBackend(row.backend).some((o) => o.value === row.model) && (
-                <option value={row.model} className="bg-bg-surface">{row.model} (custom)</option>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="agent-models-title"
+    >
+      <div
+        className="relative mx-4 w-full max-w-[520px] max-h-[90vh] overflow-auto rounded-lg border border-white/10 bg-neutral-950 p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded p-1 text-neutral-400 hover:bg-white/5 hover:text-white"
+        >
+          <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M4 4l12 12M16 4L4 16" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <div className="flex items-center justify-between mb-3">
+          <h2 id="agent-models-title" className="text-base font-semibold text-white">Agent Models</h2>
+          {error && <span className="text-[10px] text-error max-w-[60%] truncate ml-2" title={error}>err: {error}</span>}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          {!rows && <div className="text-[11px] text-text-muted">Loading…</div>}
+          {rows && rows.length === 0 && (
+            <div className="text-[11px] text-text-muted">No agents configured.</div>
+          )}
+          {rows && rows.map((row) => (
+            <div key={row.agent_id} className="flex items-center gap-1.5 flex-wrap">
+              <span className="text-[11px] text-text font-semibold w-16 shrink-0">{row.agent_id}</span>
+              <span className="text-[10px] text-text-muted w-12 shrink-0">{row.backend}</span>
+              {needsRestart.has(row.agent_id) && (
+                <span
+                  className="text-[9px] text-[#ffcc00] border border-[#ffcc00]/40 px-1 py-[1px] shrink-0"
+                  title="Config changed — running session is still on the old model/effort. Click Restart to apply."
+                >
+                  restart required
+                </span>
               )}
-            </select>
-            {row.reasoning_supported ? (
+              {/* #343: backend-specific model dropdown. Empty value
+                  = CLI default (no override). Options come from
+                  MODEL_OPTIONS[backend]; unknown backends fall
+                  back to just the "(CLI default)" entry. */}
               <select
-                value={row.reasoning_effort || ""}
+                value={row.model}
                 disabled={busy === row.agent_id}
-                onChange={(e) => update(row.agent_id, { reasoning_effort: e.target.value })}
-                className="bg-transparent border border-border px-1 py-0.5 text-[11px] text-text outline-none focus:border-accent cursor-pointer disabled:opacity-50"
+                onChange={(e) => update(row.agent_id, { model: e.target.value })}
+                className="flex-1 min-w-[140px] bg-transparent border border-border px-1 py-0.5 text-[11px] font-mono text-text outline-none focus:border-accent cursor-pointer disabled:opacity-50"
               >
-                <option value="" className="bg-bg-surface">(default)</option>
-                {REASONING_LEVELS.map((lvl) => (
-                  <option key={lvl} value={lvl} className="bg-bg-surface">{lvl}</option>
+                {optionsForBackend(row.backend).map((opt) => (
+                  <option key={opt.value} value={opt.value} className="bg-bg-surface">{opt.label}</option>
                 ))}
+                {/* If the persisted model isn't in the known list
+                    (e.g. operator hand-edited config.json), keep
+                    it selectable so their override doesn't vanish. */}
+                {row.model && !optionsForBackend(row.backend).some((o) => o.value === row.model) && (
+                  <option value={row.model} className="bg-bg-surface">{row.model} (custom)</option>
+                )}
               </select>
-            ) : (
-              <span className="text-[10px] text-text-muted w-16 text-center">—</span>
-            )}
-            <button
-              type="button"
-              onClick={() => restart(row.agent_id)}
-              disabled={busy === row.agent_id}
-              title="Restart this agent to pick up the new model / reasoning setting"
-              className="shrink-0 px-1.5 py-0.5 text-[10px] text-text-muted border border-border hover:text-accent hover:border-accent/40 disabled:opacity-50 transition-colors"
-            >
-              {busy === row.agent_id ? "…" : "Restart"}
-            </button>
-          </div>
-        ))}
-        <p className="mt-1 text-[10px] text-text-muted leading-snug">
-          Codex reasoning effort defaults to <code className="text-text">medium</code> for new projects. Blank model falls back to the CLI default. Click Restart to apply changes to a live session.
-        </p>
+              {row.reasoning_supported ? (
+                <select
+                  value={row.reasoning_effort || ""}
+                  disabled={busy === row.agent_id}
+                  onChange={(e) => update(row.agent_id, { reasoning_effort: e.target.value })}
+                  className="bg-transparent border border-border px-1 py-0.5 text-[11px] text-text outline-none focus:border-accent cursor-pointer disabled:opacity-50"
+                >
+                  <option value="" className="bg-bg-surface">(default)</option>
+                  {REASONING_LEVELS.map((lvl) => (
+                    <option key={lvl} value={lvl} className="bg-bg-surface">{lvl}</option>
+                  ))}
+                </select>
+              ) : (
+                <span className="text-[10px] text-text-muted w-16 text-center">—</span>
+              )}
+              <button
+                type="button"
+                onClick={() => restart(row.agent_id)}
+                disabled={busy === row.agent_id}
+                title="Restart this agent to pick up the new model / reasoning setting"
+                className="shrink-0 px-1.5 py-0.5 text-[10px] text-text-muted border border-border hover:text-accent hover:border-accent/40 disabled:opacity-50 transition-colors"
+              >
+                {busy === row.agent_id ? "…" : "Restart"}
+              </button>
+            </div>
+          ))}
+          <p className="mt-2 text-[10px] text-text-muted leading-snug">
+            Codex reasoning effort defaults to <code className="text-text">medium</code> for new projects. Blank model falls back to the CLI default. Click Restart to apply changes to a live session.
+          </p>
+        </div>
       </div>
     </div>
+  );
+}
+
+// #367: collapsed-state row for the Operator Features right
+// column. Renders a single PanelHeader-style header with a
+// Configure button on the right and a one-line backends summary
+// (head: codex · dev: claude · …) below. Owns the modal open/
+// close state. The summary fetch is light — just enough to
+// render `agent_id: backend` pairs — and only mounts once on
+// component init; we don't poll, since backends rarely change
+// outside the modal flow.
+export default function AgentModelsButton({ projectId }: AgentModelsWidgetProps) {
+  const [open, setOpen] = useState(false);
+  const [summary, setSummary] = useState<{ id: string; backend: string }[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/project/${encodeURIComponent(projectId)}/agent-models`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const rows: AgentRow[] = data.agents || [];
+        setSummary(rows.map((r) => ({ id: r.agent_id, backend: r.backend })));
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  return (
+    <>
+      <div className="flex flex-col border border-border">
+        <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
+          <span className="text-[11px] text-text-muted uppercase tracking-wider">Agent Models</span>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="px-2 py-0.5 text-[10px] text-text-muted border border-border hover:text-accent hover:border-accent/40 transition-colors"
+          >
+            Configure →
+          </button>
+        </div>
+        {summary && summary.length > 0 && (
+          <div className="px-3 py-1 text-[10px] text-text-muted truncate" title={summary.map((s) => `${s.id}: ${s.backend}`).join(" · ")}>
+            {summary.map((s, i) => (
+              <span key={s.id}>
+                {i > 0 && <span className="text-text-muted/60"> · </span>}
+                <span className="text-text">{s.id}</span>
+                <span>: {s.backend}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      {open && <AgentModelsModal projectId={projectId} onClose={() => setOpen(false)} />}
+    </>
   );
 }


### PR DESCRIPTION
Fixes #367. Closes #365 (superseded — once Agent Models becomes one row, the #351 Operator Features layout no longer needs reordering).

## Approach

`src/components/AgentModelsWidget.tsx` rewritten as two components:

### `AgentModelsButton` (default export)
- PanelHeader-style row with a `Configure →` button on the right.
- One-line backends summary below: `head: codex · dev: claude · reviewer1: codex · reviewer2: claude` (truncated if too wide; full string in `title`).
- Light one-shot fetch on mount of `/api/project/:id/agent-models` for the summary only — no polling, since backends rarely change outside the modal flow.
- Owns modal open/close state.

### `AgentModelsModal`
- Wraps the existing widget body (rows, model dropdowns, reasoning dropdowns, custom-slug fallback, restart buttons, needs-restart badges, footer help) inside a modal shell that matches `TelegramSetupModal`: dark overlay, `max-w-[520px]`, `max-h-[90vh]` scroll, X close button, Escape key closes, click-outside closes.
- Mounted only when `open === true`, so the full data fetch + dirty tracking only run when the operator actually opens the modal.
- All `#343` behavior preserved: PUT `/api/project/:id/agent-models/:agent`, restart endpoint, `needsRestart` Set-based dirty tracking, custom-slug option fallback for hand-edited configs.

`OperatorFeaturesPanel.tsx` is unchanged — the default import (`AgentModelsWidget`) still resolves to the new button, mounted in the same slot.

## Result

Right column now stacks: Agent Models button (~40px) + Telegram Bridge + Loop Guard + Project History — comfortably fits at default dashboard height without scrolling, addressing the core complaint in #367 and incidentally restoring the #351 layout intent that #365 flagged.

## Verification

- `next build` clean.

## Test plan

- [ ] Right column shows a single Agent Models row with `head: codex · dev: claude · …` summary and a `Configure →` button.
- [ ] Clicking Configure opens a modal centered on the dark overlay; X / Escape / click-outside all close it.
- [ ] Inside the modal: model dropdowns persist via PUT, restart-required badge appears on edit, Restart button clears it.
- [ ] No fetch to `/api/project/:id/agent-models` happens for the modal body until the modal is actually opened.
- [ ] Right column at default dashboard height now fits Telegram Bridge + Loop Guard + Project History without scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)