### PR TITLE
[#424] Fix Discord bridge echo prevention on AC slot rename

### DIFF
--- a/bridges/discord/discord_bridge.py
+++ b/bridges/discord/discord_bridge.py
@@ -145,7 +145,7 @@ def save_cursor(path):
 
 # Mutable dict so heartbeat thread sees re-registration updates.
 # bridge_sender is set from cfg during main() so all callers can read it.
-ac = {"token": "", "name": "", "bridge_sender": "discord-bridge"}
+ac = {"token": "", "name": "", "bridge_sender": "discord-bridge", "known_names": set()}
 
 
 def ac_register(url, base=None, label="Discord Bridge"):
@@ -161,7 +161,8 @@ def ac_register(url, base=None, label="Discord Bridge"):
     data = resp.json()
     ac["name"] = data["name"]
     ac["token"] = data["token"]
-    log.info("Registered with AC as %s", ac["name"])
+    ac["known_names"].add(data["name"])
+    log.info("Registered with AC as %s (known: %s)", ac["name"], ac["known_names"])
     return data
 
 
@@ -258,8 +259,9 @@ async def poll_ac_to_discord(cfg, channel):
                 sender = msg.get("sender", "")
                 text = msg.get("text", "")
 
-                # Echo prevention: skip our own messages
-                if sender == bridge_sender or sender == ac["name"]:
+                # Echo prevention: skip our own messages (any name
+                # the bridge has ever registered as this session)
+                if sender in ac["known_names"] or sender == bridge_sender:
                     if msg_id > _cursor["last_seen_id"]:
                         _cursor["last_seen_id"] = msg_id
                     continue


### PR DESCRIPTION
## Summary
Fixes #424

When AgentChattr renames the bridge slot on restart (e.g. `discord-bridge` → `discord-bridge-2`), messages from previous slot names were not filtered by echo prevention, causing duplicate messages in Discord.

- Added `known_names` set to the `ac` state dict
- `ac_register` now adds each assigned name to the set
- Echo prevention checks `sender in ac["known_names"]` instead of only `sender == ac["name"]`

## Test plan
- [ ] Start bridge, note AC assigns `discord-bridge`
- [ ] Restart AC so bridge re-registers as `discord-bridge-2`
- [ ] Verify messages from both `discord-bridge` and `discord-bridge-2` are filtered (no echo in Discord)
- [ ] Verify normal agent messages still relay to Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)