### PR TITLE
[#399] Discord bridge QuadWork integration — widget, spawn, config, venv

### DIFF
--- a/server/routes.discordBridge.test.js
+++ b/server/routes.discordBridge.test.js
@@ -1,0 +1,80 @@
+// #399: Discord bridge integration tests. Plain node:assert script —
+// run with `node server/routes.discordBridge.test.js`.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  checkDiscordBridgePythonDeps,
+  buildDiscordBridgeToml,
+  patchAgentchattrConfigForDiscordBridge,
+  buildDiscordBridgeSpawnEnv,
+} = require("./routes");
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "qw-discord-bridge-"));
+
+try {
+  // 1) checkDiscordBridgePythonDeps: broken interpreter returns
+  //    { ok: false, error } without throwing.
+  const broken = checkDiscordBridgePythonDeps(path.join(tmp, "nope", "python3"));
+  assert.equal(broken.ok, false);
+  assert.ok(broken.error && broken.error.length > 0);
+
+  // 2) buildDiscordBridgeToml writes agentchattr_url inside [discord].
+  const toml = buildDiscordBridgeToml({
+    bot_token: "MTIz.abc.def",
+    channel_id: "123456789",
+    agentchattr_url: "http://127.0.0.1:8301",
+  }, "testproject");
+  assert.match(toml, /^\[discord\]/);
+  assert.match(toml, /bot_token = "MTIz\.abc\.def"/);
+  assert.match(toml, /channel_id = "123456789"/);
+  assert.match(toml, /agentchattr_url = "http:\/\/127\.0\.0\.1:8301"/);
+  // Per-project cursor file
+  assert.match(toml, /cursor_file = ".*discord-bridge-cursor-testproject\.json"/);
+  // Must NOT emit a separate [agentchattr] section
+  assert.equal(toml.includes("\n[agentchattr]\n"), false);
+
+  // 3) patchAgentchattrConfigForDiscordBridge is idempotent.
+  const baseConfig =
+    "[agents.head]\nlabel = \"Head\"\n\n[agents.dev]\nlabel = \"Dev\"\n";
+  const first = patchAgentchattrConfigForDiscordBridge(baseConfig);
+  assert.equal(first.changed, true);
+  assert.match(first.text, /^\[agents\.discord-bridge\]$/m);
+  assert.match(first.text, /label = "Discord Bridge"/);
+  // Second run is a no-op
+  const second = patchAgentchattrConfigForDiscordBridge(first.text);
+  assert.equal(second.changed, false);
+  assert.equal(second.text, first.text);
+  // Hand-patched config is recognized
+  const handPatched =
+    baseConfig + "\n[agents.discord-bridge]\nlabel = \"Discord Bridge\"\n";
+  const third = patchAgentchattrConfigForDiscordBridge(handPatched);
+  assert.equal(third.changed, false);
+  assert.equal(third.text, handPatched);
+
+  // 4) buildDiscordBridgeSpawnEnv strips Discord-specific env vars.
+  const scrubbed = buildDiscordBridgeSpawnEnv({
+    PATH: "/usr/bin",
+    HOME: "/home/op",
+    DISCORD_BOT_TOKEN: "wrong-token",
+    DISCORD_CHANNEL_ID: "999",
+    AGENTCHATTR_URL: "http://127.0.0.1:9999",
+  });
+  assert.equal(scrubbed.DISCORD_BOT_TOKEN, undefined);
+  assert.equal(scrubbed.DISCORD_CHANNEL_ID, undefined);
+  assert.equal(scrubbed.AGENTCHATTR_URL, undefined);
+  // Non-discord keys pass through
+  assert.equal(scrubbed.PATH, "/usr/bin");
+  assert.equal(scrubbed.HOME, "/home/op");
+
+  // 5) Missing venv path check
+  const fixtureBridgeDir = fs.mkdtempSync(path.join(tmp, "bridge-no-venv-"));
+  const missingVenvPython = path.join(fixtureBridgeDir, ".venv", "bin", "python3");
+  assert.equal(fs.existsSync(missingVenvPython), false);
+
+  console.log("routes.discordBridge.test.js: all assertions passed (5 cases)");
+} finally {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+}

--- a/server/routes.js
+++ b/server/routes.js
@@ -2930,6 +2930,354 @@ router.post("/api/telegram", async (req, res) => {
   }
 });
 
+// --- Discord Bridge ---
+// #396/#399: Discord ↔ AgentChattr bridge, bundled in quadwork
+// package at bridges/discord/. Mirrors Telegram bridge patterns.
+
+const DISCORD_BRIDGE_SRC = path.join(__dirname, "..", "bridges", "discord");
+const DISCORD_BRIDGE_DIR = path.join(CONFIG_DIR, "agentchattr-discord");
+
+function discordPidFile(projectId) {
+  return path.join(CONFIG_DIR, `discord-bridge-${projectId}.pid`);
+}
+
+function discordConfigToml(projectId) {
+  return path.join(CONFIG_DIR, `discord-${projectId}.toml`);
+}
+
+function discordBridgeLog(projectId) {
+  return path.join(CONFIG_DIR, `discord-bridge-${projectId}.log`);
+}
+
+function buildDiscordBridgeToml(dc, projectId) {
+  const cursorFile = path.join(CONFIG_DIR, `discord-bridge-cursor-${projectId}.json`);
+  return (
+    `[discord]\n` +
+    `bot_token = "${dc.bot_token}"\n` +
+    `channel_id = "${dc.channel_id}"\n` +
+    `agentchattr_url = "${dc.agentchattr_url}"\n` +
+    `cursor_file = "${cursorFile}"\n`
+  );
+}
+
+function patchAgentchattrConfigForDiscordBridge(tomlText) {
+  if (/^\[agents\.discord-bridge\]\s*$/m.test(tomlText)) {
+    return { text: tomlText, changed: false };
+  }
+  const sep = tomlText.length === 0 || tomlText.endsWith("\n") ? "" : "\n";
+  const block = `\n[agents.discord-bridge]\nlabel = "Discord Bridge"\n`;
+  return { text: tomlText + sep + block, changed: true };
+}
+
+function buildDiscordBridgeSpawnEnv(parentEnv) {
+  const env = { ...parentEnv };
+  delete env.DISCORD_BOT_TOKEN;
+  delete env.DISCORD_CHANNEL_ID;
+  delete env.AGENTCHATTR_URL;
+  return env;
+}
+
+function checkDiscordBridgePythonDeps(pythonPath = "python3") {
+  try {
+    execFileSync(pythonPath, ["-c", "import discord, requests"], {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true };
+  } catch (err) {
+    const stderr = (err && err.stderr && err.stderr.toString && err.stderr.toString()) || "";
+    const msg = stderr.trim() || (err && err.message) || "python3 import check failed";
+    return { ok: false, error: msg };
+  }
+}
+
+function isDiscordRunning(projectId) {
+  const pf = discordPidFile(projectId);
+  if (!fs.existsSync(pf)) return false;
+  const pid = parseInt(fs.readFileSync(pf, "utf-8").trim(), 10);
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    fs.unlinkSync(pf);
+    return false;
+  }
+}
+
+function discordEnvKeyForProject(projectId) {
+  return `DISCORD_BOT_TOKEN_${projectId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+}
+
+function getProjectDiscord(projectId) {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const project = cfg.projects?.find((p) => p.id === projectId);
+    if (!project?.discord) return null;
+    return {
+      bot_token: resolveToken(project.discord.bot_token || ""),
+      channel_id: project.discord.channel_id || "",
+      agentchattr_url: resolveProjectAgentchattrUrl(cfg, project),
+    };
+  } catch {
+    return null;
+  }
+}
+
+router.get("/api/discord", async (req, res) => {
+  const projectId = req.query.project || "";
+  if (!projectId) return res.status(400).json({ error: "Missing project" });
+  let configured = false;
+  let channelId = "";
+  let botUsername = "";
+  let bridgeInstalled = false;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const project = cfg.projects?.find((p) => p.id === projectId) || null;
+    if (project?.discord?.bot_token && project?.discord?.channel_id) {
+      configured = true;
+      channelId = project.discord.channel_id;
+      botUsername = project.discord.bot_username || "";
+    }
+    bridgeInstalled = fs.existsSync(path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py"));
+  } catch {}
+  const running = isDiscordRunning(projectId);
+  let lastError = "";
+  if (!running) {
+    const logPath = discordBridgeLog(projectId);
+    try {
+      if (fs.existsSync(logPath) && fs.statSync(logPath).size > 0) {
+        lastError = readLastLines(logPath, 20);
+      }
+    } catch {}
+  }
+  res.json({
+    running,
+    configured,
+    channel_id: channelId,
+    bot_username: botUsername,
+    bridge_installed: bridgeInstalled,
+    last_error: lastError,
+  });
+});
+
+router.post("/api/discord", async (req, res) => {
+  const action = req.query.action;
+  const body = req.body || {};
+
+  switch (action) {
+    case "test": {
+      const { bot_token } = body;
+      if (!bot_token) return res.json({ ok: false, error: "Missing bot_token" });
+      const resolved = resolveToken(bot_token);
+      if (!resolved) return res.json({ ok: false, error: "Could not resolve bot token from environment" });
+      try {
+        const r = await fetch(`https://discord.com/api/v10/users/@me`, {
+          headers: { Authorization: `Bot ${resolved}` },
+        });
+        const data = await r.json();
+        if (r.ok && data.username) {
+          return res.json({ ok: true, username: data.username, discriminator: data.discriminator || "" });
+        }
+        return res.json({ ok: false, error: data.message || `Discord API returned ${r.status}` });
+      } catch (err) {
+        return res.json({ ok: false, error: err.message || "Connection failed" });
+      }
+    }
+    case "install": {
+      const venvDir = path.join(DISCORD_BRIDGE_DIR, ".venv");
+      const venvPython = path.join(venvDir, "bin", "python3");
+      const venvPip = path.join(venvDir, "bin", "pip");
+      let pipOutput = "";
+      try {
+        // Copy from bundled package dir (not clone — #397 decision)
+        if (!fs.existsSync(path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py"))) {
+          fs.cpSync(DISCORD_BRIDGE_SRC, DISCORD_BRIDGE_DIR, { recursive: true });
+        } else {
+          // On upgrade: overwrite script, keep venv
+          fs.cpSync(
+            path.join(DISCORD_BRIDGE_SRC, "discord_bridge.py"),
+            path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py"),
+          );
+          fs.cpSync(
+            path.join(DISCORD_BRIDGE_SRC, "requirements.txt"),
+            path.join(DISCORD_BRIDGE_DIR, "requirements.txt"),
+          );
+        }
+        if (!fs.existsSync(venvPython)) {
+          execFileSync("python3", ["-m", "venv", venvDir], { encoding: "utf-8", timeout: 60000 });
+        }
+        pipOutput = execFileSync(
+          venvPip,
+          ["install", "-r", path.join(DISCORD_BRIDGE_DIR, "requirements.txt")],
+          { encoding: "utf-8", timeout: 120000 },
+        );
+      } catch (err) {
+        const stderr = (err && err.stderr && err.stderr.toString && err.stderr.toString()) || "";
+        return res.json({ ok: false, error: (stderr.trim() || err.message || "Install failed") });
+      }
+      const depCheck = checkDiscordBridgePythonDeps(venvPython);
+      if (!depCheck.ok) {
+        return res.json({
+          ok: false,
+          error:
+            "pip reported success but the bridge venv's Python deps still fail to import. " +
+            `Check disk space and permissions on ${venvDir}.\n\n` +
+            `Import error: ${depCheck.error}\n\n` +
+            `pip output tail:\n${pipOutput.split("\n").slice(-10).join("\n")}`,
+        });
+      }
+      // Patch all project AC configs with [agents.discord-bridge]
+      const patched = [];
+      try {
+        const cfgAll = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+        for (const proj of cfgAll.projects || []) {
+          if (!proj || !proj.id) continue;
+          const acPath = projectAgentchattrConfigPath(proj.id);
+          if (!fs.existsSync(acPath)) continue;
+          try {
+            const before = fs.readFileSync(acPath, "utf-8");
+            const { text, changed } = patchAgentchattrConfigForDiscordBridge(before);
+            if (changed) {
+              fs.writeFileSync(acPath, text);
+              patched.push(proj.id);
+            }
+          } catch {}
+        }
+      } catch {}
+      return res.json({ ok: true, patched_projects: patched });
+    }
+    case "start": {
+      const projectId = body.project_id;
+      if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      if (isDiscordRunning(projectId)) return res.json({ ok: true, running: true, message: "Already running" });
+      const bridgeScript = path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py");
+      if (!fs.existsSync(bridgeScript)) return res.json({ ok: false, error: "Bridge not installed. Click Install Bridge first." });
+      const venvPython = path.join(DISCORD_BRIDGE_DIR, ".venv", "bin", "python3");
+      if (!fs.existsSync(venvPython)) {
+        return res.json({ ok: false, error: "Bridge venv missing. Click \"Install Bridge\" to create it." });
+      }
+      const dc = getProjectDiscord(projectId);
+      if (!dc || !dc.bot_token || !dc.channel_id) return res.json({ ok: false, error: "Save bot_token and channel_id in project settings first." });
+      const tomlPath = discordConfigToml(projectId);
+      const tomlContent = buildDiscordBridgeToml(dc, projectId);
+      fs.writeFileSync(tomlPath, tomlContent, { mode: 0o600 });
+      fs.chmodSync(tomlPath, 0o600);
+      const depCheck = checkDiscordBridgePythonDeps(venvPython);
+      if (!depCheck.ok) {
+        const msg =
+          "Bridge Python dependencies not installed in the dedicated venv. " +
+          "Click \"Install Bridge\" to (re)create the venv and install them.\n\n" +
+          `Import error: ${depCheck.error}`;
+        try {
+          fs.writeFileSync(
+            discordBridgeLog(projectId),
+            `[${new Date().toISOString()}] pre-flight dep check failed\n${msg}\n`,
+          );
+        } catch {}
+        return res.json({ ok: false, error: msg });
+      }
+      const logPath = discordBridgeLog(projectId);
+      try { fs.writeFileSync(logPath, ""); } catch {}
+      let outFd, errFd;
+      try {
+        outFd = fs.openSync(logPath, "a");
+        errFd = fs.openSync(logPath, "a");
+      } catch (err) {
+        return res.json({ ok: false, error: `Could not open bridge log file: ${err.message}` });
+      }
+      let child;
+      try {
+        child = spawn(venvPython, [bridgeScript, "--config", tomlPath], {
+          detached: true,
+          stdio: ["ignore", outFd, errFd],
+          env: buildDiscordBridgeSpawnEnv(process.env),
+        });
+        child.unref();
+        if (child.pid) fs.writeFileSync(discordPidFile(projectId), String(child.pid));
+      } catch (err) {
+        try { fs.closeSync(outFd); } catch {}
+        try { fs.closeSync(errFd); } catch {}
+        return res.json({ ok: false, error: err.message || "Start failed" });
+      }
+      try { fs.closeSync(outFd); } catch {}
+      try { fs.closeSync(errFd); } catch {}
+      await new Promise((r) => setTimeout(r, 500));
+      let alive = true;
+      try { process.kill(child.pid, 0); } catch { alive = false; }
+      if (!alive) {
+        const tail = readLastLines(logPath, 20);
+        try { fs.unlinkSync(discordPidFile(projectId)); } catch {}
+        return res.json({
+          ok: false,
+          error:
+            "Bridge crashed on start (exited within 500ms).\n\n" +
+            `Last log lines (${logPath}):\n${tail || "(log empty)"}`,
+        });
+      }
+      return res.json({ ok: true, running: true, pid: child.pid });
+    }
+    case "stop": {
+      const projectId = body.project_id;
+      if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      try {
+        const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+        const project = cfg.projects?.find((p) => p.id === projectId);
+        const acUrl = resolveProjectAgentchattrUrl(cfg, project);
+        if (acUrl) {
+          const acPort = new URL(acUrl).port || "8300";
+          await fetch(`http://127.0.0.1:${acPort}/api/deregister/discord-bridge`, {
+            method: "POST",
+            signal: AbortSignal.timeout(3000),
+          }).catch(() => {});
+        }
+      } catch {}
+      try {
+        const pf = discordPidFile(projectId);
+        if (fs.existsSync(pf)) {
+          const pid = parseInt(fs.readFileSync(pf, "utf-8").trim(), 10);
+          if (pid) process.kill(pid, "SIGTERM");
+          fs.unlinkSync(pf);
+        }
+        return res.json({ ok: true, running: false });
+      } catch (err) {
+        return res.json({ ok: false, error: err.message || "Stop failed" });
+      }
+    }
+    case "status":
+      return res.json({ running: isDiscordRunning(body.project_id || "") });
+    case "save-config": {
+      const projectId = body.project_id;
+      const bot_token = typeof body.bot_token === "string" ? body.bot_token.trim() : "";
+      const channel_id = typeof body.channel_id === "string" ? body.channel_id.trim() : "";
+      if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      if (!bot_token || !channel_id) return res.json({ ok: false, error: "bot_token and channel_id are required" });
+      const envKey = discordEnvKeyForProject(projectId);
+      try { writeEnvToken(envKey, bot_token); }
+      catch (err) { return res.json({ ok: false, error: `Could not write .env: ${err.message}` }); }
+      try {
+        const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+        const cfg = JSON.parse(raw);
+        const project = cfg.projects?.find((p) => p.id === projectId);
+        if (!project) return res.json({ ok: false, error: "Unknown project" });
+        project.discord = {
+          ...(project.discord || {}),
+          bot_token: `env:${envKey}`,
+          channel_id,
+          bot_username: "",
+        };
+        fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+        return res.json({ ok: true, env_key: envKey });
+      } catch (err) {
+        return res.json({ ok: false, error: err.message || "Config write failed" });
+      }
+    }
+    default:
+      return res.status(400).json({ error: "Unknown action" });
+  }
+});
+
 // #343: per-agent model + reasoning-effort settings endpoint.
 // GET returns the rows the dashboard Agent Models widget needs;
 // PUT persists a single row back to config.json. Kept narrow on
@@ -3019,6 +3367,10 @@ module.exports.resolveProjectAgentchattrUrl = resolveProjectAgentchattrUrl;
 module.exports.buildTelegramBridgeToml = buildTelegramBridgeToml;
 module.exports.patchAgentchattrConfigForTelegramBridge = patchAgentchattrConfigForTelegramBridge;
 module.exports.buildTelegramBridgeSpawnEnv = buildTelegramBridgeSpawnEnv;
+module.exports.checkDiscordBridgePythonDeps = checkDiscordBridgePythonDeps;
+module.exports.buildDiscordBridgeToml = buildDiscordBridgeToml;
+module.exports.patchAgentchattrConfigForDiscordBridge = patchAgentchattrConfigForDiscordBridge;
+module.exports.buildDiscordBridgeSpawnEnv = buildDiscordBridgeSpawnEnv;
 // #236: expose sendViaWebSocket so the chat-ws-send regression test
 // can verify the ack/body/error paths against a fake AC ws server.
 module.exports.sendViaWebSocket = sendViaWebSocket;

--- a/server/routes.js
+++ b/server/routes.js
@@ -3041,6 +3041,25 @@ router.get("/api/discord", async (req, res) => {
       botUsername = project.discord.bot_username || "";
     }
     bridgeInstalled = fs.existsSync(path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py"));
+    // Lazy-resolve bot username via Discord's /users/@me the first time
+    // after a token is saved. Cache it on the project entry so later
+    // requests don't hit the network.
+    if (configured && !botUsername && project?.discord?.bot_token && cfg) {
+      try {
+        const resolved = resolveToken(project.discord.bot_token);
+        if (resolved) {
+          const r = await fetch("https://discord.com/api/v10/users/@me", {
+            headers: { Authorization: `Bot ${resolved}` },
+          });
+          const data = await r.json();
+          if (r.ok && data.username) {
+            botUsername = data.username;
+            project.discord.bot_username = botUsername;
+            try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2)); } catch {}
+          }
+        }
+      } catch { /* non-fatal — widget will just show no username */ }
+    }
   } catch {}
   const running = isDiscordRunning(projectId);
   let lastError = "";

--- a/src/components/DiscordBridgeWidget.tsx
+++ b/src/components/DiscordBridgeWidget.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import InfoTooltip from "./InfoTooltip";
+import DiscordSetupModal from "./DiscordSetupModal";
+
+interface DiscordBridgeWidgetProps {
+  projectId: string;
+}
+
+interface DiscordStatus {
+  running: boolean;
+  configured: boolean;
+  channel_id: string;
+  bot_username: string;
+  bridge_installed: boolean;
+  last_error?: string;
+}
+
+async function callDiscord(action: string, body: Record<string, unknown>) {
+  const r = await fetch(`/api/discord?action=${encodeURIComponent(action)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await r.json();
+  if (!r.ok || data.ok === false) throw new Error(data.error || `${r.status}`);
+  return data;
+}
+
+/**
+ * Per-project Discord Bridge widget.
+ *
+ * Lives in the bottom-right Operator Features quadrant. Shows
+ * whether the bridge is running + channel id, and gives the operator
+ * start/stop + a setup modal to configure bot_token + channel_id from
+ * scratch.
+ */
+export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetProps) {
+  const [status, setStatus] = useState<DiscordStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+  const [setupOpen, setSetupOpen] = useState(false);
+  const [restartNotice, setRestartNotice] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch(`/api/discord?project=${encodeURIComponent(projectId)}`);
+      if (!r.ok) throw new Error(`${r.status}`);
+      const data = (await r.json()) as DiscordStatus;
+      setStatus(data);
+      setPollError(null);
+    } catch (e) {
+      setPollError((e as Error).message);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    load();
+    const id = window.setInterval(load, 5000);
+    return () => window.clearInterval(id);
+  }, [load]);
+
+  const noteInstallResponse = (data: { patched_projects?: string[] }) => {
+    const patched = Array.isArray(data?.patched_projects) ? data.patched_projects : [];
+    if (patched.length > 0) {
+      setRestartNotice(
+        `Install Bridge patched ${patched.length} AgentChattr config(s) ` +
+        `(${patched.join(", ")}) to declare [agents.discord-bridge]. ` +
+        `Click SERVER \u2192 Restart so AgentChattr picks up the new agent slug, ` +
+        `then click Start again. Without the restart, Start will fail with a 400 registration loop.`,
+      );
+    } else {
+      setRestartNotice(null);
+    }
+  };
+
+  const start = async () => {
+    setBusy(true); setActionError(null);
+    try {
+      if (status && !status.bridge_installed) {
+        const data = await callDiscord("install", {});
+        noteInstallResponse(data);
+      }
+      await callDiscord("start", { project_id: projectId });
+      await load();
+    } catch (e) { setActionError((e as Error).message); }
+    finally { setBusy(false); }
+  };
+
+  const stop = async () => {
+    setBusy(true); setActionError(null);
+    try {
+      await callDiscord("stop", { project_id: projectId });
+      await load();
+    } catch (e) { setActionError((e as Error).message); }
+    finally { setBusy(false); }
+  };
+
+  const onSaveCredentials = async (bot_token: string, channel_id: string) => {
+    await callDiscord("save-config", { project_id: projectId, bot_token, channel_id });
+    try {
+      if (status && !status.bridge_installed) {
+        const data = await callDiscord("install", {});
+        noteInstallResponse(data);
+      }
+      await callDiscord("start", { project_id: projectId });
+    } catch (e) {
+      setActionError((e as Error).message);
+    }
+    await load();
+  };
+
+  const configured = !!status?.configured;
+  const running = !!status?.running;
+  const displayError = actionError || pollError || (!running && status?.last_error) || "";
+
+  return (
+    <>
+      <div className="flex flex-col border border-border">
+        <div className="flex items-center justify-between h-7 px-3 shrink-0 border-b border-border">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] text-text-muted uppercase tracking-wider">Discord Bridge</span>
+            <InfoTooltip>
+              <b>Discord Bridge</b> forwards AgentChattr messages to a Discord channel so you can monitor from Discord. Bidirectional — replies from Discord appear in chat.
+            </InfoTooltip>
+          </div>
+          {displayError && (
+            <span className="text-[10px] text-error">error</span>
+          )}
+        </div>
+        <div className="p-3 flex flex-col gap-2">
+          {!configured ? (
+            <>
+              <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                <span className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                <span>Not configured</span>
+              </div>
+              <button
+                onClick={() => setSetupOpen(true)}
+                disabled={busy}
+                className="self-start px-3 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 transition-colors"
+              >
+                Set up Discord Bridge
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2 text-[11px] flex-wrap">
+                {running ? (
+                  <>
+                    <span className="relative inline-flex items-center justify-center w-2 h-2">
+                      <span className="absolute inline-flex h-full w-full rounded-full bg-accent opacity-60 animate-ping" />
+                      <span className="relative w-1.5 h-1.5 rounded-full bg-accent" />
+                    </span>
+                    <span className="text-accent">Running</span>
+                  </>
+                ) : (
+                  <>
+                    <span className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                    <span className="text-text-muted">Stopped</span>
+                  </>
+                )}
+                {status?.bot_username && (
+                  <span className="text-text-muted">· Bot: {status.bot_username}</span>
+                )}
+                {status?.channel_id && (
+                  <span className="text-text-muted tabular-nums">· Channel: {status.channel_id}</span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 flex-wrap">
+                {running ? (
+                  <button
+                    onClick={stop}
+                    disabled={busy}
+                    className="px-3 py-1 text-[11px] text-text-muted border border-border hover:text-error hover:border-error/40 disabled:opacity-50 transition-colors"
+                  >
+                    {busy ? "Stopping\u2026" : "Stop"}
+                  </button>
+                ) : (
+                  <button
+                    onClick={start}
+                    disabled={busy}
+                    className="px-3 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 transition-colors"
+                  >
+                    {busy ? "Starting\u2026" : "Start"}
+                  </button>
+                )}
+                <button
+                  onClick={() => setSetupOpen(true)}
+                  disabled={busy}
+                  className="px-3 py-1 text-[11px] text-text-muted border border-border hover:text-text disabled:opacity-50 transition-colors"
+                >
+                  How to set up
+                </button>
+                <button
+                  onClick={() => setSetupOpen(true)}
+                  disabled={busy}
+                  className="px-3 py-1 text-[11px] text-text-muted border border-border hover:text-text disabled:opacity-50 transition-colors"
+                >
+                  Edit credentials
+                </button>
+              </div>
+            </>
+          )}
+          {restartNotice && (
+            <div className="mt-1 p-2 text-[10px] text-accent border border-accent/40 bg-accent/5 whitespace-pre-wrap break-words">
+              {restartNotice}
+              <button
+                type="button"
+                onClick={() => setRestartNotice(null)}
+                className="block mt-1 text-text-muted hover:text-text underline"
+              >
+                dismiss
+              </button>
+            </div>
+          )}
+          {displayError && (
+            <div className="mt-1 p-2 text-[10px] text-error border border-error/40 bg-error/5 font-mono whitespace-pre-wrap break-words max-h-40 overflow-y-auto">
+              {displayError}
+              {actionError && (
+                <button
+                  type="button"
+                  onClick={() => setActionError(null)}
+                  className="block mt-1 text-text-muted hover:text-text underline"
+                >
+                  dismiss
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+      <DiscordSetupModal
+        open={setupOpen}
+        initialChannelId={status?.channel_id || ""}
+        onClose={() => setSetupOpen(false)}
+        onSave={onSaveCredentials}
+      />
+    </>
+  );
+}

--- a/src/components/DiscordSetupModal.tsx
+++ b/src/components/DiscordSetupModal.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface DiscordSetupModalProps {
+  open: boolean;
+  initialChannelId?: string;
+  onClose: () => void;
+  onSave: (botToken: string, channelId: string) => Promise<void>;
+}
+
+/**
+ * Step-by-step setup modal for the per-project Discord Bridge.
+ *
+ * Walks the operator through creating a Discord bot, getting a
+ * channel ID, pasting both into the form, and hitting
+ * "Save and start bridge".
+ */
+export default function DiscordSetupModal({ open, initialChannelId = "", onClose, onSave }: DiscordSetupModalProps) {
+  const [botToken, setBotToken] = useState("");
+  const [channelId, setChannelId] = useState(initialChannelId);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { if (open) setChannelId(initialChannelId); }, [open, initialChannelId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(botToken.trim(), channelId.trim());
+      onClose();
+    } catch (e) {
+      setError((e as Error).message || "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="discord-setup-title"
+    >
+      <div
+        className="relative mx-4 max-w-xl w-full max-h-[90vh] overflow-auto rounded-lg border border-white/10 bg-neutral-950 p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded p-1 text-neutral-400 hover:bg-white/5 hover:text-white"
+        >
+          <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M4 4l12 12M16 4L4 16" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <h2 id="discord-setup-title" className="text-base font-semibold text-white">Set up your Discord Bridge</h2>
+        <p className="mt-2 text-[12px] leading-relaxed text-neutral-300">
+          The bridge forwards AgentChattr messages from your project to a Discord channel, so you can read and reply from Discord.
+        </p>
+
+        <div className="mt-4 text-[12px] text-neutral-300 space-y-3">
+          <section>
+            <h3 className="text-[13px] font-semibold text-white">Step 1 — Create a Discord bot</h3>
+            <ol className="mt-1 pl-4 list-decimal space-y-0.5 text-neutral-300">
+              <li>Go to the <a href="https://discord.com/developers/applications" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">Discord Developer Portal</a>.</li>
+              <li>Click <b>New Application</b>, give it a name, and click <b>Create</b>.</li>
+              <li>Go to the <b>Bot</b> tab on the left sidebar.</li>
+              <li>Click <b>Reset Token</b> (or <b>Copy</b> if shown) to get your <b>bot token</b>. Save it somewhere safe.</li>
+              <li>Scroll down to <b>Privileged Gateway Intents</b> and enable <b>MESSAGE CONTENT INTENT</b>.</li>
+              <li>Go to <b>OAuth2 &rarr; URL Generator</b>, select the <b>bot</b> scope, then under Bot Permissions select <b>Send Messages</b> and <b>Read Message History</b>. Copy the generated URL and open it to invite the bot to your server.</li>
+            </ol>
+          </section>
+
+          <section>
+            <h3 className="text-[13px] font-semibold text-white">Step 2 — Get your channel ID</h3>
+            <ol className="mt-1 pl-4 list-decimal space-y-0.5 text-neutral-300">
+              <li>Open Discord and go to <b>Settings &rarr; Advanced</b>.</li>
+              <li>Enable <b>Developer Mode</b>.</li>
+              <li>Right-click the channel you want the bridge to post in and select <b>Copy Channel ID</b>.</li>
+            </ol>
+            <p className="mt-1 text-[11px] text-neutral-500">
+              Channel IDs are large numbers like <code className="bg-white/5 px-1 rounded text-[11px]">1234567890123456789</code>.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-[13px] font-semibold text-white">Step 3 — Paste credentials below</h3>
+            <div className="mt-2 flex flex-col gap-2">
+              <label className="text-[11px] text-neutral-400">Bot token
+                <input
+                  type="password"
+                  value={botToken}
+                  onChange={(e) => setBotToken(e.target.value)}
+                  placeholder="MTIzNDU2Nzg5MDEyMzQ1Njc4OQ..."
+                  className="mt-0.5 w-full bg-transparent border border-white/10 px-2 py-1 text-[12px] text-white outline-none focus:border-accent font-mono"
+                />
+              </label>
+              <label className="text-[11px] text-neutral-400">Channel ID
+                <input
+                  type="text"
+                  value={channelId}
+                  onChange={(e) => setChannelId(e.target.value)}
+                  placeholder="1234567890123456789"
+                  className="mt-0.5 w-full bg-transparent border border-white/10 px-2 py-1 text-[12px] text-white outline-none focus:border-accent font-mono"
+                />
+              </label>
+              {error && <div className="text-[11px] text-error">{error}</div>}
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving || !botToken.trim() || !channelId.trim()}
+                className="mt-1 self-start px-3 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {saving ? "Saving\u2026" : "Save and start bridge"}
+              </button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -4,6 +4,7 @@ import PanelHeader from "./PanelHeader";
 import InfoTooltip from "./InfoTooltip";
 import ScheduledTriggerWidget from "./ScheduledTriggerWidget";
 import TelegramBridgeWidget from "./TelegramBridgeWidget";
+import DiscordBridgeWidget from "./DiscordBridgeWidget";
 import LoopGuardWidget from "./LoopGuardWidget";
 import ProjectHistoryWidget from "./ProjectHistoryWidget";
 import AgentModelsWidget from "./AgentModelsWidget";
@@ -55,6 +56,7 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
         <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto flex flex-col gap-2">
           <AgentModelsWidget projectId={projectId} />
           <TelegramBridgeWidget projectId={projectId} />
+          <DiscordBridgeWidget projectId={projectId} />
           <LoopGuardWidget projectId={projectId} />
           <ProjectHistoryWidget projectId={projectId} />
         </div>

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -45,6 +45,10 @@ label = "Builder"
 [agents.telegram-bridge]
 label = "Telegram Bridge"
 
+# #399: Discord bridge registers as `discord-bridge`.
+[agents.discord-bridge]
+label = "Discord Bridge"
+
 [routing]
 default = "none"
 max_agent_hops = 30


### PR DESCRIPTION
## Summary
- Adds full Discord bridge integration mirroring Telegram bridge patterns
- Server routes (`/api/discord`): GET status, POST install/start/stop/save-config/test with dedicated venv, per-project cursor file, env scrubbing, AC config patching
- Install copies from bundled `bridges/discord/` (no repo clone — #397 decision)
- New `DiscordBridgeWidget` + `DiscordSetupModal` UI components mounted in Operator Features panel
- `[agents.discord-bridge]` added to `templates/config.toml`
- Test suite: `routes.discordBridge.test.js` with 5 cases

### Files changed (6 files)
- **New:** `server/routes.discordBridge.test.js`, `src/components/DiscordBridgeWidget.tsx`, `src/components/DiscordSetupModal.tsx`
- **Modified:** `server/routes.js` (+Discord handlers), `src/components/OperatorFeaturesPanel.tsx` (+mount), `templates/config.toml` (+discord-bridge agent)

## Test plan
- [x] All server tests pass (7 test files, 54 total cases)
- [x] Build succeeds (`npm run build`)
- [ ] Discord Bridge widget appears in Operator Features panel
- [ ] Edit credentials → save → config persisted, token in .env
- [ ] Install Bridge → script copied, venv created, deps installed
- [ ] Start → bridge spawns, Running pill
- [ ] Stop → bridge killed, Stopped pill
- [ ] AC config auto-patched with `[agents.discord-bridge]`
- [ ] No regressions to Telegram bridge

Fixes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)