### PR TITLE
[#393] Add orphan cleanup to AC start path

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -888,6 +888,13 @@ async function handleAgentChattr(req, res) {
     if (proc.state === "running" && proc.process) {
       return res.json({ ok: true, state: "running", message: "Already running" });
     }
+    // #393: kill any orphaned process on the port before spawning
+    // (same pattern as restart/stop from #386).
+    killProcessOnPort(chattrPort);
+    const portFree = await waitForPortFree(chattrPort, 3000);
+    if (!portFree) {
+      console.warn(`[agentchattr] ${projectId} port ${chattrPort} still occupied after 3s — spawning anyway`);
+    }
     try {
       const child = spawnChattr();
       if (!child) {


### PR DESCRIPTION
Fixes #393

## Summary
- The `action === "start"` path in `handleAgentChattr` now calls `killProcessOnPort()` + `waitForPortFree()` before spawning, matching the restart/stop/update paths from PR #389
- Fixes the case where QuadWork restarts but a detached AC process survives — clicking Start now cleans up the orphan first

## Test plan
- [ ] Kill QuadWork while AC is running, restart QuadWork, click Start — old orphan is killed, new AC starts on same port
- [ ] Normal first start (no orphan) still works without delay
- [ ] Port occupied by non-AC process: start proceeds after 3s timeout with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)