### PR TITLE
[#388] Fix sender overflow CSS + bridge deregister on stop

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ const { spawn } = require("child_process");
 const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH } = require("./config");
 const routes = require("./routes");
 const { waitForAgentChattrReady, registerAgent, deregisterAgent, startHeartbeat, stopHeartbeat } = require("./agentchattr-registry");
+const { patchAgentchattrCss } = require("./install-agentchattr");
 const { startQueueWatcher, stopQueueWatcher } = require("./queue-watcher");
 
 const net = require("net");
@@ -1006,6 +1007,8 @@ async function handleAgentChattr(req, res) {
       }
 
       const pullResult = execSync("git pull 2>&1", { cwd: acDir, encoding: "utf-8", timeout: 30000 }).trim();
+      // #388: re-apply sender-overflow CSS patch after git pull
+      patchAgentchattrCss(acDir);
       const venvPython = path.join(acDir, ".venv", "bin", "python");
       let pipResult = "";
       const reqFile = path.join(acDir, "requirements.txt");

--- a/server/install-agentchattr.js
+++ b/server/install-agentchattr.js
@@ -192,6 +192,8 @@ function _installAgentChattrLocked(dir, setError) {
       if (pipResult === null) return setError(`pip install -r ${reqFile} failed`);
     }
   }
+  // #388: patch sender-column overflow CSS after clone/install
+  patchAgentchattrCss(dir);
   return dir;
 }
 
@@ -207,9 +209,37 @@ function chattrSpawnArgs(dir, extraArgs) {
   return { command: venvPython, spawnArgs: ["run.py", ...(extraArgs || [])], cwd: dir };
 }
 
+/**
+ * #388: Patch AgentChattr's style.css to cap the sender column width.
+ * Idempotent — skips if the marker comment is already present.
+ * Called after install and after update (git pull overwrites style.css).
+ */
+function patchAgentchattrCss(dir) {
+  if (!dir) return;
+  const cssPath = path.join(dir, "static", "style.css");
+  if (!fs.existsSync(cssPath)) return;
+  try {
+    const content = fs.readFileSync(cssPath, "utf-8");
+    if (content.includes("/* quadwork#388 sender-overflow fix */")) return;
+    const patch = `
+/* quadwork#388 sender-overflow fix */
+.msg-sender {
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: middle;
+}
+`;
+    fs.writeFileSync(cssPath, content + patch);
+  } catch {}
+}
+
 module.exports = {
   AGENTCHATTR_REPO,
   findAgentChattr,
   installAgentChattr,
   chattrSpawnArgs,
+  patchAgentchattrCss,
 };

--- a/server/install-agentchattr.js
+++ b/server/install-agentchattr.js
@@ -210,18 +210,22 @@ function chattrSpawnArgs(dir, extraArgs) {
 }
 
 /**
- * #388: Patch AgentChattr's style.css to cap the sender column width.
- * Idempotent — skips if the marker comment is already present.
- * Called after install and after update (git pull overwrites style.css).
+ * #388: Patch AgentChattr's static files for sender-column overflow.
+ * Idempotent — skips if the marker is already present.
+ * Called after install and after update (git pull overwrites static/).
+ *
+ * CSS: cap .msg-sender width with ellipsis truncation.
+ * JS:  add title attribute to .msg-sender spans for hover tooltip.
  */
 function patchAgentchattrCss(dir) {
   if (!dir) return;
+  // --- CSS patch ---
   const cssPath = path.join(dir, "static", "style.css");
-  if (!fs.existsSync(cssPath)) return;
-  try {
-    const content = fs.readFileSync(cssPath, "utf-8");
-    if (content.includes("/* quadwork#388 sender-overflow fix */")) return;
-    const patch = `
+  if (fs.existsSync(cssPath)) {
+    try {
+      const content = fs.readFileSync(cssPath, "utf-8");
+      if (!content.includes("/* quadwork#388 sender-overflow fix */")) {
+        const patch = `
 /* quadwork#388 sender-overflow fix */
 .msg-sender {
   max-width: 80px;
@@ -232,8 +236,27 @@ function patchAgentchattrCss(dir) {
   vertical-align: middle;
 }
 `;
-    fs.writeFileSync(cssPath, content + patch);
-  } catch {}
+        fs.writeFileSync(cssPath, content + patch);
+      }
+    } catch {}
+  }
+  // --- JS patch: add title attribute to .msg-sender for hover tooltip ---
+  const jsPath = path.join(dir, "static", "chat.js");
+  if (fs.existsSync(jsPath)) {
+    try {
+      const content = fs.readFileSync(jsPath, "utf-8");
+      if (!content.includes("quadwork#388")) {
+        // Add title= to the msg-sender span so truncated names show full on hover
+        const patched = content.replace(
+          /(<span class="msg-sender" style="color: \$\{senderColor\}">)/g,
+          `<span class="msg-sender" title="\${escapeHtml(msg.sender)}" style="color: \${senderColor}">`,
+        );
+        if (patched !== content) {
+          fs.writeFileSync(jsPath, patched + "\n// quadwork#388\n");
+        }
+      }
+    } catch {}
+  }
 }
 
 module.exports = {

--- a/server/routes.js
+++ b/server/routes.js
@@ -2837,6 +2837,17 @@ router.post("/api/telegram", async (req, res) => {
     case "stop": {
       const projectId = body.project_id;
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      // #388: deregister the bridge from AC before killing so the slot
+      // clears immediately instead of lingering for 60s as a stale -2/-3.
+      try {
+        const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+        const project = cfg.projects?.find((p) => p.id === projectId);
+        const acUrl = resolveProjectAgentchattrUrl(cfg, project);
+        if (acUrl) {
+          const acPort = new URL(acUrl).port || "8300";
+          fetch(`http://127.0.0.1:${acPort}/api/deregister/telegram-bridge`, { method: "POST" }).catch(() => {});
+        }
+      } catch {}
       try {
         const pf = telegramPidFile(projectId);
         if (fs.existsSync(pf)) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -2839,13 +2839,17 @@ router.post("/api/telegram", async (req, res) => {
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
       // #388: deregister the bridge from AC before killing so the slot
       // clears immediately instead of lingering for 60s as a stale -2/-3.
+      // Awaited so a fast stop→start cycle doesn't race the deregister.
       try {
         const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
         const project = cfg.projects?.find((p) => p.id === projectId);
         const acUrl = resolveProjectAgentchattrUrl(cfg, project);
         if (acUrl) {
           const acPort = new URL(acUrl).port || "8300";
-          fetch(`http://127.0.0.1:${acPort}/api/deregister/telegram-bridge`, { method: "POST" }).catch(() => {});
+          await fetch(`http://127.0.0.1:${acPort}/api/deregister/telegram-bridge`, {
+            method: "POST",
+            signal: AbortSignal.timeout(3000),
+          }).catch(() => {});
         }
       } catch {}
       try {


### PR DESCRIPTION
Fixes #388

## Summary
- **Issue A (CSS overflow):** Added `patchAgentchattrCss()` to `install-agentchattr.js` that appends `max-width`, `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` to AC's `.msg-sender` class. Called after install and after update (git pull overwrites style.css). Idempotent via marker comment.
- **Issue B (stale slots):** Added deregister call to AC's `/api/deregister/telegram-bridge` in the telegram bridge "stop" handler so the slot clears immediately instead of lingering for 60s as a stale `-2`/`-3` suffix. Regular agent sessions already deregister on stop via `stopAgentSession`.

## Test plan
- [ ] Install AC fresh → verify `.msg-sender` CSS patch in `~/.quadwork/<project>/agentchattr/static/style.css`
- [ ] Update AC (SERVER → Update) → verify CSS patch survives git pull
- [ ] Long agent names in chat are truncated with ellipsis in the sender column
- [ ] Stop telegram bridge → verify `telegram-bridge` slot deregisters from AC immediately (no 60s linger)
- [ ] Restart cycle: no `-2`/`-3` suffixed slots accumulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)