### PR TITLE
[#425] Fix Discord bridge dropping messages under high volume

### DIFF
--- a/bridges/discord/discord_bridge.py
+++ b/bridges/discord/discord_bridge.py
@@ -224,74 +224,82 @@ async def poll_ac_to_discord(cfg, channel):
 
     while True:
         try:
-            params = {"limit": 50}
-            if _cursor["last_seen_id"]:
-                params["since_id"] = _cursor["last_seen_id"]
-            headers = {}
-            if ac["token"]:
-                headers["Authorization"] = f"Bearer {ac['token']}"
+            # Drain all available messages before sleeping. When AC
+            # returns a full batch (limit messages), immediately
+            # re-fetch with the updated cursor to avoid dropping
+            # overflow under high volume.
+            while True:
+                params = {"limit": 50}
+                if _cursor["last_seen_id"]:
+                    params["since_id"] = _cursor["last_seen_id"]
+                headers = {}
+                if ac["token"]:
+                    headers["Authorization"] = f"Bearer {ac['token']}"
 
-            resp = requests.get(
-                f"{url}/api/messages",
-                params=params,
-                headers=headers,
-                timeout=10,
-            )
+                resp = requests.get(
+                    f"{url}/api/messages",
+                    params=params,
+                    headers=headers,
+                    timeout=10,
+                )
 
-            if resp.status_code in (401, 403):
-                log.warning("AC poll %d — re-registering", resp.status_code)
-                try:
-                    ac_register(url)
-                except Exception as exc:
-                    log.error("Re-register failed: %s", exc)
-                await asyncio.sleep(interval)
-                continue
+                if resp.status_code in (401, 403):
+                    log.warning("AC poll %d — re-registering", resp.status_code)
+                    try:
+                        ac_register(url)
+                    except Exception as exc:
+                        log.error("Re-register failed: %s", exc)
+                    break
 
-            resp.raise_for_status()
-            messages = resp.json()
+                resp.raise_for_status()
+                messages = resp.json()
 
-            if not isinstance(messages, list):
-                await asyncio.sleep(interval)
-                continue
+                if not isinstance(messages, list):
+                    break
 
-            for msg in messages:
-                msg_id = msg.get("id", 0)
-                sender = msg.get("sender", "")
-                text = msg.get("text", "")
+                for msg in messages:
+                    msg_id = msg.get("id", 0)
+                    sender = msg.get("sender", "")
+                    text = msg.get("text", "")
 
-                # Echo prevention: skip our own messages (any name
-                # the bridge has ever registered as this session)
-                if sender in ac["known_names"] or sender == bridge_sender:
+                    # Echo prevention: skip our own messages (any name
+                    # the bridge has ever registered as this session)
+                    if sender in ac["known_names"] or sender == bridge_sender:
+                        if msg_id > _cursor["last_seen_id"]:
+                            _cursor["last_seen_id"] = msg_id
+                        continue
+
+                    # Skip system auto-recovery messages
+                    if sender == "system":
+                        if msg_id > _cursor["last_seen_id"]:
+                            _cursor["last_seen_id"] = msg_id
+                        continue
+
+                    if not text:
+                        if msg_id > _cursor["last_seen_id"]:
+                            _cursor["last_seen_id"] = msg_id
+                        continue
+
+                    # Forward to Discord
+                    try:
+                        discord_text = f"**{sender}**: {text}"
+                        # Discord message limit is 2000 chars
+                        if len(discord_text) > 2000:
+                            discord_text = discord_text[:1997] + "..."
+                        await channel.send(discord_text)
+                    except Exception as exc:
+                        log.error("Failed to send to Discord: %s", exc)
+
                     if msg_id > _cursor["last_seen_id"]:
                         _cursor["last_seen_id"] = msg_id
+
+                # Persist cursor after each page
+                save_cursor(cfg["cursor_file"])
+
+                # If we got a full batch, there may be more — drain immediately
+                if len(messages) >= 50:
                     continue
-
-                # Skip system auto-recovery messages
-                if sender == "system":
-                    if msg_id > _cursor["last_seen_id"]:
-                        _cursor["last_seen_id"] = msg_id
-                    continue
-
-                if not text:
-                    if msg_id > _cursor["last_seen_id"]:
-                        _cursor["last_seen_id"] = msg_id
-                    continue
-
-                # Forward to Discord
-                try:
-                    discord_text = f"**{sender}**: {text}"
-                    # Discord message limit is 2000 chars
-                    if len(discord_text) > 2000:
-                        discord_text = discord_text[:1997] + "..."
-                    await channel.send(discord_text)
-                except Exception as exc:
-                    log.error("Failed to send to Discord: %s", exc)
-
-                if msg_id > _cursor["last_seen_id"]:
-                    _cursor["last_seen_id"] = msg_id
-
-            # Persist cursor after each poll cycle
-            save_cursor(cfg["cursor_file"])
+                break
 
         except requests.RequestException as exc:
             log.warning("AC poll error: %s", exc)


### PR DESCRIPTION
## Summary
Fixes #425

The AC → Discord poll loop fetched one batch of 50 messages per interval and slept, silently dropping any overflow. Now the loop drains all available messages by immediately re-fetching when it gets a full batch (≥50), only sleeping once the backlog is empty.

## Changes
- `bridges/discord/discord_bridge.py` — wrapped the fetch+process block in an inner `while True` loop that `continue`s on full batches and `break`s otherwise

## Test plan
- [ ] Under normal volume (<50 msgs/interval): behavior unchanged, single fetch per cycle
- [ ] Under high volume (>50 msgs queued): bridge drains all pages before sleeping
- [ ] Auth failure (401/403) breaks out of inner loop and retries on next cycle
- [ ] Cursor persisted after each page, not just after the final page

🤖 Generated with [Claude Code](https://claude.com/claude-code)