### PR TITLE
[#383] Telegram Bridge: fix 4 layered config bugs

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1122,9 +1122,18 @@ bridge_sender = "telegram-bridge"
           const bridgeTomlContent = `[telegram]\nbot_token = "${botToken}"\nchat_id = "${chatId}"\nagentchattr_url = "${projectChattrUrl}"\n`;
           fs.writeFileSync(bridgeToml, bridgeTomlContent, { mode: 0o600 });
           fs.chmodSync(bridgeToml, 0o600);
+          // #383 Bug 4: scrub TELEGRAM_*/AGENTCHATTR_URL from the
+          // child env so an ambient shell that exported a different
+          // bot's token can't silently override the TOML we just
+          // wrote. Same fix as server/routes.js Start handler.
+          const bridgeEnv = { ...process.env };
+          delete bridgeEnv.TELEGRAM_BOT_TOKEN;
+          delete bridgeEnv.TELEGRAM_CHAT_ID;
+          delete bridgeEnv.AGENTCHATTR_URL;
           const bridgeProc = spawn("python3", [bridgeScript, "--config", bridgeToml], {
             stdio: "ignore",
             detached: true,
+            env: bridgeEnv,
           });
           bridgeProc.unref();
           if (bridgeProc.pid) {

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1116,7 +1116,10 @@ bridge_sender = "telegram-bridge"
         if (fs.existsSync(bridgeScript)) {
           log("Starting Telegram bridge...");
           const bridgeToml = path.join(CONFIG_DIR, `telegram-${setup.projectName}.toml`);
-          const bridgeTomlContent = `[telegram]\nbot_token = "${botToken}"\nchat_id = "${chatId}"\n\n[agentchattr]\nurl = "${projectChattrUrl}"\n`;
+          // #383 Bug 2: the bridge only reads agentchattr_url from
+          // inside [telegram]. A separate [agentchattr] section is
+          // silently ignored and the bridge falls back to :8300.
+          const bridgeTomlContent = `[telegram]\nbot_token = "${botToken}"\nchat_id = "${chatId}"\nagentchattr_url = "${projectChattrUrl}"\n`;
           fs.writeFileSync(bridgeToml, bridgeTomlContent, { mode: 0o600 });
           fs.chmodSync(bridgeToml, 0o600);
           const bridgeProc = spawn("python3", [bridgeScript, "--config", bridgeToml], {

--- a/server/routes.js
+++ b/server/routes.js
@@ -2385,6 +2385,63 @@ function telegramConfigToml(projectId) {
   return path.join(CONFIG_DIR, `telegram-${projectId}.toml`);
 }
 
+// #383: path to a project's AgentChattr config.toml. The install
+// handler patches this file to declare the `telegram-bridge` agent
+// so AC's registry accepts the bridge's register call.
+function projectAgentchattrConfigPath(projectId) {
+  return path.join(CONFIG_DIR, projectId, "agentchattr", "config.toml");
+}
+
+// #383 Bug 1: prefer the per-project agentchattr_url. Every project
+// after the first uses a distinct port (8301, 8302, ...), so reading
+// the global default silently routed bridge traffic to the wrong AC
+// instance.
+function resolveProjectAgentchattrUrl(cfg, project) {
+  return (
+    (project && project.agentchattr_url) ||
+    (cfg && cfg.agentchattr_url) ||
+    "http://127.0.0.1:8300"
+  );
+}
+
+// #383 Bug 2: the upstream bridge only reads `agentchattr_url` from
+// inside `[telegram]`. A separate `[agentchattr]` section is silently
+// ignored and the bridge falls back to its hardcoded :8300 default.
+function buildTelegramBridgeToml(tg) {
+  return (
+    `[telegram]\n` +
+    `bot_token = "${tg.bot_token}"\n` +
+    `chat_id = "${tg.chat_id}"\n` +
+    `agentchattr_url = "${tg.agentchattr_url}"\n`
+  );
+}
+
+// #383 Bug 3: AC's registry rejects any base name not pre-declared
+// in config.toml with `400 unknown base`. The bridge registers as
+// `telegram-bridge`, so every per-project AC config must declare it.
+// Idempotent: only appends if the section is not already present.
+function patchAgentchattrConfigForTelegramBridge(tomlText) {
+  if (/^\[agents\.telegram-bridge\]\s*$/m.test(tomlText)) {
+    return { text: tomlText, changed: false };
+  }
+  const sep = tomlText.length === 0 || tomlText.endsWith("\n") ? "" : "\n";
+  const block = `\n[agents.telegram-bridge]\nlabel = "Telegram Bridge"\n`;
+  return { text: tomlText + sep + block, changed: true };
+}
+
+// #383 Bug 4: the upstream bridge treats env vars as higher
+// precedence than TOML values. If the parent shell exported
+// TELEGRAM_BOT_TOKEN for a different bot, the bridge silently ran
+// as the wrong identity. Scrub those keys from the child's env so
+// the TOML is the single source of truth.
+function buildTelegramBridgeSpawnEnv(parentEnv) {
+  const env = { ...parentEnv };
+  delete env.TELEGRAM_BOT_TOKEN;
+  delete env.TELEGRAM_CHAT_ID;
+  delete env.AGENTCHATTR_URL;
+  return env;
+}
+
 // #353: per-project log file for the bridge subprocess. The start
 // handler redirects stdout + stderr here so crashes (ImportError,
 // config parse, auth failure) are recoverable instead of
@@ -2502,7 +2559,8 @@ function getProjectTelegram(projectId) {
     return {
       bot_token: resolveToken(project.telegram.bot_token || ""),
       chat_id: project.telegram.chat_id || "",
-      agentchattr_url: cfg.agentchattr_url || "http://127.0.0.1:8300",
+      // #383 Bug 1: prefer per-project URL over the global default.
+      agentchattr_url: resolveProjectAgentchattrUrl(cfg, project),
     };
   } catch {
     return null;
@@ -2638,7 +2696,31 @@ router.post("/api/telegram", async (req, res) => {
             `pip output tail:\n${pipOutput.split("\n").slice(-10).join("\n")}`,
         });
       }
-      return res.json({ ok: true });
+      // #383 Bug 3: ensure every known project's AC config declares
+      // the `telegram-bridge` agent. Without this, AC's registry
+      // rejects the bridge's register call with `400 unknown base`
+      // and the bridge enters an infinite re-register loop.
+      // Idempotent — append-only, skips configs that already have
+      // the section. Does NOT restart AC servers; the operator
+      // must click SERVER → Restart to load the new agent slug.
+      const patched = [];
+      try {
+        const cfgAll = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+        for (const proj of cfgAll.projects || []) {
+          if (!proj || !proj.id) continue;
+          const acPath = projectAgentchattrConfigPath(proj.id);
+          if (!fs.existsSync(acPath)) continue;
+          try {
+            const before = fs.readFileSync(acPath, "utf-8");
+            const { text, changed } = patchAgentchattrConfigForTelegramBridge(before);
+            if (changed) {
+              fs.writeFileSync(acPath, text);
+              patched.push(proj.id);
+            }
+          } catch {}
+        }
+      } catch {}
+      return res.json({ ok: true, patched_projects: patched });
     }
     case "start": {
       const projectId = body.project_id;
@@ -2661,7 +2743,9 @@ router.post("/api/telegram", async (req, res) => {
       const tg = getProjectTelegram(projectId);
       if (!tg || !tg.bot_token || !tg.chat_id) return res.json({ ok: false, error: "Save bot_token and chat_id in project settings first." });
       const tomlPath = telegramConfigToml(projectId);
-      const tomlContent = `[telegram]\nbot_token = "${tg.bot_token}"\nchat_id = "${tg.chat_id}"\n\n[agentchattr]\nurl = "${tg.agentchattr_url}"\n`;
+      // #383 Bug 2: write agentchattr_url inside [telegram]; the
+      // bridge's load_config only reads from that section.
+      const tomlContent = buildTelegramBridgeToml(tg);
       fs.writeFileSync(tomlPath, tomlContent, { mode: 0o600 });
       fs.chmodSync(tomlPath, 0o600);
       // #353: pre-flight import check so a fresh install with no
@@ -2710,9 +2794,15 @@ router.post("/api/telegram", async (req, res) => {
       }
       let child;
       try {
+        // #383 Bug 4: scrub TELEGRAM_*/AGENTCHATTR_URL from the child
+        // env so an operator shell that exports a different bot's
+        // token (common on machines running AC2) can't silently
+        // override the TOML. Makes the TOML the single source of
+        // truth for the bridge's identity.
         child = spawn(venvPython, [bridgeScript, "--config", tomlPath], {
           detached: true,
           stdio: ["ignore", outFd, errFd],
+          env: buildTelegramBridgeSpawnEnv(process.env),
         });
         child.unref();
         if (child.pid) fs.writeFileSync(telegramPidFile(projectId), String(child.pid));
@@ -2898,6 +2988,13 @@ module.exports.readLastLines = readLastLines;
 // #380: expose checkTelegramBridgePythonDeps so the bridge test can
 // exercise the venv-path interpreter argument round trip.
 module.exports.checkTelegramBridgePythonDeps = checkTelegramBridgePythonDeps;
+// #383: pure helpers exposed for unit tests in
+// routes.telegramBridge.test.js. No production callers outside
+// this file.
+module.exports.resolveProjectAgentchattrUrl = resolveProjectAgentchattrUrl;
+module.exports.buildTelegramBridgeToml = buildTelegramBridgeToml;
+module.exports.patchAgentchattrConfigForTelegramBridge = patchAgentchattrConfigForTelegramBridge;
+module.exports.buildTelegramBridgeSpawnEnv = buildTelegramBridgeSpawnEnv;
 // #236: expose sendViaWebSocket so the chat-ws-send regression test
 // can verify the ack/body/error paths against a fake AC ws server.
 module.exports.sendViaWebSocket = sendViaWebSocket;

--- a/server/routes.telegramBridge.test.js
+++ b/server/routes.telegramBridge.test.js
@@ -11,7 +11,14 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
-const { readLastLines, checkTelegramBridgePythonDeps } = require("./routes");
+const {
+  readLastLines,
+  checkTelegramBridgePythonDeps,
+  resolveProjectAgentchattrUrl,
+  buildTelegramBridgeToml,
+  patchAgentchattrConfigForTelegramBridge,
+  buildTelegramBridgeSpawnEnv,
+} = require("./routes");
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "qw-bridge-log-"));
 function write(name, content) {
@@ -133,8 +140,96 @@ try {
     venvSkipped = true;
   }
 
+  // 12) #383 Bug 1: resolveProjectAgentchattrUrl prefers the
+  //     per-project URL over the global default. Every project
+  //     after the first uses a distinct port, so silently reading
+  //     the global default routed bridge traffic to the wrong AC
+  //     instance.
+  assert.equal(
+    resolveProjectAgentchattrUrl(
+      { agentchattr_url: "http://127.0.0.1:8300" },
+      { id: "quadwork", agentchattr_url: "http://127.0.0.1:8301" },
+    ),
+    "http://127.0.0.1:8301",
+  );
+  // Falls back to global default when the project has no URL of
+  // its own (legacy single-project installs).
+  assert.equal(
+    resolveProjectAgentchattrUrl(
+      { agentchattr_url: "http://127.0.0.1:8300" },
+      { id: "legacy" },
+    ),
+    "http://127.0.0.1:8300",
+  );
+  // Hard-coded fallback when neither is set.
+  assert.equal(
+    resolveProjectAgentchattrUrl({}, {}),
+    "http://127.0.0.1:8300",
+  );
+
+  // 13) #383 Bug 2: buildTelegramBridgeToml writes agentchattr_url
+  //     inside [telegram]. The upstream bridge's load_config only
+  //     reads from that section — a separate [agentchattr] section
+  //     is silently ignored and the bridge falls back to its
+  //     hardcoded :8300 default.
+  const toml13 = buildTelegramBridgeToml({
+    bot_token: "123:abc",
+    chat_id: "-42",
+    agentchattr_url: "http://127.0.0.1:8301",
+  });
+  assert.match(toml13, /^\[telegram\]/);
+  assert.match(toml13, /bot_token = "123:abc"/);
+  assert.match(toml13, /chat_id = "-42"/);
+  assert.match(toml13, /agentchattr_url = "http:\/\/127\.0\.0\.1:8301"/);
+  // Must NOT emit a separate [agentchattr] section — the bridge
+  // would silently ignore it.
+  assert.equal(toml13.includes("\n[agentchattr]\n"), false);
+
+  // 14) #383 Bug 3: patchAgentchattrConfigForTelegramBridge is
+  //     idempotent. The Install Bridge migration may run multiple
+  //     times; it must not duplicate the section or corrupt the
+  //     file.
+  const baseConfig =
+    "[agents.head]\nlabel = \"Head\"\n\n[agents.dev]\nlabel = \"Dev\"\n";
+  const first = patchAgentchattrConfigForTelegramBridge(baseConfig);
+  assert.equal(first.changed, true);
+  assert.match(first.text, /^\[agents\.telegram-bridge\]$/m);
+  assert.match(first.text, /label = "Telegram Bridge"/);
+  // Running a second time is a no-op.
+  const second = patchAgentchattrConfigForTelegramBridge(first.text);
+  assert.equal(second.changed, false);
+  assert.equal(second.text, first.text);
+  // A config that was hand-patched during diagnosis is recognized
+  // as already-correct — do not clobber the operator's edit.
+  const handPatched =
+    baseConfig + "\n[agents.telegram-bridge]\nlabel = \"Telegram Bridge\"\n";
+  const third = patchAgentchattrConfigForTelegramBridge(handPatched);
+  assert.equal(third.changed, false);
+  assert.equal(third.text, handPatched);
+
+  // 15) #383 Bug 4: buildTelegramBridgeSpawnEnv strips the three
+  //     env vars the upstream bridge treats as higher-precedence
+  //     than TOML. Without this, an operator shell that exported a
+  //     different bot's token (common on machines running AC2)
+  //     silently overrode the QuadWork-written TOML and the bridge
+  //     ran as the wrong identity.
+  const scrubbed = buildTelegramBridgeSpawnEnv({
+    PATH: "/usr/bin",
+    HOME: "/home/op",
+    TELEGRAM_BOT_TOKEN: "wrong-token",
+    TELEGRAM_CHAT_ID: "-999",
+    AGENTCHATTR_URL: "http://127.0.0.1:9999",
+  });
+  assert.equal(scrubbed.TELEGRAM_BOT_TOKEN, undefined);
+  assert.equal(scrubbed.TELEGRAM_CHAT_ID, undefined);
+  assert.equal(scrubbed.AGENTCHATTR_URL, undefined);
+  // Non-telegram keys must pass through untouched — the bridge
+  // still needs PATH/HOME/etc. to find python and open files.
+  assert.equal(scrubbed.PATH, "/usr/bin");
+  assert.equal(scrubbed.HOME, "/home/op");
+
   console.log(
-    "routes.telegramBridge.test.js: all assertions passed (11 cases" +
+    "routes.telegramBridge.test.js: all assertions passed (15 cases" +
       (venvSkipped ? ", case 11 pip step skipped" : "") +
       ")",
   );

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -50,6 +50,15 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
   const [actionError, setActionError] = useState<string | null>(null);
   const [pollError, setPollError] = useState<string | null>(null);
   const [setupOpen, setSetupOpen] = useState(false);
+  // #383: the Install Bridge handler now migrates every existing
+  // per-project AC `config.toml` to declare `[agents.telegram-bridge]`
+  // (required so AC's registry accepts the bridge's register call).
+  // When that migration actually touches any configs, the operator
+  // must click SERVER → Restart for AC to load the new agent slug;
+  // otherwise Start immediately afterwards will still fail with a
+  // 400 registration loop. Surface that prompt here instead of
+  // silently returning "Installed".
+  const [restartNotice, setRestartNotice] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -69,13 +78,28 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
     return () => window.clearInterval(id);
   }, [load]);
 
+  const noteInstallResponse = (data: { patched_projects?: string[] }) => {
+    const patched = Array.isArray(data?.patched_projects) ? data.patched_projects : [];
+    if (patched.length > 0) {
+      setRestartNotice(
+        `Install Bridge patched ${patched.length} AgentChattr config(s) ` +
+        `(${patched.join(", ")}) to declare [agents.telegram-bridge]. ` +
+        `Click SERVER → Restart so AgentChattr picks up the new agent slug, ` +
+        `then click Start again. Without the restart, Start will fail with a 400 registration loop.`,
+      );
+    } else {
+      setRestartNotice(null);
+    }
+  };
+
   const start = async () => {
     setBusy(true); setActionError(null);
     try {
       // The first-time path clones + pip-installs the bridge before
       // spawning it. "install" is a no-op if it's already installed.
       if (status && !status.bridge_installed) {
-        await callTelegram("install", {});
+        const data = await callTelegram("install", {});
+        noteInstallResponse(data);
       }
       await callTelegram("start", { project_id: projectId });
       await load();
@@ -97,7 +121,10 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
     // After saving, try to start immediately — matches the
     // "Save and start bridge" affordance in the modal.
     try {
-      if (status && !status.bridge_installed) await callTelegram("install", {});
+      if (status && !status.bridge_installed) {
+        const data = await callTelegram("install", {});
+        noteInstallResponse(data);
+      }
       await callTelegram("start", { project_id: projectId });
     } catch (e) {
       // Leave the save persisted even if start fails; the operator
@@ -199,6 +226,18 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
                 </button>
               </div>
             </>
+          )}
+          {restartNotice && (
+            <div className="mt-1 p-2 text-[10px] text-accent border border-accent/40 bg-accent/5 whitespace-pre-wrap break-words">
+              {restartNotice}
+              <button
+                type="button"
+                onClick={() => setRestartNotice(null)}
+                className="block mt-1 text-text-muted hover:text-text underline"
+              >
+                dismiss
+              </button>
+            </div>
           )}
           {displayError && (
             <div className="mt-1 p-2 text-[10px] text-error border border-error/40 bg-error/5 font-mono whitespace-pre-wrap break-words max-h-40 overflow-y-auto">

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -37,6 +37,14 @@ cwd = "{{dev_cwd}}"
 color = "#da7756"
 label = "Dev Builder"
 
+# #383: AC's registry rejects bases not declared in config.toml.
+# The Telegram bridge registers as `telegram-bridge`, so every
+# per-project AC config must declare it. The bridge has no
+# command/cwd of its own — it is a long-running external client
+# that posts to AC's HTTP API.
+[agents.telegram-bridge]
+label = "Telegram Bridge"
+
 [routing]
 default = "none"
 max_agent_hops = 30


### PR DESCRIPTION
## Summary
- Fixes the four layered bugs in #383 that kept the Telegram Bridge from exchanging messages end-to-end after the #381 venv fix.
- Bug 1: `getProjectTelegram()` now prefers `project.agentchattr_url` (per-project port) over the global default.
- Bug 2: Both bridge TOML writers (`server/routes.js` start handler + `bin/quadwork.js` setup wizard) now emit `agentchattr_url` inside `[telegram]`. The upstream bridge's `load_config` never read a separate `[agentchattr]` section.
- Bug 3: `templates/config.toml` declares `[agents.telegram-bridge]`, and the Install Bridge handler runs an idempotent migration that appends the section to every existing per-project AC `config.toml`. Hand-patched configs are recognized as already-correct and not clobbered. Operator must click SERVER → Restart after Install Bridge for AC to pick up the new slug.
- Bug 4: Start handler scrubs `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` / `AGENTCHATTR_URL` from the spawn child env so an ambient shell can't override the TOML.
- Extracts four pure helpers (`resolveProjectAgentchattrUrl`, `buildTelegramBridgeToml`, `patchAgentchattrConfigForTelegramBridge`, `buildTelegramBridgeSpawnEnv`) and exports them for unit tests.

## Test plan
- [x] `node server/routes.telegramBridge.test.js` — 15 cases pass (4 new: 12-15 cover all four bugs).
- [x] `node server/routes.batchProgress.test.js` — no regression.
- [x] `node server/routes.parseActiveBatch.test.js` — no regression.
- [x] `node server/routes.chatWsSend.test.js` — no regression.
- [x] `node -e \"require('./server/routes')\"` — module loads clean.
- [ ] Manual: click Install Bridge on a machine with hand-patched configs, verify no duplicate sections and no clobbering.
- [ ] Manual: click Start on quadwork project, verify bridge registers 200 against :8301 and forwards messages both ways.

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)