### PR TITLE
[#447] Chain agent reset into AC restart endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1006,6 +1006,26 @@ async function handleAgentChattr(req, res) {
         }, 3000);
       }
       res.json({ ok: true, state: "running", pid: child.pid });
+      // #447: auto-reset all agents after AC restart so they get
+      // fresh MCP tokens. buildAgentArgs → waitForAgentChattrReady
+      // handles the AC-readiness wait internally; the 2s delay here
+      // just lets the AC process finish binding its port before we
+      // start polling.
+      setTimeout(async () => {
+        try {
+          const resetResp = await fetch(`http://127.0.0.1:${PORT}/api/agents/${encodeURIComponent(projectId)}/reset`, {
+            method: "POST",
+          });
+          if (resetResp.ok) {
+            const resetData = await resetResp.json();
+            console.log(`[agentchattr] ${projectId} auto-reset ${resetData.restarted} agent(s) after AC restart`);
+          } else {
+            console.warn(`[agentchattr] ${projectId} agent reset after AC restart returned ${resetResp.status}`);
+          }
+        } catch (err) {
+          console.warn(`[agentchattr] ${projectId} agent reset after AC restart failed: ${err.message || err}`);
+        }
+      }, 2000);
     } catch (err) {
       setProc({ process: null, state: "error", error: err.message });
       res.status(500).json({ ok: false, state: "error", error: err.message });
@@ -1880,19 +1900,8 @@ async function acHealthCheck() {
       if (resp.ok) {
         const data = await resp.json();
         console.log(`[health] AC for ${project.id} auto-restarted (PID: ${data.pid})`);
-        // #417/#416: also reset agents so they get fresh MCP tokens,
-        // same as the manual SERVER Restart button chain.
-        try {
-          const resetResp = await fetch(`http://127.0.0.1:${PORT}/api/agents/${encodeURIComponent(project.id)}/reset`, {
-            method: "POST",
-          });
-          if (resetResp.ok) {
-            const resetData = await resetResp.json();
-            console.log(`[health] ${resetData.restarted} agent(s) reset for ${project.id}`);
-          }
-        } catch (resetErr) {
-          console.warn(`[health] Agent reset after AC auto-restart failed for ${project.id}:`, resetErr.message);
-        }
+        // #447: agent reset is now chained inside the restart endpoint
+        // itself (fires on a 2s timer), so no separate call needed here.
       } else {
         const body = await resp.text().catch(() => "");
         console.error(`[health] AC auto-restart failed for ${project.id}: ${resp.status} ${body.slice(0, 120)}`);


### PR DESCRIPTION
## Summary

- The manual **SERVER → Restart** button restarted the AC process but left all 4 agent PTY sessions running with stale MCP tokens — agents showed `[session closed: 1006]` and couldn't communicate via AgentChattr
- The health monitor path had a separate agent reset call after AC restart, but the manual button path was missing it entirely
- **Fix**: Move the agent reset chain directly into the `/api/agentchattr/:project/restart` endpoint (fires on a 2s timer after AC spawn), so **every** AC restart path — manual button, health monitor, future callers — automatically resets agents with fresh MCP tokens
- Remove the now-redundant separate reset call from `acHealthCheck()` since it calls the restart endpoint which now chains the reset

## What changed

`server/index.js`:
- **Restart endpoint** (line ~1008): Added a 2s-delayed `POST /api/agents/:project/reset` after `res.json()`. `buildAgentArgs` → `waitForAgentChattrReady` handles the AC-readiness poll internally, so agents register only after AC is accepting connections.
- **Health monitor** (line ~1903): Replaced the separate agent reset block with a comment noting it's now handled by the restart endpoint.

## Test plan

- [ ] Click **SERVER → Restart** — verify all 4 agent terminals recover with live output within ~15s (no `[session closed: 1006]`)
- [ ] Kill the AC process manually (`kill <pid>`) — verify health monitor detects within 30s, auto-restarts AC, and all 4 agents auto-recover
- [ ] After recovery, verify no `-2` / `-3` suffixed agent registrations in AgentChattr `/api/who`
- [ ] Verify agents can read and send via MCP tools after recovery (not just queue-watcher PTY injection)

Fixes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)