### PR TITLE
[#402] Backfill sender-overflow patch on QuadWork startup

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1743,10 +1743,14 @@ setInterval(runLoopGuardPollingTick, LOOP_GUARD_POLL_INTERVAL_MS);
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`QuadWork server listening on http://127.0.0.1:${PORT}`);
   syncTriggersFromConfig();
-  // Sync AgentChattr tokens for all projects on startup
+  // Sync AgentChattr tokens for all projects on startup and backfill
+  // the sender-overflow CSS/JS patch (#402) so already-running AC
+  // instances receive the fix without requiring a restart.
   const startupCfg = readConfig();
   for (const p of (startupCfg.projects || [])) {
     syncChattrToken(p.id);
+    const { dir: acDir } = resolveProjectChattr(p.id);
+    if (acDir) patchAgentchattrCss(acDir);
   }
 });
 


### PR DESCRIPTION
## Summary
- Adds `patchAgentchattrCss()` call to the server startup loop that already iterates all projects for token sync.
- Already-running AC instances now receive the CSS/JS sender-overflow fix immediately after a QuadWork upgrade, without requiring the operator to restart AgentChattr.
- The patch function is idempotent (checks for `/* quadwork#388 */` marker), so repeated startups and the existing `spawnChattr()` path are safe.

## Test plan
- [ ] Upgrade QuadWork with AC already running → CSS/JS files patched on startup
- [ ] Restart QuadWork again → no duplicate patches (idempotent)
- [ ] Start a new AC instance → still patched via `spawnChattr()` as before

Fixes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)