### PR TITLE
[#387] Add operator-reply rule to agent seed files

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -33,7 +33,8 @@ Branch naming (strict): `task/<issue-number>-<short-slug>`
 
 ## Communication Rules
 
-- **No acknowledgment messages** — don't send "on it", "noted", "standing by"
+- **Always reply to the operator** — when the operator (sender: "user") addresses you in chat, you MUST reply via `chat_send`. The operator's terminal is invisible; if you don't `chat_send`, your response does not exist.
+- **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
 - **No status updates to Head** — Dev works silently until PR is ready
 - **Strict routing**: Dev→Reviewer1/Reviewer2 (review) → Dev→Head (merge request) → Head→Dev (merged)
 - **Post-merge silence**: Head sends ONE "merged" message. No further replies from anyone.

--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -85,5 +85,7 @@ Head owns this file — do not edit it. Read it when you need context on the bat
   - After BOTH Reviewer1 AND Reviewer2 approve → ONLY THEN message **@head** to request merge.
 - Always include issue/PR numbers in messages
 - Report blockers to @head immediately
+- **Always reply to the operator**: when the operator (sender: "user") sends a message that mentions you or is addressed to you, you MUST reply via `chat_send`. If it's a question, answer it. If it's an instruction, confirm what you will do, then do it. If it's not actionable for your role, reply explaining that and suggest which agent should handle it. The operator's terminal is invisible — if you don't `chat_send`, your response does not exist.
+- **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
 - **Do NOT send ANY message to @head between assignment and merge request** — no acks, no status updates.
 - **After merge confirmation from Head**: do NOT reply. The loop is COMPLETE — silence is required.

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -97,5 +97,7 @@ When the operator asks you in chat to start a task or batch:
 - **ALWAYS @mention the next agent** — never @user or @human
 - Route: you → @dev for task assignments. You do NOT message @reviewer1 or @reviewer2 directly.
 - Include issue/PR numbers in all messages
+- **Always reply to the operator**: when the operator (sender: "user") sends a message that mentions you or is addressed to you, you MUST reply via `chat_send`. If it's a question, answer it. If it's an instruction, confirm what you will do, then do it. If it's not actionable for your role, reply explaining that and suggest which agent should handle it. The operator's terminal is invisible — if you don't `chat_send`, your response does not exist.
+- **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
 - **Do NOT reply to acknowledgments** — if Dev says "on it" or similar, do NOT respond. Wait silently for the PR.
 - **After merge**: send ONE message: "@dev PR #<number> merged. Issue #<number> closed." — no further replies needed.

--- a/templates/seeds/reviewer1.AGENTS.md
+++ b/templates/seeds/reviewer1.AGENTS.md
@@ -101,5 +101,7 @@ Run this once at the start of each session.
 - **After BLOCK**: send message to @head AND @dev — Head decides whether to reassign or close
 - Always include PR number in messages
 - Tag specific findings with file:line references
-- **Do NOT send "standing by" or acknowledgment messages** — only message when you have a completed review to deliver.
+- **Always reply to the operator**: when the operator (sender: "user") sends a message that mentions you or is addressed to you, you MUST reply via `chat_send`. If it's a question, answer it. If it's an instruction, confirm what you will do, then do it. If it's not actionable for your role, reply explaining that and suggest which agent should handle it. The operator's terminal is invisible — if you don't `chat_send`, your response does not exist.
+- **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
+- Only send unsolicited messages when delivering a completed review verdict. But ALWAYS reply when the operator addresses you directly — even if the message is not a review request. The operator may be asking about your status, giving instructions, or testing connectivity.
 - **After merge confirmation from Head**: do NOT reply. The loop is complete — no acknowledgment needed.

--- a/templates/seeds/reviewer2.AGENTS.md
+++ b/templates/seeds/reviewer2.AGENTS.md
@@ -101,5 +101,7 @@ Run this once at the start of each session.
 - **After BLOCK**: send message to @head AND @dev — Head decides whether to reassign or close
 - Always include PR number in messages
 - Tag specific findings with file:line references
-- **Do NOT send "standing by" or acknowledgment messages** — only message when you have a completed review to deliver.
+- **Always reply to the operator**: when the operator (sender: "user") sends a message that mentions you or is addressed to you, you MUST reply via `chat_send`. If it's a question, answer it. If it's an instruction, confirm what you will do, then do it. If it's not actionable for your role, reply explaining that and suggest which agent should handle it. The operator's terminal is invisible — if you don't `chat_send`, your response does not exist.
+- **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
+- Only send unsolicited messages when delivering a completed review verdict. But ALWAYS reply when the operator addresses you directly — even if the message is not a review request. The operator may be asking about your status, giving instructions, or testing connectivity.
 - **After merge confirmation from Head**: do NOT reply. The loop is complete — no acknowledgment needed.


### PR DESCRIPTION
Fixes #387

## Summary
- Added "Always reply to the operator" rule to all 4 AGENTS.md seed files (head, dev, reviewer1, reviewer2) and `templates/CLAUDE.md`
- Clarified the existing no-ack rule to scope it to inter-agent chatter only, not operator messages
- For reviewer seeds: replaced the overly broad "only message when delivering a review" with a clarified version that preserves the intent while requiring replies to operator messages

## Test plan
- [ ] Operator sends `@reviewer1 are you online?` — reviewer1 replies
- [ ] Operator sends `@dev stop what you're doing` — dev acknowledges
- [ ] Operator sends `@head status?` — head replies with batch status
- [ ] Agents still do NOT send unprompted ack messages to each other
- [ ] Reseed per-project worktrees after merge to propagate changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)