### PR TITLE
[#448] Sync chat token on GET /api/chat 403 + startup retry

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1926,9 +1926,12 @@ server.listen(PORT, "127.0.0.1", () => {
   // Sync AgentChattr tokens for all projects on startup and backfill
   // the sender-overflow CSS/JS patch (#402) so already-running AC
   // instances receive the fix without requiring a restart.
+  // #448: retry after 5s for projects where AC isn't up yet at boot.
   const startupCfg = readConfig();
   for (const p of (startupCfg.projects || [])) {
-    syncChattrToken(p.id);
+    syncChattrToken(p.id).catch(() => {
+      setTimeout(() => syncChattrToken(p.id).catch(() => {}), 5000);
+    });
     const { dir: acDir } = resolveProjectChattr(p.id);
     if (acDir) patchAgentchattrCss(acDir);
   }

--- a/server/routes.js
+++ b/server/routes.js
@@ -113,18 +113,32 @@ function chatAuthHeaders(token) {
 }
 
 router.get("/api/chat", async (req, res) => {
+  const projectId = req.query.project;
   const apiPath = req.query.path || "/api/messages";
-  const { url: base, token } = getChattrConfig(req.query.project);
+  const { url: base, token } = getChattrConfig(projectId);
 
-  const fwd = new URLSearchParams();
-  for (const [k, v] of Object.entries(req.query)) {
-    if (k !== "path") fwd.set(k, String(v));
-  }
-  if (token) fwd.set("token", token);
+  const buildUrl = (tok) => {
+    const fwd = new URLSearchParams();
+    for (const [k, v] of Object.entries(req.query)) {
+      if (k !== "path") fwd.set(k, String(v));
+    }
+    if (tok) fwd.set("token", tok);
+    return `${base}${apiPath}?${fwd.toString()}`;
+  };
 
-  const url = `${base}${apiPath}?${fwd.toString()}`;
   try {
-    const r = await fetch(url, { headers: chatAuthHeaders(token) });
+    const r = await fetch(buildUrl(token), { headers: chatAuthHeaders(token) });
+    // #448: on 401/403, re-sync the session token from AC and retry
+    // once. The stored token may be stale after an AC restart.
+    if ((r.status === 401 || r.status === 403) && projectId) {
+      try { await syncChattrToken(projectId); } catch {}
+      const { token: refreshed } = getChattrConfig(projectId);
+      if (refreshed && refreshed !== token) {
+        const retry = await fetch(buildUrl(refreshed), { headers: chatAuthHeaders(refreshed) });
+        if (!retry.ok) return res.status(retry.status).json({ error: `AgentChattr returned ${retry.status}` });
+        return res.json(await retry.json());
+      }
+    }
     if (!r.ok) return res.status(r.status).json({ error: `AgentChattr returned ${r.status}` });
     res.json(await r.json());
   } catch (err) {


### PR DESCRIPTION
## Summary

- Chat panel showed "Loading messages..." indefinitely after AC restarts — the stored `agentchattr_token` was stale and no code path re-synced it for the GET `/api/chat` poll
- **GET `/api/chat`**: Added 401/403 → `syncChattrToken()` → retry-once logic, mirroring the existing POST handler's retry pattern. This creates a self-healing loop: even if the startup sync misses, the first chat poll auto-fixes the token
- **Startup sync**: Added a 5s delayed retry so projects whose AC isn't listening at boot time still get their token synced (the original fire-and-forget call silently failed if AC wasn't ready)

## What changed

- `server/routes.js` (GET `/api/chat`): On 401/403 response, call `syncChattrToken(projectId)`, re-read the config, and retry the fetch with the refreshed token
- `server/index.js` (startup): Wrap `syncChattrToken()` with `.catch()` that schedules a 5s delayed retry

## Test plan

- [ ] Stop QuadWork + AC, restart both — chat panel loads messages on first page load (no "Loading messages...")
- [ ] Kill AC process manually, let health monitor restart it — chat panel recovers within one poll cycle (~3s)
- [ ] Click SERVER → Restart — chat panel recovers within one poll cycle
- [ ] Verify no double-sync on normal startup when AC is already running (token matches, no unnecessary config write)

Fixes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)