### PR TITLE
[#414] Fix tooltip popover: OVERNIGHT-QUEUE.md clipped + Loop Guard inline

### DIFF
--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -307,7 +307,7 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
       <div className="shrink-0 flex items-center justify-between px-3 py-1.5 border-t border-border">
         <div className="flex items-center gap-1.5">
           <span className="text-[11px] text-text-muted font-mono">OVERNIGHT-QUEUE.md</span>
-          <InfoTooltip>
+          <InfoTooltip position="above">
             <b>Overnight Queue</b> — the task queue file Head reads to pick the next ticket. Click Edit to modify batch contents and ordering.
           </InfoTooltip>
         </div>

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -4,6 +4,8 @@ import { useState, useRef, useEffect } from "react";
 
 interface InfoTooltipProps {
   children: React.ReactNode;
+  /** Open popover above the button instead of below. */
+  position?: "below" | "above";
 }
 
 /**
@@ -14,7 +16,7 @@ interface InfoTooltipProps {
  * AgentTerminalsGrid — consistent `w-3.5 h-3.5 rounded-full`
  * styling with accent hover.
  */
-export default function InfoTooltip({ children }: InfoTooltipProps) {
+export default function InfoTooltip({ children, position = "below" }: InfoTooltipProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -42,7 +44,7 @@ export default function InfoTooltip({ children }: InfoTooltipProps) {
         className="w-3.5 h-3.5 rounded-full border border-border text-[9px] leading-none text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
       >?</button>
       {open && (
-        <div className="absolute left-0 top-5 z-30 w-64 p-2 text-[10px] leading-snug text-text bg-bg-surface border border-border rounded shadow-lg">
+        <div className={`absolute left-0 z-30 w-64 p-2 text-[10px] leading-snug text-text bg-bg-surface border border-border rounded shadow-lg ${position === "above" ? "bottom-5" : "top-5"}`}>
           {children}
         </div>
       )}

--- a/src/components/LoopGuardWidget.tsx
+++ b/src/components/LoopGuardWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import InfoTooltip from "./InfoTooltip";
 
 interface LoopGuardWidgetProps {
   projectId: string;
@@ -22,7 +23,6 @@ export default function LoopGuardWidget({ projectId }: LoopGuardWidgetProps) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [live, setLive] = useState<boolean | null>(null);
-  const [showHelp, setShowHelp] = useState(false);
   // #422 / quadwork#310: per-project auto-continue opt-in. Default
   // OFF — operators opt in knowing the trade-off (runaway loops
   // will silently resume after the delay). Hydrated from /api/config
@@ -123,18 +123,10 @@ export default function LoopGuardWidget({ projectId }: LoopGuardWidgetProps) {
     <div className="border border-border rounded p-2 text-[11px] font-mono">
       <div className="flex items-center gap-1.5 mb-1">
         <span className="uppercase tracking-wider text-text-muted">Loop Guard</span>
-        <button
-          type="button"
-          aria-label="About loop guard"
-          onClick={() => setShowHelp((s) => !s)}
-          className="w-3.5 h-3.5 rounded-full border border-border text-[9px] leading-none text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
-        >?</button>
-      </div>
-      {showHelp && (
-        <div className="mb-1.5 p-1.5 text-[10px] leading-snug text-text bg-bg-surface border border-border/60 rounded">
+        <InfoTooltip>
           <b>Loop Guard</b> pauses agent-to-agent message chains after this many hops with no human reply. Higher values let agents work longer overnight; lower values add safety against runaway loops. AgentChattr accepts <b>4–50</b>; QuadWork defaults to <b>30</b> (about 5–6 full PR cycles). Posting any chat message yourself resets the counter immediately.
-        </div>
-      )}
+        </InfoTooltip>
+      </div>
       <div className="flex items-center gap-1.5">
         <span className="text-text-muted">Pause after</span>
         <input


### PR DESCRIPTION
## Summary
Fixes #414

- **Bug 1 — OVERNIGHT-QUEUE.md tooltip invisible:** The `(?)` popover opened downward but the parent panel has `overflow-hidden`, clipping it entirely. Added a `position="above"` prop to `InfoTooltip` so bottom-of-panel tooltips render upward.
- **Bug 2 — Loop Guard tooltip renders inline:** Replaced the old `showHelp` state + inline `<div>` pattern with the shared `InfoTooltip` component so it renders as a floating popover matching all other sections.

## Changes
- `InfoTooltip.tsx` — new optional `position` prop (`"below"` default / `"above"`)
- `GitHubPanel.tsx` — use `position="above"` on the OVERNIGHT-QUEUE.md tooltip
- `LoopGuardWidget.tsx` — remove `showHelp` state, use `<InfoTooltip>` instead

## Test plan
- [ ] Click `(?)` next to OVERNIGHT-QUEUE.md → floating popover appears **above** the button
- [ ] Click `(?)` next to Loop Guard → floating popover appears (not inline block)
- [ ] Both dismiss on click-outside and Escape
- [ ] No layout shift when tooltips open
- [ ] Other existing tooltips (Issues, Pull Requests, Batch Progress) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)