### PR TITLE
[#366] Pin AgentChattr on a named 'pinned' branch, not detached HEAD

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -247,12 +247,38 @@ function _installAgentChattrLocked(dir, setError) {
     if (cloneResult === null) return setError(`git clone of ${AGENTCHATTR_REPO} into ${dir} failed`);
     if (!fs.existsSync(runPy)) return setError(`Clone completed but run.py missing at ${dir}`);
     // #348: pin to the known-good AgentChattr commit shipped with
-    // this QuadWork release. On failure (commit unreachable /
-    // force-pushed away), fall back to the default branch with a
-    // loud warning instead of hard-failing the install.
-    const pinResult = run(`git -C "${dir}" checkout ${AGENTCHATTR_PIN} 2>&1`, { timeout: 30000 });
+    // this QuadWork release. #366: use `checkout -B pinned <sha>`
+    // so the clone lands on a named local branch ("pinned") whose
+    // HEAD is the pinned commit, rather than detached HEAD. Named
+    // HEAD avoids the AC2 worktree-rot class of bug: `git status`
+    // says `On branch pinned`, downstream tooling that reads the
+    // current branch sees a stable name, and a future `git pull`
+    // fails with a clear "no upstream" message instead of a vague
+    // detached-HEAD warning. -B (capital) is idempotent — it
+    // force-creates/updates the branch so re-runs are no-ops.
+    // On failure (commit unreachable / force-pushed away), fall
+    // back to the default branch with a loud warning instead of
+    // hard-failing the install.
+    const pinResult = run(`git -C "${dir}" checkout -B pinned ${AGENTCHATTR_PIN} 2>&1`, { timeout: 30000 });
     if (pinResult === null) {
       try { console.warn(`[quadwork] WARNING: could not check out AgentChattr pin ${AGENTCHATTR_PIN} at ${dir}; falling back to default branch. The upstream commit may have been force-pushed away — update AGENTCHATTR_PIN in bin/quadwork.js for reproducible installs.`); } catch {}
+    }
+  } else {
+    // #366: existing clone from a pre-fix install. If the clone
+    // is currently in detached HEAD pointing exactly at the pin,
+    // migrate it onto the named `pinned` branch in place. This
+    // is safe because no commits are lost — the SHA is the same,
+    // we're just attaching a name to it. Skip migration if the
+    // clone is on a different SHA (drift) or already on a named
+    // branch (operator may have set up their own work branch on
+    // top); doctor will flag drift cases.
+    const headSha = (run(`git -C "${dir}" rev-parse HEAD 2>&1`) || "").trim();
+    const headRef = (run(`git -C "${dir}" symbolic-ref --quiet HEAD 2>&1`) || "").trim();
+    if (headSha === AGENTCHATTR_PIN && !headRef) {
+      const migrateResult = run(`git -C "${dir}" checkout -B pinned ${AGENTCHATTR_PIN} 2>&1`, { timeout: 30000 });
+      if (migrateResult === null) {
+        try { console.warn(`[quadwork] WARNING: could not migrate ${dir} from detached HEAD to the 'pinned' branch.`); } catch {}
+      }
     }
   }
 
@@ -1916,6 +1942,15 @@ function cmdDoctor() {
     const sha = run(`git -C "${dir}" rev-parse HEAD 2>&1`);
     return sha ? sha.trim() : null;
   };
+  // #366: surface whether the clone is on the named `pinned`
+  // branch, on a different named branch, or in detached HEAD.
+  // Detached-HEAD-but-on-pin gets a soft warning so operators
+  // know to re-run install (which auto-migrates) or re-clone.
+  const cloneBranchAt = (dir) => {
+    const ref = run(`git -C "${dir}" symbolic-ref --quiet HEAD 2>&1`);
+    if (!ref) return null; // detached
+    return ref.trim().replace(/^refs\/heads\//, "");
+  };
   const report = (label, dir) => {
     if (!dir || !fs.existsSync(dir)) {
       console.log(`  [skip] ${label}: ${dir || "(not configured)"} — missing`);
@@ -1926,8 +1961,19 @@ function cmdDoctor() {
       console.log(`  [warn] ${label}: ${dir} — not a git clone`);
       return;
     }
-    const tag = sha === AGENTCHATTR_PIN ? "OK  " : "DIFF";
-    console.log(`  [${tag}] ${label}: ${sha} (${dir})`);
+    const branch = cloneBranchAt(dir);
+    let tag;
+    if (sha !== AGENTCHATTR_PIN) {
+      tag = "DIFF";
+    } else if (!branch) {
+      tag = "DETACH"; // on-pin but in detached HEAD — re-run install to migrate
+    } else if (branch !== "pinned") {
+      tag = "BR  "; // on-pin but on a non-`pinned` named branch (operator override)
+    } else {
+      tag = "OK  ";
+    }
+    const branchLabel = branch ? `branch=${branch}` : "branch=(detached)";
+    console.log(`  [${tag}] ${label}: ${sha} ${branchLabel} (${dir})`);
   };
   // Global clone
   report("global", DEFAULT_AGENTCHATTR_DIR);
@@ -1951,7 +1997,7 @@ function cmdDoctor() {
     console.log(`  (could not enumerate projects: ${err.message})`);
   }
   console.log("");
-  console.log("Legend: [OK  ] clone matches the pin; [DIFF] clone is off-pin (re-clone manually to re-sync)");
+  console.log("Legend: [OK  ] on pin + on `pinned` branch; [BR  ] on pin but on a non-`pinned` named branch; [DETACH] on pin but in detached HEAD (re-run quadwork start to auto-migrate); [DIFF] off-pin (re-clone manually to re-sync)");
   console.log("");
 }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -125,6 +125,21 @@ If the pinned commit becomes unreachable (upstream force-push),
 default branch instead of hard-failing the install. The next
 release should update the pin to a reachable commit.
 
+### Branch model (#366)
+
+The pin is checked out via `git checkout -B pinned <sha>` so the
+clone always lands on a named local branch called `pinned` whose
+HEAD is the pinned commit, never in detached HEAD. This avoids
+the AC2 worktree-rot class of bug (downstream tooling reading
+"detached at <sha>" as the branch name) and gives `git status` a
+clean `On branch pinned` line. When bumping the pin in a future
+release, leave this branch model intact: keep using `-B pinned`
+(capital B is idempotent and force-updates the branch on re-
+runs). Pre-#366 detached-HEAD clones are auto-migrated onto the
+`pinned` branch on the next `quadwork start`, but only when the
+clone is currently exactly at the pin SHA — drift cases are left
+alone and surfaced by `quadwork doctor`.
+
 ## Pitfalls
 
 - **Never run `npm run release:*` from a dirty tree.** `npm version` will


### PR DESCRIPTION
Fixes #366. The #348 pin path used `git checkout <sha>` which leaves clones in detached HEAD — the same git-state-drift class of bug behind the AC2 worktree-rot diagnostic session that triggered tickets #341-#355. Switch to a named local branch so downstream tooling sees a stable HEAD.

## Changes

### `bin/quadwork.js _installAgentChattrLocked`
- Replace `git checkout <sha>` with `git checkout -B pinned <sha>`. The clone now lands on a local branch called `pinned` whose HEAD is the pinned commit. Capital `-B` is idempotent and force-updates the branch on re-runs.
- New `else` branch on the existing-clone path: if the clone is currently in detached HEAD **and** its HEAD SHA equals `AGENTCHATTR_PIN`, auto-migrate it onto the `pinned` branch in place. Safe because the SHA is unchanged — only a name is being attached. Drift cases (HEAD ≠ pin) and operator-overridden named branches are left alone; `doctor` surfaces them.

### `bin/quadwork.js cmdDoctor`
- New `cloneBranchAt()` helper.
- New status tags: `[OK  ]` (on pin + on `pinned`), `[BR  ]` (on pin but on a non-`pinned` named branch — operator override), `[DETACH]` (on pin but detached — re-run install to migrate), `[DIFF]` (off-pin — re-clone manually).
- Each report line now appends `branch=<name>` so operators can see the HEAD ref alongside the SHA.
- Updated legend.

### `docs/RELEASING.md`
- New "Branch model (#366)" subsection documenting the `-B pinned` invariant, the auto-migration of pre-#366 detached-HEAD clones at the pin, and the AC2-worktree-rot rationale.

## Verification

```
$ node -c bin/quadwork.js
$ node bin/quadwork.js doctor
QuadWork doctor
===============
AgentChattr repo: https://github.com/bcurts/agentchattr.git
Expected pin:     3e71d4267572579e7ffeb83576645f90932c1849

  [BR  ] global: 3e71d4267572579e7ffeb83576645f90932c1849 branch=main (...)
  [BR  ] project:dropcast: 3e71d4267572579e7ffeb83576645f90932c1849 branch=main (...)
  [BR  ] project:quadwork: 3e71d4267572579e7ffeb83576645f90932c1849 branch=main (...)
```

Existing clones on this dev box are on `main` (named, on-pin) so they get `[BR  ]`, which is the correct fall-through state — no destructive auto-action. A fresh `npx quadwork init` from this commit forward will land on `pinned` and report `[OK  ]`.

## Test plan

- [ ] Fresh install: `rm -rf ~/.quadwork/agentchattr && node bin/quadwork.js start` → clone lands on `pinned` branch, doctor reports `[OK  ]`.
- [ ] Detached-HEAD migration: manually `git -C ~/.quadwork/agentchattr checkout <pin-sha>` to detach, re-run `quadwork start` → clone migrates back to `pinned`, doctor reports `[OK  ]`.
- [ ] Drift case: `git -C ~/.quadwork/agentchattr reset --hard HEAD~1` → doctor reports `[DIFF]`, no auto-action.
- [ ] Operator-override case: `git -C ~/.quadwork/agentchattr checkout -B my-feature` (still on pin) → doctor reports `[BR  ]`, no auto-action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)