### PR TITLE
[#410] Fix chat panel welcome screen showing over existing messages

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -228,7 +228,6 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
       })
       .then((data) => {
         setAuthError(null);
-        setLoaded(true);
         const msgs: Message[] = Array.isArray(data) ? data : data.messages || [];
         if (msgs.length > 0) {
           setMessages((prev) => {
@@ -240,7 +239,8 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
           if (maxId > cursorRef.current) cursorRef.current = maxId;
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => { setLoaded(true); });
   }, [channel, projectId]);
 
   useEffect(() => {

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -175,6 +175,9 @@ export default function ChatPanel({ projectId }: ChatPanelProps) {
 function ChatPanelAPI({ projectId }: { projectId?: string }) {
   const channel = "general";
   const [messages, setMessages] = useState<Message[]>([]);
+  // #410: track whether the initial fetch has completed so we don't
+  // flash the welcome/empty state while messages are still loading.
+  const [loaded, setLoaded] = useState(false);
   const [input, setInput] = useState("");
   const [showMentions, setShowMentions] = useState(false);
   const [mentionFilter, setMentionFilter] = useState("");
@@ -207,6 +210,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
   useEffect(() => {
     cursorRef.current = 0;
     setMessages([]);
+    setLoaded(false);
   }, [projectId]);
 
   // Poll messages via proxy
@@ -224,6 +228,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
       })
       .then((data) => {
         setAuthError(null);
+        setLoaded(true);
         const msgs: Message[] = Array.isArray(data) ? data : data.messages || [];
         if (msgs.length > 0) {
           setMessages((prev) => {
@@ -381,7 +386,12 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
         onScroll={handleScroll}
         className="flex-1 min-h-0 overflow-y-auto px-3 py-2 space-y-0.5"
       >
-        {messages.length === 0 && (
+        {!loaded && messages.length === 0 && (
+          <div className="flex items-center justify-center h-full">
+            <span className="text-xs text-text-muted">Loading messages...</span>
+          </div>
+        )}
+        {loaded && messages.length === 0 && (
           // #229: replace the bare "No messages" text with a richer
           // empty state — friendly icon, headline, click-to-insert
           // example chips, and a How to Work modal trigger.


### PR DESCRIPTION
## Summary
- **Bug**: Chat panel displayed the "Ready when you are" welcome screen on page load even when the channel had existing messages (from bridge, agents, or prior conversations). The welcome screen only disappeared after the user sent a message locally.
- **Root cause**: `messages` state starts as `[]`, so the empty-state guard (`messages.length === 0`) was true until the first poll returned — and the welcome screen rendered in that window. For channels with messages, the poll would fill `messages`, but the initial flash was jarring and confusing.
- **Fix**: Added a `loaded` flag (default `false`) that flips to `true` after the first successful `/api/chat` poll. The welcome/empty state only renders when `loaded && messages.length === 0`. A "Loading messages..." placeholder shows during the initial fetch.

Fixes #410

## Test plan
- [ ] Navigate to a project with existing chat messages — should show messages immediately, no welcome screen flash
- [ ] Navigate to a project with zero messages — should show "Loading messages..." briefly, then the welcome screen
- [ ] Switch between projects — loading state resets correctly per project
- [ ] Messages arriving via Telegram bridge while page is open appear in real-time
- [ ] No regression to chat input, @mention autocomplete, or slash command menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)