### PR TITLE
[#417] Fix Reset Agents + SERVER Restart to recover agents after AC crash

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1089,32 +1089,41 @@ app.post("/api/agentchattr/:projectOrAction", handleAgentChattr);
 app.post("/api/agents/:project/reset", async (req, res) => {
   const projectId = req.params.project;
 
-  // #417: Reset Agents now stops and respawns all running agent
-  // sessions for the project. The old implementation only deregistered
-  // AC slots, which fails with stale tokens after an AC crash and
-  // doesn't restart the agent processes (leaving them with broken MCP).
+  // #417: Reset Agents now stops and respawns all agent sessions for
+  // the project. Uses the configured agent list from config.json so
+  // agents missing from agentSessions (e.g. after a crash or prior
+  // stop) are still brought back. The old implementation only
+  // deregistered AC slots, which fails with stale tokens after an AC
+  // crash and doesn't restart the agent processes.
   try {
-    // Find all sessions belonging to this project
-    const projectAgents = [];
-    for (const [key, session] of agentSessions) {
+    // Build the full agent set: start with configured agents, then
+    // merge any tracked sessions that might use a different key.
+    const cfg = readConfig();
+    const project = cfg.projects?.find((p) => p.id === projectId);
+    const configuredAgents = project?.agents ? Object.keys(project.agents) : [];
+
+    // Also include any live sessions not in the config (defensive)
+    const sessionAgentIds = new Set();
+    for (const [key] of agentSessions) {
       if (key.startsWith(`${projectId}/`)) {
-        projectAgents.push({ key, agentId: session.agentId || key.split("/")[1] });
+        sessionAgentIds.add(key.split("/")[1]);
       }
     }
+    const allAgentIds = [...new Set([...configuredAgents, ...sessionAgentIds])];
 
-    if (projectAgents.length === 0) {
-      return res.json({ ok: true, restarted: 0, total: 0, message: "No agent sessions found" });
+    if (allAgentIds.length === 0) {
+      return res.json({ ok: true, restarted: 0, total: 0, message: "No agents configured" });
     }
 
     // Stop all agents first (handles deregistration best-effort)
-    for (const { key } of projectAgents) {
-      await stopAgentSession(key);
+    for (const agentId of allAgentIds) {
+      await stopAgentSession(`${projectId}/${agentId}`);
     }
 
     // Respawn all agents with fresh MCP tokens
     let restarted = 0;
     const errors = [];
-    for (const { key, agentId } of projectAgents) {
+    for (const agentId of allAgentIds) {
       const result = await spawnAgentPty(projectId, agentId);
       if (result.ok) {
         restarted++;
@@ -1126,7 +1135,7 @@ app.post("/api/agents/:project/reset", async (req, res) => {
     res.json({
       ok: restarted > 0,
       restarted,
-      total: projectAgents.length,
+      total: allAgentIds.length,
       ...(errors.length > 0 ? { errors } : {}),
     });
   } catch (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -1088,33 +1088,47 @@ app.post("/api/agentchattr/:projectOrAction", handleAgentChattr);
 
 app.post("/api/agents/:project/reset", async (req, res) => {
   const projectId = req.params.project;
-  const { url: chattrUrl, token: chattrToken } = resolveProjectChattr(projectId);
-  const headers = {};
-  if (chattrToken) headers["x-session-token"] = chattrToken;
 
+  // #417: Reset Agents now stops and respawns all running agent
+  // sessions for the project. The old implementation only deregistered
+  // AC slots, which fails with stale tokens after an AC crash and
+  // doesn't restart the agent processes (leaving them with broken MCP).
   try {
-    // Fetch current agent status from AgentChattr
-    const statusRes = await fetch(`${chattrUrl}/api/status`, { headers });
-    if (!statusRes.ok) {
-      return res.status(statusRes.status).json({ ok: false, error: `AgentChattr status failed: ${statusRes.status}` });
-    }
-    const status = await statusRes.json();
-    const slots = status.agents || status.slots || [];
-
-    let cleared = 0;
-    for (const agent of slots) {
-      const name = typeof agent === "string" ? agent : agent.name || agent.sender;
-      if (!name) continue;
-      try {
-        const dereg = await fetch(`${chattrUrl}/api/deregister/${encodeURIComponent(name)}`, {
-          method: "POST",
-          headers,
-        });
-        if (dereg.ok) cleared++;
-      } catch {}
+    // Find all sessions belonging to this project
+    const projectAgents = [];
+    for (const [key, session] of agentSessions) {
+      if (key.startsWith(`${projectId}/`)) {
+        projectAgents.push({ key, agentId: session.agentId || key.split("/")[1] });
+      }
     }
 
-    res.json({ ok: true, cleared, total: slots.length });
+    if (projectAgents.length === 0) {
+      return res.json({ ok: true, restarted: 0, total: 0, message: "No agent sessions found" });
+    }
+
+    // Stop all agents first (handles deregistration best-effort)
+    for (const { key } of projectAgents) {
+      await stopAgentSession(key);
+    }
+
+    // Respawn all agents with fresh MCP tokens
+    let restarted = 0;
+    const errors = [];
+    for (const { key, agentId } of projectAgents) {
+      const result = await spawnAgentPty(projectId, agentId);
+      if (result.ok) {
+        restarted++;
+      } else {
+        errors.push(`${agentId}: ${result.error}`);
+      }
+    }
+
+    res.json({
+      ok: restarted > 0,
+      restarted,
+      total: projectAgents.length,
+      ...(errors.length > 0 ? { errors } : {}),
+    });
   } catch (err) {
     res.status(500).json({ ok: false, error: err.message });
   }

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -60,7 +60,24 @@ function ServerSection({ projectId }: { projectId: string }) {
       );
       const d = await r.json();
       if (d.ok && d.pid) {
-        setFeedback(`Restarted (PID: ${d.pid})`);
+        setFeedback(`AC restarted (PID: ${d.pid}) — resetting agents...`);
+        // #417: After AC restart, also reset all agents so they get
+        // fresh MCP tokens. Without this, agents stay stuck with stale
+        // connections from the pre-restart session.
+        try {
+          const resetRes = await fetch(
+            `/api/agents/${encodeURIComponent(projectId)}/reset`,
+            { method: "POST" }
+          );
+          const resetData = await resetRes.json();
+          if (resetData.ok) {
+            setFeedback(`AC + ${resetData.restarted} agent${resetData.restarted !== 1 ? "s" : ""} restarted`);
+          } else {
+            setFeedback(`AC restarted — agent reset failed`);
+          }
+        } catch {
+          setFeedback(`AC restarted — agent reset failed`);
+        }
       } else {
         setFeedback(d.error || "Failed to restart");
       }
@@ -80,7 +97,7 @@ function ServerSection({ projectId }: { projectId: string }) {
       );
       const d = await r.json();
       setFeedback(
-        d.ok ? `Reset — ${d.cleared} of ${d.total} slot${d.total !== 1 ? "s" : ""} deregistered` : "Failed"
+        d.ok ? `Reset — ${d.restarted} of ${d.total} agent${d.total !== 1 ? "s" : ""} restarted` : (d.error || "Failed")
       );
     } catch {
       setFeedback("Error");


### PR DESCRIPTION
## Summary
Fixes #417

After an AC crash, both the Reset Agents and SERVER Restart buttons failed to recover agents because:
- **Reset Agents** only deregistered AC slots (fails with stale tokens) and never restarted agent processes
- **SERVER Restart** only restarted AC without touching agent sessions

### Changes

**`server/index.js`** — `POST /api/agents/:project/reset`:
- Now finds all running sessions for the project, stops them (handles deregistration best-effort), and respawns with fresh MCP tokens
- Returns `{ok, restarted, total}` instead of `{ok, cleared, total}`

**`src/components/ControlBar.tsx`**:
- Reset Agents feedback updated for new response shape
- SERVER Restart now chains a Reset Agents call after AC comes back, so agents automatically get fresh MCP connections

## Test plan
- [ ] After AC crash: click Reset Agents → all 4 agents come back with working MCP within 10s
- [ ] After AC crash: click SERVER Restart → AC restarts, then agents auto-reset with fresh connections
- [ ] Normal operation: Reset Agents still works (stop + respawn cycle)
- [ ] Agents register under base names (no -2 suffix) when old slots are cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)