### PR TITLE
[#391] Global notification sound across all pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Sidebar from "@/components/Sidebar";
 import TopHeader from "@/components/TopHeader";
+import GlobalNotificationListener from "@/components/GlobalNotificationListener";
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -22,6 +23,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geistMono.variable} h-full`}>
       <body className="h-full flex flex-col">
+        <GlobalNotificationListener />
         <TopHeader />
         <div className="flex flex-1 min-h-0">
           <Sidebar />

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import ProjectChatEmptyState from "./ProjectChatEmptyState";
-import { playNotificationSound } from "../lib/notificationSound";
 
 interface Message {
   id: number;
@@ -192,22 +191,6 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
   // #397 / quadwork#262: tracks the message the next send will be a
   // threaded reply to. Cleared after a successful send or on cancel.
   const [replyTo, setReplyTo] = useState<{ id: number; sender: string } | null>(null);
-  // #409 / quadwork#273 + #405 / quadwork#278: track the operator's
-  // configured display name so the notification-sound filter
-  // suppresses self-messages even when the operator renamed
-  // themselves (e.g. operator_name = "alice"). Held in a ref so the
-  // hot poll path doesn't need a dep on the state value.
-  const operatorNameRef = useRef<string>("user");
-  useEffect(() => {
-    fetch("/api/config")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((cfg) => {
-        if (cfg && typeof cfg.operator_name === "string" && cfg.operator_name) {
-          operatorNameRef.current = cfg.operator_name;
-        }
-      })
-      .catch(() => {});
-  }, []);
   const cursorRef = useRef(0);
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -243,25 +226,6 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
         setAuthError(null);
         const msgs: Message[] = Array.isArray(data) ? data : data.messages || [];
         if (msgs.length > 0) {
-          // #409 / quadwork#273: ding on incoming agent chat. Skip
-          // the operator's own messages, skip system/join/leave
-          // events, and only fire after the first poll has populated
-          // the cursor so the initial backfill doesn't dump a chord
-          // of historical pings. Detected here (outside the
-          // setMessages updater) so React strict mode's double-invoke
-          // can't double-fire the audio.
-          const previousCursor = cursorRef.current;
-          const opName = operatorNameRef.current;
-          const newAgentMessage =
-            previousCursor > 0 &&
-            msgs.some(
-              (m) =>
-                m.id > previousCursor &&
-                (m.type === undefined || m.type === "chat") &&
-                m.sender !== "user" &&
-                m.sender !== opName &&
-                m.sender !== "system",
-            );
           setMessages((prev) => {
             const existingIds = new Set(prev.map((m) => m.id));
             const newMsgs = msgs.filter((m) => !existingIds.has(m.id));
@@ -269,7 +233,6 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
           });
           const maxId = Math.max(...msgs.map((m) => m.id));
           if (maxId > cursorRef.current) cursorRef.current = maxId;
-          if (newAgentMessage) playNotificationSound();
         }
       })
       .catch(() => {});

--- a/src/components/GlobalNotificationListener.tsx
+++ b/src/components/GlobalNotificationListener.tsx
@@ -27,17 +27,35 @@ export default function GlobalNotificationListener() {
   // Whether initial config has loaded (skip polling until we know projects).
   const readyRef = useRef(false);
 
-  // Fetch config once to populate project list + operator name.
+  // Fetch config once to populate project list + operator name, then
+  // seed per-project cursors so the first genuinely new message chimes
+  // instead of being swallowed by the "initial backfill" guard.
   useEffect(() => {
     fetch("/api/config")
       .then((r) => (r.ok ? r.json() : null))
-      .then((cfg) => {
+      .then(async (cfg) => {
         if (!cfg) return;
         if (typeof cfg.operator_name === "string" && cfg.operator_name) {
           operatorNameRef.current = cfg.operator_name;
         }
         const projects: Project[] = cfg.projects || [];
         projectsRef.current = projects;
+        // Seed cursors: fetch current max message id per project so
+        // the polling loop treats everything already present as "seen".
+        await Promise.all(
+          projects.map((p) =>
+            fetch(`/api/chat?path=/api/messages&channel=general&cursor=0&project=${encodeURIComponent(p.id)}`)
+              .then((r) => (r.ok ? r.json() : null))
+              .then((data) => {
+                if (!data) return;
+                const msgs: { id: number }[] = Array.isArray(data) ? data : data.messages || [];
+                if (msgs.length > 0) {
+                  cursorsRef.current[p.id] = Math.max(...msgs.map((m) => m.id));
+                }
+              })
+              .catch(() => {}),
+          ),
+        );
         readyRef.current = true;
       })
       .catch(() => {});
@@ -61,10 +79,6 @@ export default function GlobalNotificationListener() {
           const prevCursor = cursorsRef.current[project.id] ?? 0;
           const maxId = Math.max(...msgs.map((m) => m.id));
           if (maxId > prevCursor) cursorsRef.current[project.id] = maxId;
-
-          // Only fire after the first poll has seeded the cursor so the
-          // initial backfill doesn't produce a burst of chimes.
-          if (prevCursor === 0) return;
 
           const opName = operatorNameRef.current;
           const hasNewAgentMessage = msgs.some(

--- a/src/components/GlobalNotificationListener.tsx
+++ b/src/components/GlobalNotificationListener.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * #391: Global notification listener — plays the notification chime for
+ * ALL projects with sound enabled, regardless of which page is displayed.
+ *
+ * Mounted once in the root layout so it survives page navigation. Polls
+ * /api/chat per project on a 3s interval (same cadence as ChatPanel).
+ * Replaces the per-ChatPanel notification logic to avoid double-play.
+ */
+
+import { useEffect, useRef, useCallback } from "react";
+import { playNotificationSound } from "../lib/notificationSound";
+
+interface Project {
+  id: string;
+  agentchattr_url?: string;
+}
+
+export default function GlobalNotificationListener() {
+  // Per-project cursors so we only fire on genuinely new messages.
+  const cursorsRef = useRef<Record<string, number>>({});
+  // Operator name for filtering self-messages.
+  const operatorNameRef = useRef<string>("user");
+  // Project list refreshed from config.
+  const projectsRef = useRef<Project[]>([]);
+  // Whether initial config has loaded (skip polling until we know projects).
+  const readyRef = useRef(false);
+
+  // Fetch config once to populate project list + operator name.
+  useEffect(() => {
+    fetch("/api/config")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (!cfg) return;
+        if (typeof cfg.operator_name === "string" && cfg.operator_name) {
+          operatorNameRef.current = cfg.operator_name;
+        }
+        const projects: Project[] = cfg.projects || [];
+        projectsRef.current = projects;
+        readyRef.current = true;
+      })
+      .catch(() => {});
+  }, []);
+
+  const pollAll = useCallback(() => {
+    if (!readyRef.current) return;
+    for (const project of projectsRef.current) {
+      const cursor = cursorsRef.current[project.id] ?? 0;
+      fetch(
+        `/api/chat?path=/api/messages&channel=general&cursor=${cursor}&project=${encodeURIComponent(project.id)}`,
+      )
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (!data) return;
+          const msgs: { id: number; sender: string; type?: string }[] = Array.isArray(data)
+            ? data
+            : data.messages || [];
+          if (msgs.length === 0) return;
+
+          const prevCursor = cursorsRef.current[project.id] ?? 0;
+          const maxId = Math.max(...msgs.map((m) => m.id));
+          if (maxId > prevCursor) cursorsRef.current[project.id] = maxId;
+
+          // Only fire after the first poll has seeded the cursor so the
+          // initial backfill doesn't produce a burst of chimes.
+          if (prevCursor === 0) return;
+
+          const opName = operatorNameRef.current;
+          const hasNewAgentMessage = msgs.some(
+            (m) =>
+              m.id > prevCursor &&
+              (m.type === undefined || m.type === "chat") &&
+              m.sender !== "user" &&
+              m.sender !== opName &&
+              m.sender !== "system",
+          );
+          if (hasNewAgentMessage) playNotificationSound();
+        })
+        .catch(() => {});
+    }
+  }, []);
+
+  useEffect(() => {
+    // Small delay on first poll to let config load.
+    const initial = setTimeout(pollAll, 1500);
+    const interval = setInterval(pollAll, 3000);
+    return () => {
+      clearTimeout(initial);
+      clearInterval(interval);
+    };
+  }, [pollAll]);
+
+  // Invisible — no DOM output.
+  return null;
+}


### PR DESCRIPTION
## Summary
- New `GlobalNotificationListener` component mounted in root `layout.tsx` — always active regardless of which page is displayed.
- Polls `/api/chat` per project on a 3s interval, tracks per-project cursors, filters self/system messages, and plays the configured chime on new agent messages.
- Removed notification detection + playback from `ChatPanel` (deferred entirely to the global listener to avoid double-play).
- Reads the same localStorage prefs (sound choice, enabled, background-only) that ControlBar already manages.

## Test plan
- [ ] On Home page: agent posts on any project → chime plays
- [ ] On different project page: agent posts on another project → chime plays
- [ ] On Settings page: agent posts → chime plays
- [ ] Sound toggle off → no chime
- [ ] Background-only mode: tab focused → no chime; tab blurred → chime plays
- [ ] Operator's own messages and system events do not trigger chime
- [ ] No double chime when on the project page (ChatPanel no longer plays)
- [ ] Initial page load does not burst historical chimes (cursor seeding)

Fixes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)