### PR TITLE
[#407] Add info tooltips to all project page sections

### DIFF
--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -20,6 +20,7 @@
 // widgets — see #367 for the rationale.
 
 import { useCallback, useEffect, useState } from "react";
+import InfoTooltip from "./InfoTooltip";
 
 interface AgentRow {
   agent_id: string;
@@ -275,7 +276,12 @@ export default function AgentModelsButton({ projectId }: AgentModelsWidgetProps)
     <>
       <div className="flex flex-col border border-border">
         <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
-          <span className="text-[11px] text-text-muted uppercase tracking-wider">Agent Models</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] text-text-muted uppercase tracking-wider">Agent Models</span>
+            <InfoTooltip>
+              <b>Agent Models</b> — configure which LLM model and reasoning effort each agent uses. Changes require an agent restart to take effect.
+            </InfoTooltip>
+          </div>
           <button
             type="button"
             onClick={() => setOpen(true)}

--- a/src/components/BatchProgressPanel.tsx
+++ b/src/components/BatchProgressPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import InfoTooltip from "./InfoTooltip";
 
 interface BatchProgressItem {
   issue_number: number;
@@ -112,6 +113,9 @@ export default function BatchProgressPanel({ projectId }: BatchProgressPanelProp
           Current Batch: Batch {data.batch_number ?? "—"}
         </span>
         <span className="text-[10px] text-text-muted">({data.items.length} items)</span>
+        <InfoTooltip>
+          <b>Current Batch</b> — progress tracker for the active batch. Polls GitHub to resolve each issue&apos;s status (queued &rarr; in review &rarr; approved &rarr; merged).
+        </InfoTooltip>
       </div>
       <div className="max-h-40 overflow-y-auto">
         {data.items.map((item) => {

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import InfoTooltip from "./InfoTooltip";
 import OvernightQueueModal from "./OvernightQueueModal";
 import BatchProgressPanel from "./BatchProgressPanel";
 
@@ -152,10 +153,13 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
       <div className="flex-1 min-h-0 flex">
         {/* Issues column */}
         <div className="flex-1 min-w-0 flex flex-col border-r border-border">
-          <div className="px-3 py-1.5 border-b border-border shrink-0">
+          <div className="px-3 py-1.5 border-b border-border shrink-0 flex items-center gap-1.5">
             <span className="text-[10px] text-text-muted uppercase tracking-wider">
               Issues ({issues.length})
             </span>
+            <InfoTooltip>
+              <b>Issues</b> — open issues on the project&apos;s GitHub repo. Click any item to open it on GitHub.
+            </InfoTooltip>
           </div>
           <div className="flex-1 min-h-0 overflow-y-auto">
             {issues.length === 0 && (
@@ -205,10 +209,13 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
 
         {/* PRs column */}
         <div className="flex-1 min-w-0 flex flex-col">
-          <div className="px-3 py-1.5 border-b border-border shrink-0">
+          <div className="px-3 py-1.5 border-b border-border shrink-0 flex items-center gap-1.5">
             <span className="text-[10px] text-text-muted uppercase tracking-wider">
               Pull Requests ({prs.length})
             </span>
+            <InfoTooltip>
+              <b>Pull Requests</b> — open PRs awaiting review or merge. Click to open on GitHub.
+            </InfoTooltip>
           </div>
           <div className="flex-1 min-h-0 overflow-y-auto">
             {prs.length === 0 && (
@@ -298,7 +305,12 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
 
       {/* #226: compact OVERNIGHT-QUEUE.md row at the bottom */}
       <div className="shrink-0 flex items-center justify-between px-3 py-1.5 border-t border-border">
-        <span className="text-[11px] text-text-muted font-mono">OVERNIGHT-QUEUE.md</span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] text-text-muted font-mono">OVERNIGHT-QUEUE.md</span>
+          <InfoTooltip>
+            <b>Overnight Queue</b> — the task queue file Head reads to pick the next ticket. Click Edit to modify batch contents and ordering.
+          </InfoTooltip>
+        </div>
         <button
           onClick={() => setQueueModalOpen(true)}
           className="px-2 py-0.5 text-[10px] text-text-muted hover:text-accent border border-border hover:border-accent transition-colors uppercase tracking-wider"

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+interface InfoTooltipProps {
+  children: React.ReactNode;
+}
+
+/**
+ * #407: Reusable (?) info tooltip button. Click to toggle a popover
+ * with help text. Dismisses on click-outside or Escape.
+ *
+ * Matches the existing pattern from ControlBar (#311) and
+ * AgentTerminalsGrid — consistent `w-3.5 h-3.5 rounded-full`
+ * styling with accent hover.
+ */
+export default function InfoTooltip({ children }: InfoTooltipProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClickOutside);
+    document.addEventListener("keydown", onEsc);
+    return () => {
+      document.removeEventListener("mousedown", onClickOutside);
+      document.removeEventListener("keydown", onEsc);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-3.5 h-3.5 rounded-full border border-border text-[9px] leading-none text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
+      >?</button>
+      {open && (
+        <div className="absolute left-0 top-5 z-30 w-64 p-2 text-[10px] leading-snug text-text bg-bg-surface border border-border rounded shadow-lg">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import PanelHeader from "./PanelHeader";
+import InfoTooltip from "./InfoTooltip";
 import ScheduledTriggerWidget from "./ScheduledTriggerWidget";
 import TelegramBridgeWidget from "./TelegramBridgeWidget";
 import LoopGuardWidget from "./LoopGuardWidget";
@@ -30,7 +31,11 @@ import AgentModelsWidget from "./AgentModelsWidget";
 export default function OperatorFeaturesPanel({ projectId }: { projectId: string }) {
   return (
     <div className="flex flex-col h-full min-h-0">
-      <PanelHeader label="Operator Features" />
+      <PanelHeader label="Operator Features" tooltip={
+        <InfoTooltip>
+          <b>Operator Features</b> — tools for running autonomous overnight batches. Includes the Scheduled Trigger, Telegram Bridge, Loop Guard, Project History, and Agent Models.
+        </InfoTooltip>
+      } />
       <div className="flex-1 min-h-0 flex flex-col lg:flex-row gap-2 p-2 overflow-auto lg:overflow-hidden">
         {/* Left column: Scheduled Trigger spans full panel height.
             min-w-[280px] at lg+ keeps the message textarea from

--- a/src/components/PanelHeader.tsx
+++ b/src/components/PanelHeader.tsx
@@ -1,14 +1,18 @@
 "use client";
 
+import React from "react";
+
 interface PanelHeaderProps {
   label: string;
   status?: "running" | "stopped" | "error";
   projectId?: string;
   agentId?: string;
   onStatusChange?: (newStatus: string) => void;
+  /** #407: optional info tooltip element rendered after the label */
+  tooltip?: React.ReactNode;
 }
 
-export default function PanelHeader({ label, status, projectId, agentId, onStatusChange }: PanelHeaderProps) {
+export default function PanelHeader({ label, status, projectId, agentId, onStatusChange, tooltip }: PanelHeaderProps) {
   const dotColor =
     status === "running"
       ? "bg-accent"
@@ -39,6 +43,7 @@ export default function PanelHeader({ label, status, projectId, agentId, onStatu
         <span className="text-[11px] text-text-muted uppercase tracking-wider">
           {label}
         </span>
+        {tooltip}
       </div>
       {showControls && (
         <div className="flex items-center gap-1">

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import PanelHeader from "./PanelHeader";
+import InfoTooltip from "./InfoTooltip";
 import ChatPanel from "./ChatPanel";
 import GitHubPanel from "./GitHubPanel";
 import ControlBar from "./ControlBar";
@@ -112,7 +113,11 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
           the primary interface (#208). 2px accent border + explicit
           "primary chat" label in the panel header. */}
       <div className="flex flex-col overflow-hidden border-2 border-accent">
-        <PanelHeader label="AgentChattr — primary chat" />
+        <PanelHeader label="AgentChattr — primary chat" tooltip={
+          <InfoTooltip>
+            <b>Primary Chat</b> — live chat between you and the 4 AI agents. Messages you type here trigger agent actions. Use @mentions to address specific agents.
+          </InfoTooltip>
+        } />
         <div className="flex-1 min-h-0">
           <ChatPanel projectId={projectId} />
         </div>
@@ -155,7 +160,11 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
 
       {/* Quadrant 3 (bottom-left): GitHub (#208). */}
       <div className="flex flex-col overflow-hidden">
-        <PanelHeader label="GitHub" />
+        <PanelHeader label="GitHub" tooltip={
+          <InfoTooltip>
+            <b>GitHub</b> — open issues and pull requests on this project&apos;s repo. Click any item to open it on GitHub. The batch progress panel tracks the active batch&apos;s lifecycle from queued to merged.
+          </InfoTooltip>
+        } />
         <div className="flex-1 min-h-0">
           <GitHubPanel projectId={projectId} />
         </div>

--- a/src/components/ProjectHistoryWidget.tsx
+++ b/src/components/ProjectHistoryWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import InfoTooltip from "./InfoTooltip";
 
 interface ProjectHistoryWidgetProps {
   projectId: string;
@@ -259,7 +260,12 @@ export default function ProjectHistoryWidget({ projectId }: ProjectHistoryWidget
 
   return (
     <div className="border border-border rounded p-2 text-[11px] font-mono">
-      <div className="text-text-muted uppercase tracking-wider mb-1.5">Project History</div>
+      <div className="flex items-center gap-1.5 text-text-muted uppercase tracking-wider mb-1.5">
+        Project History
+        <InfoTooltip>
+          <b>Project History</b> — export or import the full AgentChattr chat history for this project. Useful for backup, migration, or resuming after a fresh install.
+        </InfoTooltip>
+      </div>
       <div className="flex items-center gap-1.5 flex-wrap">
         <button
           type="button"

--- a/src/components/ScheduledTriggerWidget.tsx
+++ b/src/components/ScheduledTriggerWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import InfoTooltip from "./InfoTooltip";
 
 interface ScheduledTriggerWidgetProps {
   projectId: string;
@@ -249,9 +250,14 @@ export default function ScheduledTriggerWidget({ projectId }: ScheduledTriggerWi
   return (
     <div className="flex flex-col border border-border">
       <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
-        <span className="text-[11px] text-text-muted uppercase tracking-wider">
-          Scheduled Trigger{running ? " (running)" : ""}
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] text-text-muted uppercase tracking-wider">
+            Scheduled Trigger{running ? " (running)" : ""}
+          </span>
+          <InfoTooltip>
+            <b>Scheduled Trigger</b> sends a periodic message to all agents on a timer. Use this to keep the autonomous workflow running overnight. First message fires after the configured interval, not immediately.
+          </InfoTooltip>
+        </div>
         {error && <span className="text-[10px] text-error">err: {error}</span>}
       </div>
 

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import InfoTooltip from "./InfoTooltip";
 import TelegramSetupModal from "./TelegramSetupModal";
 
 interface TelegramBridgeWidgetProps {
@@ -148,7 +149,12 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
     <>
       <div className="flex flex-col border border-border">
         <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
-          <span className="text-[11px] text-text-muted uppercase tracking-wider">Telegram Bridge</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] text-text-muted uppercase tracking-wider">Telegram Bridge</span>
+            <InfoTooltip>
+              <b>Telegram Bridge</b> forwards AgentChattr messages to a Telegram bot so you can monitor from your phone. Bidirectional — replies from Telegram appear in chat.
+            </InfoTooltip>
+          </div>
           {displayError && (
             <span className="text-[10px] text-error">error</span>
           )}


### PR DESCRIPTION
## Summary
- Creates a reusable `InfoTooltip` component with click-to-toggle, click-outside dismiss, and Escape dismiss
- Adds `(?)` info tooltip buttons to every major section header on the project dashboard:
  - **Left column**: Primary Chat
  - **Top-right**: Agent Terminals (already had one - preserved)
  - **Bottom-left**: GitHub (parent), Issues, Pull Requests, Current Batch, Overnight Queue
  - **Bottom-right**: Operator Features, Scheduled Trigger, Telegram Bridge, Agent Models, Project History
- Existing tooltips (Agent Terminals, Loop Guard, Keep Awake, Sound) preserved unchanged
- Added optional `tooltip` prop to `PanelHeader` for reuse across panels

Fixes #407

## Test plan
- [ ] Every major section on the project page has a `(?)` tooltip button
- [ ] Clicking `(?)` opens a popover with 1-3 sentence help text
- [ ] Clicking outside or pressing Escape dismisses the popover
- [ ] Clicking `(?)` again toggles it closed
- [ ] No layout shifts — tooltips appear as overlays
- [ ] Existing tooltips (Agent Terminals, Loop Guard, Keep Awake, Sound) still work
- [ ] Tooltip text is accurate for each section

🤖 Generated with [Claude Code](https://claude.com/claude-code)