### PR TITLE
[#416] Add AC health monitor with auto-restart on crash detection

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1086,6 +1086,23 @@ app.post("/api/agentchattr/:projectOrAction", handleAgentChattr);
 // AgentChattr doesn't expose staleness metadata, so this clears all slots.
 // Agents' wrapper heartbeat will auto-re-register with clean names.
 
+// #416: AC health status endpoint — returns the health monitor state
+// for a project so the dashboard can surface auto-restart events.
+app.get("/api/agentchattr/:project/health", (req, res) => {
+  const projectId = req.params.project;
+  const proc = chattrProcesses.get(projectId);
+  const health = _acHealth.state.get(projectId) || { lastRestart: 0, consecutiveFailures: 0 };
+  res.json({
+    state: proc?.state || "unknown",
+    error: proc?.error || null,
+    autoRestart: {
+      lastRestart: health.lastRestart || null,
+      consecutiveFailures: health.consecutiveFailures,
+      gaveUp: health.consecutiveFailures >= 3,
+    },
+  });
+});
+
 app.post("/api/agents/:project/reset", async (req, res) => {
   const projectId = req.params.project;
 
@@ -1763,6 +1780,149 @@ setInterval(runLoopGuardPollingTick, LOOP_GUARD_POLL_INTERVAL_MS);
 
 // --- Start ---
 
+// ---------------------------------------------------------------------------
+// #416: AC health monitor — auto-restart AgentChattr on crash detection.
+// Runs a TCP connect probe every 30s for each project with a "running" AC
+// process. If the port is dead, auto-restarts (reusing the existing restart
+// logic). Rate-limited to one restart per 60s per project; gives up after
+// 3 consecutive failures and surfaces a persistent error.
+// ---------------------------------------------------------------------------
+const _acHealth = {
+  // Per-project: { lastRestart: timestamp, consecutiveFailures: number }
+  state: new Map(),
+  intervalHandle: null,
+};
+
+function isPortAlive(port) {
+  return new Promise((resolve) => {
+    const sock = net.createConnection({ port, host: "127.0.0.1" }, () => {
+      sock.destroy();
+      resolve(true);
+    });
+    sock.on("error", () => resolve(false));
+    sock.setTimeout(2000, () => { sock.destroy(); resolve(false); });
+  });
+}
+
+async function acHealthCheck() {
+  const cfg = readConfig();
+  for (const project of (cfg.projects || [])) {
+    const proc = chattrProcesses.get(project.id);
+    // Only monitor projects that were explicitly started (state === "running"
+    // or had a process). Skip intentionally stopped projects.
+    if (!proc || proc.state === "stopped") continue;
+
+    const { url } = resolveProjectChattr(project.id);
+    const portMatch = url.match(/:(\d+)/);
+    const port = portMatch ? parseInt(portMatch[1], 10) : 8300;
+
+    const alive = await isPortAlive(port);
+    const health = _acHealth.state.get(project.id) || { lastRestart: 0, consecutiveFailures: 0 };
+
+    if (alive) {
+      // Healthy — reset failure counter
+      if (health.consecutiveFailures > 0) {
+        console.log(`[health] AC for ${project.id} recovered (port ${port} alive)`);
+      }
+      health.consecutiveFailures = 0;
+      _acHealth.state.set(project.id, health);
+      continue;
+    }
+
+    // Port is dead — check rate limits
+    if (health.consecutiveFailures >= 3) {
+      // Already gave up — don't spam restarts. The error state persists
+      // in chattrProcesses for the dashboard to surface.
+      continue;
+    }
+
+    const now = Date.now();
+    if (now - health.lastRestart < 60_000) {
+      // Too soon since last restart attempt
+      continue;
+    }
+
+    health.consecutiveFailures++;
+    health.lastRestart = now;
+    _acHealth.state.set(project.id, health);
+
+    console.warn(`[health] AC for ${project.id} on port ${port} is down (failure ${health.consecutiveFailures}/3) — auto-restarting`);
+
+    try {
+      // Reuse the same restart logic as the /api/agentchattr/:id/restart endpoint
+      if (proc.process) {
+        try { proc.process.kill("SIGTERM"); } catch {}
+      }
+      chattrProcesses.set(project.id, { process: null, state: "stopped", error: null });
+
+      // Resolve and spawn — inline version of spawnChattr from the route closure
+      const { dir: acDir } = resolveProjectChattr(project.id);
+      const acSpawn = resolveChattrSpawn(acDir);
+      if (!acSpawn) {
+        console.error(`[health] AC for ${project.id} — not installed, cannot auto-restart`);
+        chattrProcesses.set(project.id, { process: null, state: "error", error: "AgentChattr not installed" });
+        health.consecutiveFailures = 3; // give up
+        continue;
+      }
+
+      // Find config.toml for the project
+      let projectConfigToml = null;
+      const perProjectAcDir = path.join(os.homedir(), ".quadwork", project.id, "agentchattr");
+      if (fs.existsSync(path.join(perProjectAcDir, "config.toml"))) {
+        projectConfigToml = path.join(perProjectAcDir, "config.toml");
+      } else if (fs.existsSync(path.join(acDir, "config.toml"))) {
+        projectConfigToml = path.join(acDir, "config.toml");
+      } else if (project.working_dir) {
+        const legacyToml = path.join(project.working_dir, "agentchattr", "config.toml");
+        if (fs.existsSync(legacyToml)) projectConfigToml = legacyToml;
+      }
+
+      const extraArgs = projectConfigToml
+        ? ["--config", projectConfigToml]
+        : ["--port", String(port)];
+
+      patchAgentchattrCss(acDir);
+      const child = spawn(acSpawn.command, [...acSpawn.args, ...extraArgs], {
+        cwd: acSpawn.cwd,
+        env: process.env,
+        stdio: "ignore",
+        detached: true,
+      });
+
+      if (!child.pid) {
+        console.error(`[health] AC for ${project.id} — spawn failed`);
+        chattrProcesses.set(project.id, { process: null, state: "error", error: "Auto-restart spawn failed" });
+        continue;
+      }
+
+      child.unref();
+      child.on("error", (err) => {
+        chattrProcesses.set(project.id, { process: null, state: "error", error: err.message });
+      });
+      child.on("exit", (code) => {
+        const cur = chattrProcesses.get(project.id);
+        if (cur && cur.process === child) {
+          chattrProcesses.set(project.id, { process: null, state: "stopped", error: code ? `exit:${code}` : null });
+        }
+      });
+      chattrProcesses.set(project.id, { process: child, state: "running", error: null });
+      console.log(`[health] AC for ${project.id} auto-restarted (PID: ${child.pid})`);
+
+      // Sync token after restart
+      setTimeout(() => syncChattrToken(project.id), 2000);
+    } catch (err) {
+      console.error(`[health] AC auto-restart failed for ${project.id}:`, err.message);
+      chattrProcesses.set(project.id, { process: null, state: "error", error: `Auto-restart failed: ${err.message}` });
+    }
+  }
+}
+
+function startAcHealthMonitor() {
+  if (_acHealth.intervalHandle) return;
+  _acHealth.intervalHandle = setInterval(acHealthCheck, 30_000);
+  console.log("[health] AC health monitor started (30s interval)");
+}
+
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`QuadWork server listening on http://127.0.0.1:${PORT}`);
   syncTriggersFromConfig();
@@ -1775,6 +1935,8 @@ server.listen(PORT, "127.0.0.1", () => {
     const { dir: acDir } = resolveProjectChattr(p.id);
     if (acDir) patchAgentchattrCss(acDir);
   }
+  // #416: start the AC health monitor
+  startAcHealthMonitor();
 });
 
 /**

--- a/server/index.js
+++ b/server/index.js
@@ -1859,6 +1859,19 @@ async function acHealthCheck() {
       if (resp.ok) {
         const data = await resp.json();
         console.log(`[health] AC for ${project.id} auto-restarted (PID: ${data.pid})`);
+        // #417/#416: also reset agents so they get fresh MCP tokens,
+        // same as the manual SERVER Restart button chain.
+        try {
+          const resetResp = await fetch(`http://127.0.0.1:${PORT}/api/agents/${encodeURIComponent(project.id)}/reset`, {
+            method: "POST",
+          });
+          if (resetResp.ok) {
+            const resetData = await resetResp.json();
+            console.log(`[health] ${resetData.restarted} agent(s) reset for ${project.id}`);
+          }
+        } catch (resetErr) {
+          console.warn(`[health] Agent reset after AC auto-restart failed for ${project.id}:`, resetErr.message);
+        }
       } else {
         const body = await resp.text().catch(() => "");
         console.error(`[health] AC auto-restart failed for ${project.id}: ${resp.status} ${body.slice(0, 120)}`);

--- a/server/index.js
+++ b/server/index.js
@@ -1848,68 +1848,22 @@ async function acHealthCheck() {
 
     console.warn(`[health] AC for ${project.id} on port ${port} is down (failure ${health.consecutiveFailures}/3) — auto-restarting`);
 
+    // Call the existing restart endpoint internally so we reuse the
+    // hardened path (killProcessOnPort, waitForPortFree, snapshot,
+    // auto-restore) instead of reimplementing spawn logic inline.
     try {
-      // Reuse the same restart logic as the /api/agentchattr/:id/restart endpoint
-      if (proc.process) {
-        try { proc.process.kill("SIGTERM"); } catch {}
-      }
-      chattrProcesses.set(project.id, { process: null, state: "stopped", error: null });
-
-      // Resolve and spawn — inline version of spawnChattr from the route closure
-      const { dir: acDir } = resolveProjectChattr(project.id);
-      const acSpawn = resolveChattrSpawn(acDir);
-      if (!acSpawn) {
-        console.error(`[health] AC for ${project.id} — not installed, cannot auto-restart`);
-        chattrProcesses.set(project.id, { process: null, state: "error", error: "AgentChattr not installed" });
-        health.consecutiveFailures = 3; // give up
-        continue;
-      }
-
-      // Find config.toml for the project
-      let projectConfigToml = null;
-      const perProjectAcDir = path.join(os.homedir(), ".quadwork", project.id, "agentchattr");
-      if (fs.existsSync(path.join(perProjectAcDir, "config.toml"))) {
-        projectConfigToml = path.join(perProjectAcDir, "config.toml");
-      } else if (fs.existsSync(path.join(acDir, "config.toml"))) {
-        projectConfigToml = path.join(acDir, "config.toml");
-      } else if (project.working_dir) {
-        const legacyToml = path.join(project.working_dir, "agentchattr", "config.toml");
-        if (fs.existsSync(legacyToml)) projectConfigToml = legacyToml;
-      }
-
-      const extraArgs = projectConfigToml
-        ? ["--config", projectConfigToml]
-        : ["--port", String(port)];
-
-      patchAgentchattrCss(acDir);
-      const child = spawn(acSpawn.command, [...acSpawn.args, ...extraArgs], {
-        cwd: acSpawn.cwd,
-        env: process.env,
-        stdio: "ignore",
-        detached: true,
+      const resp = await fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(project.id)}/restart`, {
+        method: "POST",
+        timeout: 15000,
       });
-
-      if (!child.pid) {
-        console.error(`[health] AC for ${project.id} — spawn failed`);
-        chattrProcesses.set(project.id, { process: null, state: "error", error: "Auto-restart spawn failed" });
-        continue;
+      if (resp.ok) {
+        const data = await resp.json();
+        console.log(`[health] AC for ${project.id} auto-restarted (PID: ${data.pid})`);
+      } else {
+        const body = await resp.text().catch(() => "");
+        console.error(`[health] AC auto-restart failed for ${project.id}: ${resp.status} ${body.slice(0, 120)}`);
+        chattrProcesses.set(project.id, { process: null, state: "error", error: `Auto-restart failed: ${resp.status}` });
       }
-
-      child.unref();
-      child.on("error", (err) => {
-        chattrProcesses.set(project.id, { process: null, state: "error", error: err.message });
-      });
-      child.on("exit", (code) => {
-        const cur = chattrProcesses.get(project.id);
-        if (cur && cur.process === child) {
-          chattrProcesses.set(project.id, { process: null, state: "stopped", error: code ? `exit:${code}` : null });
-        }
-      });
-      chattrProcesses.set(project.id, { process: child, state: "running", error: null });
-      console.log(`[health] AC for ${project.id} auto-restarted (PID: ${child.pid})`);
-
-      // Sync token after restart
-      setTimeout(() => syncChattrToken(project.id), 2000);
     } catch (err) {
       console.error(`[health] AC auto-restart failed for ${project.id}:`, err.message);
       chattrProcesses.set(project.id, { process: null, state: "error", error: `Auto-restart failed: ${err.message}` });

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -18,6 +18,36 @@ function ServerSection({ projectId }: { projectId: string }) {
   const [loading, setLoading] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [confirmStop, setConfirmStop] = useState(false);
+  // #416: AC health monitor status — poll every 30s to surface
+  // auto-restart events and persistent errors in the dashboard.
+  const [healthNote, setHealthNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    const pollHealth = () => {
+      fetch(`/api/agentchattr/${encodeURIComponent(projectId)}/health`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (!d) { setHealthNote(null); return; }
+          if (d.autoRestart?.gaveUp) {
+            setHealthNote("AC auto-restart failed 3x — manual restart required");
+          } else if (d.autoRestart?.lastRestart) {
+            const ago = Math.round((Date.now() - d.autoRestart.lastRestart) / 1000);
+            if (ago < 300) {
+              const time = new Date(d.autoRestart.lastRestart).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+              setHealthNote(`AC auto-restarted at ${time}`);
+            } else {
+              setHealthNote(null);
+            }
+          } else {
+            setHealthNote(null);
+          }
+        })
+        .catch(() => setHealthNote(null));
+    };
+    pollHealth();
+    const interval = setInterval(pollHealth, 30000);
+    return () => clearInterval(interval);
+  }, [projectId]);
 
   const clearFeedback = () => {
     setTimeout(() => setFeedback(null), 3000);
@@ -140,6 +170,11 @@ function ServerSection({ projectId }: { projectId: string }) {
       </div>
       {feedback && (
         <div className="text-[10px] text-accent">{feedback}</div>
+      )}
+      {healthNote && !feedback && (
+        <div className={`text-[10px] ${healthNote.includes("failed") ? "text-error" : "text-[#ffcc00]"}`}>
+          {healthNote}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Fixes #416

Adds a lightweight AC health monitor that detects crashed AgentChattr processes and auto-restarts them.

### How it works
- **TCP connect probe** every 30s for each project with a "running" AC process
- If port is dead, auto-restarts using the same spawn logic as the manual restart endpoint
- **Rate limiting:** max one restart per 60s per project
- **Failure cap:** gives up after 3 consecutive failures, surfaces persistent error
- **Intentional stops** are not monitored (only unexpected crashes)

### Dashboard
- `GET /api/agentchattr/:project/health` returns health monitor state
- ServerSection polls every 30s and shows:
  - Yellow note: "AC auto-restarted at HH:MM" (for 5 minutes after auto-restart)
  - Red error: "AC auto-restart failed 3x — manual restart required"

## Changes
- `server/index.js` — health monitor loop, `isPortAlive()`, `acHealthCheck()`, health API endpoint (+162 lines)
- `src/components/ControlBar.tsx` — health polling + indicator in ServerSection (+35 lines)

## Test plan
- [ ] Kill an AC process manually → monitor detects within 30s and auto-restarts
- [ ] Auto-restart succeeds → agents reconnect, chat works
- [ ] Kill AC 3 times rapidly → after 3 failures, monitor stops trying and shows red error
- [ ] Click SERVER → Stop → monitor does NOT auto-restart (intentional stop)
- [ ] Console shows `[health] AC for project X on port Y is down — auto-restarting`
- [ ] Dashboard shows yellow auto-restart indicator briefly after recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)