### PR TITLE
[#391] Fix global notification resilience + project refresh

### DIFF
--- a/src/components/GlobalNotificationListener.tsx
+++ b/src/components/GlobalNotificationListener.tsx
@@ -17,6 +17,9 @@ interface Project {
   agentchattr_url?: string;
 }
 
+// How often to re-fetch config to pick up added/removed projects.
+const CONFIG_REFRESH_MS = 30_000;
+
 export default function GlobalNotificationListener() {
   // Per-project cursors so we only fire on genuinely new messages.
   const cursorsRef = useRef<Record<string, number>>({});
@@ -27,44 +30,67 @@ export default function GlobalNotificationListener() {
   // Whether initial config has loaded (skip polling until we know projects).
   const readyRef = useRef(false);
 
-  // Fetch config once to populate project list + operator name, then
-  // seed per-project cursors so the first genuinely new message chimes
-  // instead of being swallowed by the "initial backfill" guard.
-  useEffect(() => {
+  // Seed cursor for a single project (best-effort, non-blocking).
+  const seedCursor = useCallback((projectId: string) => {
+    if (cursorsRef.current[projectId] != null) return; // already seeded
+    fetch(`/api/chat?path=/api/messages&channel=general&cursor=0&project=${encodeURIComponent(projectId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!data) return;
+        const msgs: { id: number }[] = Array.isArray(data) ? data : data.messages || [];
+        if (msgs.length > 0) {
+          cursorsRef.current[projectId] = Math.max(...msgs.map((m) => m.id));
+        } else {
+          // Mark as seeded with 0 so pollAll doesn't skip it.
+          cursorsRef.current[projectId] = 0;
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  // Fetch config to populate/refresh project list + operator name.
+  // Seeds cursors for any newly discovered projects.
+  const refreshConfig = useCallback(() => {
     fetch("/api/config")
       .then((r) => (r.ok ? r.json() : null))
-      .then(async (cfg) => {
+      .then((cfg) => {
         if (!cfg) return;
         if (typeof cfg.operator_name === "string" && cfg.operator_name) {
           operatorNameRef.current = cfg.operator_name;
         }
         const projects: Project[] = cfg.projects || [];
         projectsRef.current = projects;
-        // Seed cursors: fetch current max message id per project so
-        // the polling loop treats everything already present as "seen".
-        await Promise.all(
-          projects.map((p) =>
-            fetch(`/api/chat?path=/api/messages&channel=general&cursor=0&project=${encodeURIComponent(p.id)}`)
-              .then((r) => (r.ok ? r.json() : null))
-              .then((data) => {
-                if (!data) return;
-                const msgs: { id: number }[] = Array.isArray(data) ? data : data.messages || [];
-                if (msgs.length > 0) {
-                  cursorsRef.current[p.id] = Math.max(...msgs.map((m) => m.id));
-                }
-              })
-              .catch(() => {}),
-          ),
-        );
+        // Seed cursors for any projects we haven't seen yet.
+        for (const p of projects) {
+          seedCursor(p.id);
+        }
+        // Clean up cursors for removed projects.
+        const activeIds = new Set(projects.map((p) => p.id));
+        for (const id of Object.keys(cursorsRef.current)) {
+          if (!activeIds.has(id)) delete cursorsRef.current[id];
+        }
         readyRef.current = true;
       })
-      .catch(() => {});
-  }, []);
+      .catch(() => {
+        // Transient failure — readyRef stays as-is. If this was the
+        // first attempt, the next refresh cycle will retry.
+      });
+  }, [seedCursor]);
+
+  // Initial config fetch + periodic refresh to pick up project changes
+  // and recover from transient startup failures.
+  useEffect(() => {
+    refreshConfig();
+    const interval = setInterval(refreshConfig, CONFIG_REFRESH_MS);
+    return () => clearInterval(interval);
+  }, [refreshConfig]);
 
   const pollAll = useCallback(() => {
     if (!readyRef.current) return;
     for (const project of projectsRef.current) {
-      const cursor = cursorsRef.current[project.id] ?? 0;
+      const cursor = cursorsRef.current[project.id];
+      // Skip projects whose cursor hasn't been seeded yet.
+      if (cursor == null) continue;
       fetch(
         `/api/chat?path=/api/messages&channel=general&cursor=${cursor}&project=${encodeURIComponent(project.id)}`,
       )
@@ -96,8 +122,8 @@ export default function GlobalNotificationListener() {
   }, []);
 
   useEffect(() => {
-    // Small delay on first poll to let config load.
-    const initial = setTimeout(pollAll, 1500);
+    // Small delay on first poll to let config + cursor seeding complete.
+    const initial = setTimeout(pollAll, 2000);
     const interval = setInterval(pollAll, 3000);
     return () => {
       clearTimeout(initial);

--- a/src/components/GlobalNotificationListener.tsx
+++ b/src/components/GlobalNotificationListener.tsx
@@ -29,23 +29,20 @@ export default function GlobalNotificationListener() {
   const projectsRef = useRef<Project[]>([]);
   // Whether initial config has loaded (skip polling until we know projects).
   const readyRef = useRef(false);
+  // #410 review fix: projects whose first poll should advance the cursor
+  // without chiming. Prevents false notifications for pre-existing messages
+  // while eliminating the async-seed race that could swallow the first real
+  // post-add message.
+  const suppressChimeRef = useRef<Set<string>>(new Set());
 
-  // Seed cursor for a single project (best-effort, non-blocking).
+  // Seed cursor for a single project. Synchronous — sets cursor to 0
+  // immediately so pollAll can start on the next cycle. The first poll
+  // result advances the cursor but suppresses the chime (via
+  // suppressChimeRef) to avoid false notifications for old messages.
   const seedCursor = useCallback((projectId: string) => {
     if (cursorsRef.current[projectId] != null) return; // already seeded
-    fetch(`/api/chat?path=/api/messages&channel=general&cursor=0&project=${encodeURIComponent(projectId)}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (!data) return;
-        const msgs: { id: number }[] = Array.isArray(data) ? data : data.messages || [];
-        if (msgs.length > 0) {
-          cursorsRef.current[projectId] = Math.max(...msgs.map((m) => m.id));
-        } else {
-          // Mark as seeded with 0 so pollAll doesn't skip it.
-          cursorsRef.current[projectId] = 0;
-        }
-      })
-      .catch(() => {});
+    cursorsRef.current[projectId] = 0;
+    suppressChimeRef.current.add(projectId);
   }, []);
 
   // Fetch config to populate/refresh project list + operator name.
@@ -107,6 +104,13 @@ export default function GlobalNotificationListener() {
           if (maxId > prevCursor) cursorsRef.current[project.id] = maxId;
 
           const opName = operatorNameRef.current;
+          // Suppress chime on the first poll after seeding — this batch
+          // contains pre-existing messages, not genuinely new ones.
+          if (suppressChimeRef.current.has(project.id)) {
+            suppressChimeRef.current.delete(project.id);
+            return;
+          }
+
           const hasNewAgentMessage = msgs.some(
             (m) =>
               m.id > prevCursor &&
@@ -122,13 +126,9 @@ export default function GlobalNotificationListener() {
   }, []);
 
   useEffect(() => {
-    // Small delay on first poll to let config + cursor seeding complete.
-    const initial = setTimeout(pollAll, 2000);
+    // Cursor seeding is now synchronous, so no startup delay needed.
     const interval = setInterval(pollAll, 3000);
-    return () => {
-      clearTimeout(initial);
-      clearInterval(interval);
-    };
+    return () => clearInterval(interval);
   }, [pollAll]);
 
   // Invisible — no DOM output.

--- a/src/components/GlobalNotificationListener.tsx
+++ b/src/components/GlobalNotificationListener.tsx
@@ -97,7 +97,11 @@ export default function GlobalNotificationListener() {
           const msgs: { id: number; sender: string; type?: string }[] = Array.isArray(data)
             ? data
             : data.messages || [];
-          if (msgs.length === 0) return;
+          if (msgs.length === 0) {
+            // Clear suppress flag so the next poll with real messages chimes.
+            suppressChimeRef.current.delete(project.id);
+            return;
+          }
 
           const prevCursor = cursorsRef.current[project.id] ?? 0;
           const maxId = Math.max(...msgs.map((m) => m.id));


### PR DESCRIPTION
## Summary
Follow-up to merged PR #406, addressing two findings from @head's Batch 8 review:

1. **Config fetch failure resilience**: `refreshConfig()` now retries every 30s instead of being a one-shot. A transient startup failure no longer permanently disables notifications for the session.

2. **Periodic project list refresh**: Project list is re-fetched every 30s so newly added projects start chiming and removed projects stop polling — without requiring a page reload.

Also improved cursor seeding to be per-project and skip already-seeded projects, so new projects discovered mid-session get proper cursor initialization.

## Test plan
- [ ] Kill the QuadWork server briefly on page load, then restart → notifications recover within 30s
- [ ] Add a new project while dashboard is open → chimes start within 30s without reload
- [ ] Remove a project → polling stops for it within 30s
- [ ] Existing behavior unchanged: chimes on new agent messages, no chime on self/system

🤖 Generated with [Claude Code](https://claude.com/claude-code)