### PR TITLE
[#401] Guard AC install before port cleanup on Start

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -891,6 +891,17 @@ async function handleAgentChattr(req, res) {
     if (proc.state === "running" && proc.process) {
       return res.json({ ok: true, state: "running", message: "Already running" });
     }
+    // #401: validate AgentChattr is installed BEFORE killing anything on
+    // the port. Without this guard, clicking Start when AC is missing
+    // kills an unrelated process then fails with "not installed".
+    const { dir: acDir } = resolveProjectChattr(projectId);
+    const acSpawn = resolveChattrSpawn(acDir);
+    if (!acSpawn) {
+      const errMsg = `AgentChattr not installed. Clone it: git clone https://github.com/bcurts/agentchattr.git ${acDir}`;
+      setProc({ process: null, state: "error", error: errMsg });
+      return res.status(500).json({ ok: false, state: "error", error: errMsg });
+    }
+
     // #393: kill any orphaned process on the port before spawning
     // (same pattern as restart/stop from #386).
     killProcessOnPort(chattrPort);


### PR DESCRIPTION
## Summary
- Moves AgentChattr install validation (`resolveProjectChattr` + `resolveChattrSpawn`) **before** the orphaned-port `killProcessOnPort` call in the `start` action.
- If AC is not installed/runnable, the start path returns a clear error immediately **without** killing any process on the configured port.
- The orphan cleanup from PR #395 still runs when AC is valid and startable.

## Test plan
- [ ] With AC missing: click Start → error returned, no process killed on the port
- [ ] With AC installed: click Start → orphan cleanup runs, AC starts normally
- [ ] Stop/Restart paths unchanged — still kill port as before

Fixes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)