### PR TITLE
[#236] Chat WS send: await broadcast echo, return stored message

### DIFF
--- a/server/routes.chatWsSend.test.js
+++ b/server/routes.chatWsSend.test.js
@@ -36,9 +36,16 @@ function startFakeAc({ historyBeforeAck = [], rejectWithCode = null, dropBeforeA
     wss.handleUpgrade(req, socket, head, (ws) => {
       // Simulate history replay on connect — these must NOT satisfy
       // the ack, even if they match (sender,text,channel).
+      let historyMaxId = 0;
       for (const msg of historyBeforeAck) {
         ws.send(JSON.stringify({ type: "message", data: msg }));
+        if (typeof msg.id === "number" && msg.id > historyMaxId) historyMaxId = msg.id;
       }
+      // Mirror AC: emit one `type:"status"` frame after history so the
+      // client knows the replay is done. See agentchattr/app.py
+      // `broadcast_status()` call in the /ws handler (line ~1082).
+      ws.send(JSON.stringify({ type: "status", data: { ready: true } }));
+      let nextId = Math.max(9000, historyMaxId + 1);
       ws.on("message", (raw) => {
         const frame = JSON.parse(raw.toString());
         if (frame.type !== "message") return;
@@ -48,7 +55,7 @@ function startFakeAc({ historyBeforeAck = [], rejectWithCode = null, dropBeforeA
         }
         // Mirror store.add: assign id + timestamp, rebroadcast.
         const echoed = {
-          id: 9001,
+          id: nextId++,
           sender: frame.sender,
           text: frame.text,
           channel: frame.channel || "general",
@@ -80,7 +87,8 @@ function startFakeAc({ historyBeforeAck = [], rejectWithCode = null, dropBeforeA
     });
     assert.equal(result.ok, true);
     assert.ok(result.message, "expected echoed message object");
-    assert.equal(result.message.id, 9001);
+    assert.equal(typeof result.message.id, "number");
+    assert.ok(result.message.id >= 9000);
     assert.equal(result.message.text, "hello from test");
     assert.equal(result.message.sender, "user");
     assert.equal(result.message.attachments.length, 1);
@@ -88,24 +96,28 @@ function startFakeAc({ historyBeforeAck = [], rejectWithCode = null, dropBeforeA
     await ac.close();
   }
 
-  // 3) Stale history replay must NOT satisfy the ack. The server sends
-  //    a matching (sender,text) frame on connect BEFORE we've sent
-  //    anything — sendViaWebSocket should ignore it (timestamp gate
-  //    + sentAt guard) and still wait for the real post-send echo.
+  // 3) Stale history replay must NOT satisfy the ack — even when the
+  //    history contains a message that is IDENTICAL (sender, text,
+  //    channel, reply_to) and has a recent timestamp (e.g. a retry of
+  //    the same message sent <1s ago). Prior heuristic matcher was
+  //    vulnerable to this; the fix uses the (1) status-frame history
+  //    boundary and (2) strictly-greater-id correlation baseline so
+  //    the historical echo is definitionally rejected. Reviewer1
+  //    flagged this race on PR #382 round 1.
   {
     const stale = {
-      id: 1, sender: "user", text: "ghost", channel: "general",
-      attachments: [], reply_to: null,
-      timestamp: (Date.now() - 60_000) / 1000, // 60s in the past
+      id: 42, sender: "user", text: "same words",
+      channel: "general", attachments: [], reply_to: null,
+      timestamp: Date.now() / 1000, // RIGHT NOW — old heuristic would accept this
     };
     const ac = await startFakeAc({ historyBeforeAck: [stale] });
     const result = await sendViaWebSocket(ac.url, "fake-token", {
-      text: "ghost",
+      text: "same words",
       sender: "user",
       channel: "general",
       attachments: [],
     });
-    assert.equal(result.message.id, 9001, "must resolve with the live echo, not the historical one");
+    assert.ok(result.message.id > 42, `expected live echo id > 42, got ${result.message.id}`);
     await ac.close();
   }
 

--- a/server/routes.chatWsSend.test.js
+++ b/server/routes.chatWsSend.test.js
@@ -1,0 +1,149 @@
+// #236 / quadwork#236: sendViaWebSocket ack/body/error regression.
+// Stands up a minimal fake AgentChattr ws server that mirrors app.py's
+// `type:"message"` handler behavior (accept the frame, assign an id +
+// timestamp, broadcast `{type:"message", data: msg}` back to the
+// sender) and verifies:
+//
+//   1. Successful send resolves with {ok:true, message:{id,…}} — the
+//      echoed broadcast frame, not a fake {ok:true}.
+//   2. Attachments survive the round trip.
+//   3. History replay on connect does NOT satisfy the ack (the echo
+//      must come AFTER the send, not before).
+//   4. A premature close without an echo rejects with an error (the
+//      old fire-and-forget path silently resolved).
+//   5. Close code 4003 rejects with err.code === "EAGENTCHATTR_401"
+//      so the /api/chat handler can surface a proper 401.
+//
+// Run with: node server/routes.chatWsSend.test.js
+
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const { WebSocketServer } = require("ws");
+const { sendViaWebSocket } = require("./routes");
+
+function startFakeAc({ historyBeforeAck = [], rejectWithCode = null, dropBeforeAck = false } = {}) {
+  const server = http.createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (req, socket, head) => {
+    if (rejectWithCode === 4003) {
+      // Accept the upgrade, then immediately close with 4003 the way
+      // AC's /ws handler does on invalid token.
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        ws.close(4003, "forbidden: invalid session token");
+      });
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      // Simulate history replay on connect — these must NOT satisfy
+      // the ack, even if they match (sender,text,channel).
+      for (const msg of historyBeforeAck) {
+        ws.send(JSON.stringify({ type: "message", data: msg }));
+      }
+      ws.on("message", (raw) => {
+        const frame = JSON.parse(raw.toString());
+        if (frame.type !== "message") return;
+        if (dropBeforeAck) {
+          ws.close();
+          return;
+        }
+        // Mirror store.add: assign id + timestamp, rebroadcast.
+        const echoed = {
+          id: 9001,
+          sender: frame.sender,
+          text: frame.text,
+          channel: frame.channel || "general",
+          attachments: frame.attachments || [],
+          reply_to: frame.reply_to ?? null,
+          timestamp: Date.now() / 1000,
+        };
+        ws.send(JSON.stringify({ type: "message", data: echoed }));
+      });
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise((r) => server.close(() => r())) });
+    });
+  });
+}
+
+(async () => {
+  // 1 + 2) Success path: echo carries server id + attachments preserved.
+  {
+    const ac = await startFakeAc();
+    const result = await sendViaWebSocket(ac.url, "fake-token", {
+      text: "hello from test",
+      sender: "user",
+      channel: "general",
+      attachments: [{ url: "/uploads/x.png", name: "x.png" }],
+    });
+    assert.equal(result.ok, true);
+    assert.ok(result.message, "expected echoed message object");
+    assert.equal(result.message.id, 9001);
+    assert.equal(result.message.text, "hello from test");
+    assert.equal(result.message.sender, "user");
+    assert.equal(result.message.attachments.length, 1);
+    assert.equal(result.message.attachments[0].name, "x.png");
+    await ac.close();
+  }
+
+  // 3) Stale history replay must NOT satisfy the ack. The server sends
+  //    a matching (sender,text) frame on connect BEFORE we've sent
+  //    anything — sendViaWebSocket should ignore it (timestamp gate
+  //    + sentAt guard) and still wait for the real post-send echo.
+  {
+    const stale = {
+      id: 1, sender: "user", text: "ghost", channel: "general",
+      attachments: [], reply_to: null,
+      timestamp: (Date.now() - 60_000) / 1000, // 60s in the past
+    };
+    const ac = await startFakeAc({ historyBeforeAck: [stale] });
+    const result = await sendViaWebSocket(ac.url, "fake-token", {
+      text: "ghost",
+      sender: "user",
+      channel: "general",
+      attachments: [],
+    });
+    assert.equal(result.message.id, 9001, "must resolve with the live echo, not the historical one");
+    await ac.close();
+  }
+
+  // 4) Premature close without ack rejects.
+  {
+    const ac = await startFakeAc({ dropBeforeAck: true });
+    let threw = false;
+    try {
+      await sendViaWebSocket(ac.url, "fake-token", {
+        text: "will drop", sender: "user", channel: "general", attachments: [],
+      });
+    } catch (err) {
+      threw = true;
+      assert.match(err.message, /closed before ack|websocket/);
+      assert.notEqual(err.code, "EAGENTCHATTR_401");
+    }
+    assert.equal(threw, true, "expected sendViaWebSocket to reject on premature close");
+    await ac.close();
+  }
+
+  // 5) 4003 (bad token) rejects with EAGENTCHATTR_401.
+  {
+    const ac = await startFakeAc({ rejectWithCode: 4003 });
+    let threw = false;
+    try {
+      await sendViaWebSocket(ac.url, "bad-token", {
+        text: "denied", sender: "user", channel: "general", attachments: [],
+      });
+    } catch (err) {
+      threw = true;
+      assert.equal(err.code, "EAGENTCHATTR_401");
+    }
+    assert.equal(threw, true, "expected sendViaWebSocket to reject with EAGENTCHATTR_401");
+    await ac.close();
+  }
+
+  console.log("routes.chatWsSend.test.js: all assertions passed (5 cases)");
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/routes.js
+++ b/server/routes.js
@@ -149,21 +149,40 @@ const { WebSocket: NodeWebSocket } = require("ws");
 const { syncChattrToken } = require("./config");
 
 // #236: wait for AgentChattr to echo our message back over the same ws
-// connection before resolving, instead of fire-and-forgetting after
-// 250ms. AC's /ws handler broadcasts `{type:"message", data: msg}` to
-// every connected client (including the sender) after `store.add()`
-// succeeds — so if we stay subscribed briefly after sending, we see
-// our own message come back with its server-assigned id/timestamp.
-// We match on (sender, text, channel, reply_to) since AC does not
-// echo a client-supplied correlation id. On timeout / early close /
-// 4003, we surface a proper error so the /api/chat handler can
-// return a 5xx (or 401) instead of a silent {ok:true}.
+// connection before resolving, instead of fire-and-forgetting. AC's
+// /ws handler does this on every connect:
+//   1. Replays history as N `{type:"message", data: msg}` frames.
+//   2. Sends one `{type:"status", data: …}` frame (broadcast_status).
+//   3. Enters the receive loop and accepts our outgoing frame.
+// After our `type:"message"` is processed, AC calls `store.add()`
+// which broadcasts the stored record back to all clients (including
+// us) as another `{type:"message", data: msg}`.
+//
+// To get a race-free ack we therefore:
+//   A. Wait for the first `type:"status"` frame to confirm the
+//      history replay is done — any `type:"message"` frame seen
+//      BEFORE that is historical and must be ignored.
+//   B. Only then send our message and record the highest message
+//      id observed so far as a correlation baseline.
+//   C. Accept the first post-send `type:"message"` whose payload
+//      matches (sender, text, channel, reply_to) AND whose id is
+//      strictly greater than the baseline (AC ids are monotonically
+//      increasing from store.add). This eliminates the risk a
+//      reviewer flagged on #382 round 1: a historical identical
+//      message from <1.5s ago could have satisfied the old
+//      heuristic matcher.
+// On timeout / early close / 4003, we surface a proper error so the
+// /api/chat handler can return a 5xx (or 401) instead of a silent
+// {ok:true}.
 function sendViaWebSocket(baseUrl, sessionToken, message) {
   return new Promise((resolve, reject) => {
     const wsUrl = `${baseUrl.replace(/^http/, "ws")}/ws?token=${encodeURIComponent(sessionToken || "")}`;
     const ws = new NodeWebSocket(wsUrl);
     let settled = false;
-    let sentAt = 0;
+    let historyFlushed = false;
+    let sent = false;
+    let maxIdAtSend = -Infinity;
+    let maxHistoryId = -Infinity;
     const finish = (err, value) => {
       if (settled) return;
       settled = true;
@@ -171,23 +190,48 @@ function sendViaWebSocket(baseUrl, sessionToken, message) {
       if (err) reject(err); else resolve(value);
     };
     const giveUp = setTimeout(() => finish(new Error("websocket send timeout")), 4000);
-    ws.on("open", () => {
+    const doSend = () => {
+      if (sent || settled) return;
       try {
+        maxIdAtSend = maxHistoryId;
         ws.send(JSON.stringify({ type: "message", ...message }));
-        sentAt = Date.now();
+        sent = true;
       } catch (err) { clearTimeout(giveUp); finish(err); }
+    };
+    ws.on("open", () => {
+      // Do NOT send yet. Wait for the status frame that marks the
+      // end of history replay so we have a clean correlation
+      // baseline. A safety timer covers the (unlikely) case of an
+      // AC build that doesn't emit status on connect — after 750ms
+      // we fall back to sending anyway, using whatever max id we
+      // collected from history so far as the baseline.
+      setTimeout(() => {
+        if (!historyFlushed) {
+          historyFlushed = true;
+          doSend();
+        }
+      }, 750);
     });
     ws.on("message", (raw) => {
-      if (settled || !sentAt) return;
+      if (settled) return;
       let frame;
       try { frame = JSON.parse(raw.toString()); } catch { return; }
-      if (!frame || frame.type !== "message" || !frame.data) return;
+      if (!frame || !frame.type) return;
+      if (frame.type === "status" && !historyFlushed) {
+        historyFlushed = true;
+        doSend();
+        return;
+      }
+      if (frame.type !== "message" || !frame.data) return;
       const d = frame.data;
-      // AC replays history on connect (same type:"message" envelope).
-      // Ignore any echo whose stored timestamp predates our send — it
-      // can only be an old message, not our ack. AC timestamps are
-      // epoch seconds (float) on the `timestamp` field.
-      if (typeof d.timestamp === "number" && d.timestamp * 1000 < sentAt - 1500) return;
+      // Track the highest message id we have observed, whether from
+      // history replay or from other live broadcasts. Used as the
+      // baseline for the post-send correlation check.
+      if (typeof d.id === "number" && d.id > maxHistoryId) {
+        maxHistoryId = d.id;
+      }
+      if (!sent) return; // anything before our send is history
+      if (typeof d.id !== "number" || d.id <= maxIdAtSend) return;
       if (d.sender !== message.sender) return;
       if (d.text !== message.text) return;
       if ((d.channel || "general") !== (message.channel || "general")) return;

--- a/server/routes.js
+++ b/server/routes.js
@@ -148,11 +148,22 @@ router.get("/api/chat", async (req, res) => {
 const { WebSocket: NodeWebSocket } = require("ws");
 const { syncChattrToken } = require("./config");
 
+// #236: wait for AgentChattr to echo our message back over the same ws
+// connection before resolving, instead of fire-and-forgetting after
+// 250ms. AC's /ws handler broadcasts `{type:"message", data: msg}` to
+// every connected client (including the sender) after `store.add()`
+// succeeds — so if we stay subscribed briefly after sending, we see
+// our own message come back with its server-assigned id/timestamp.
+// We match on (sender, text, channel, reply_to) since AC does not
+// echo a client-supplied correlation id. On timeout / early close /
+// 4003, we surface a proper error so the /api/chat handler can
+// return a 5xx (or 401) instead of a silent {ok:true}.
 function sendViaWebSocket(baseUrl, sessionToken, message) {
   return new Promise((resolve, reject) => {
     const wsUrl = `${baseUrl.replace(/^http/, "ws")}/ws?token=${encodeURIComponent(sessionToken || "")}`;
     const ws = new NodeWebSocket(wsUrl);
     let settled = false;
+    let sentAt = 0;
     const finish = (err, value) => {
       if (settled) return;
       settled = true;
@@ -163,11 +174,28 @@ function sendViaWebSocket(baseUrl, sessionToken, message) {
     ws.on("open", () => {
       try {
         ws.send(JSON.stringify({ type: "message", ...message }));
-        // Server acks via broadcast, but the dashboard's POST /api/chat
-        // contract only needs to know the message was accepted. Wait
-        // ~250ms for the server to enqueue + close cleanly.
-        setTimeout(() => { clearTimeout(giveUp); finish(null, { ok: true }); }, 250);
+        sentAt = Date.now();
       } catch (err) { clearTimeout(giveUp); finish(err); }
+    });
+    ws.on("message", (raw) => {
+      if (settled || !sentAt) return;
+      let frame;
+      try { frame = JSON.parse(raw.toString()); } catch { return; }
+      if (!frame || frame.type !== "message" || !frame.data) return;
+      const d = frame.data;
+      // AC replays history on connect (same type:"message" envelope).
+      // Ignore any echo whose stored timestamp predates our send — it
+      // can only be an old message, not our ack. AC timestamps are
+      // epoch seconds (float) on the `timestamp` field.
+      if (typeof d.timestamp === "number" && d.timestamp * 1000 < sentAt - 1500) return;
+      if (d.sender !== message.sender) return;
+      if (d.text !== message.text) return;
+      if ((d.channel || "general") !== (message.channel || "general")) return;
+      const wantReply = message.reply_to ?? null;
+      const gotReply = d.reply_to ?? null;
+      if (wantReply !== gotReply) return;
+      clearTimeout(giveUp);
+      finish(null, { ok: true, message: d });
     });
     ws.on("error", (err) => { clearTimeout(giveUp); finish(err); });
     ws.on("close", (code, reason) => {
@@ -179,6 +207,15 @@ function sendViaWebSocket(baseUrl, sessionToken, message) {
         const e = new Error(msg);
         e.code = "EAGENTCHATTR_401";
         finish(e);
+        return;
+      }
+      // Any other premature close after we sent but before we saw
+      // the echo is an error — the old code path would have claimed
+      // success, silently swallowing a server-side reject.
+      if (!settled) {
+        clearTimeout(giveUp);
+        const r = (reason && reason.toString()) || "";
+        finish(new Error(`websocket closed before ack (code=${code}${r ? ", reason=" + r : ""})`));
       }
     });
   });
@@ -861,8 +898,12 @@ router.post("/api/chat", async (req, res) => {
   const attemptSend = () => sendViaWebSocket(base, sessionToken, message);
 
   try {
-    await attemptSend();
-    return res.json({ ok: true });
+    // #236: sendViaWebSocket now waits for AC's broadcast echo and
+    // returns `{ok, message}` where `message` is the stored record
+    // (with server-assigned id/timestamp). Pass it through so
+    // callers regain parity with the old /api/send response body.
+    const result = await attemptSend();
+    return res.json({ ok: true, message: result.message });
   } catch (err) {
     // If the cached session_token is stale (AgentChattr regenerates
     // one on every restart) the ws closes with code 4003 — re-sync
@@ -876,8 +917,8 @@ router.post("/api/chat", async (req, res) => {
       const { token: refreshed } = getChattrConfig(projectId);
       if (refreshed && refreshed !== sessionToken) {
         try {
-          await sendViaWebSocket(base, refreshed, message);
-          return res.json({ ok: true, resynced: true });
+          const retry = await sendViaWebSocket(base, refreshed, message);
+          return res.json({ ok: true, resynced: true, message: retry.message });
         } catch (retryErr) {
           console.warn(`[chat] retry after token resync failed: ${retryErr.message}`);
           return res.status(401).json({ error: "AgentChattr auth failed (token resync did not help)", detail: retryErr.message });
@@ -2813,3 +2854,6 @@ module.exports.readLastLines = readLastLines;
 // #380: expose checkTelegramBridgePythonDeps so the bridge test can
 // exercise the venv-path interpreter argument round trip.
 module.exports.checkTelegramBridgePythonDeps = checkTelegramBridgePythonDeps;
+// #236: expose sendViaWebSocket so the chat-ws-send regression test
+// can verify the ack/body/error paths against a fake AC ws server.
+module.exports.sendViaWebSocket = sendViaWebSocket;


### PR DESCRIPTION
## Summary
- `sendViaWebSocket` now stays subscribed after sending and resolves only when AgentChattr broadcasts our message back (matched on sender + text + channel + reply_to, with a timestamp gate against history replay).
- Returns `{ok, message}` so `/api/chat` regains parity with the old `/api/send` response body — callers get the server-assigned id/timestamp back.
- Premature ws close without an echo now rejects → `/api/chat` returns 502 instead of a silent `{ok:true}`.
- 4003 (bad token) path unchanged — still `EAGENTCHATTR_401` → resync + single retry.
- Attachments already pass through AC's ws `type:"message"` handler (verified in `agentchattr/app.py:1091-1123`); the new test case 1 round-trips an attachments payload to prove it.

## Changes
- `server/routes.js` — rewrite `sendViaWebSocket`; `/api/chat` now returns the echoed message object on success.
- `server/routes.chatWsSend.test.js` — new regression fixture (5 cases) using a fake AC ws server.

## Test plan
- [x] `node server/routes.chatWsSend.test.js` — 5 new cases pass.
- [x] All existing server/*.test.js suites pass (queue-watcher, batchProgress, parseActiveBatch, telegramBridge).
- [ ] Reviewers: confirm the (sender,text,channel,reply_to) echo match is safe in practice (could two near-simultaneous identical messages collide? current behavior resolves on the first matching echo after send — acceptable because the echo IS our own message round-tripped).
- [ ] Reviewers: verify the 1500ms timestamp grace doesn't reject legitimate echoes under load.

Fixes #236

@reviewer1 @reviewer2 please review.