### PR TITLE
[#394] Backfill sender-overflow patch on every AC spawn

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -801,6 +801,9 @@ async function handleAgentChattr(req, res) {
 
     // Resolve AgentChattr from its cloned directory
     const { dir: acDir } = resolveProjectChattr(projectId);
+    // #394: backfill sender-overflow CSS/JS patch on every spawn so
+    // existing installs receive the fix without manual update.
+    patchAgentchattrCss(acDir);
     const acSpawn = resolveChattrSpawn(acDir);
     if (!acSpawn) {
       setProc({ process: null, state: "error", error: `AgentChattr not installed. Clone it: git clone https://github.com/bcurts/agentchattr.git ${acDir}` });


### PR DESCRIPTION
Fixes #394

## Summary
- Added `patchAgentchattrCss(acDir)` call inside `spawnChattr()` so every AC start/restart applies the CSS/JS sender-overflow fix from PR #392 to existing installs automatically
- No manual update or reinstall needed — the patch is idempotent and runs before each spawn

## Test plan
- [ ] Existing project with AC installed (no update since #392) — click Start → verify `style.css` and `chat.js` get patched
- [ ] Already-patched installs — verify no duplicate CSS/JS markers
- [ ] Fresh install path still works (patch applied by both install and spawn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)