### PR TITLE
[#439] Rename bridge slugs: telegram-bridge→tg, discord-bridge→dc

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1106,7 +1106,7 @@ bot_token = "env:${envKey}"
 chat_id = "${chatId}"
 agentchattr_url = "${projectChattrUrl}"
 poll_interval = 2
-bridge_sender = "telegram-bridge"
+bridge_sender = "tg"
 `;
         fs.appendFileSync(configTomlPath, telegramSection);
         ok("Added Telegram config to config.toml (token stored in .env)");
@@ -1121,7 +1121,7 @@ bridge_sender = "telegram-bridge"
           // silently ignored and the bridge falls back to :8300.
           // #404: cursor_file must be per-project so multiple bridges
           // don't clobber each other's position.
-          const cursorFile = path.join(CONFIG_DIR, `telegram-bridge-cursor-${setup.projectName}.json`);
+          const cursorFile = path.join(CONFIG_DIR, `tg-bridge-cursor-${setup.projectName}.json`);
           const bridgeTomlContent = `[telegram]\nbot_token = "${botToken}"\nchat_id = "${chatId}"\nagentchattr_url = "${projectChattrUrl}"\ncursor_file = "${cursorFile}"\n`;
           fs.writeFileSync(bridgeToml, bridgeTomlContent, { mode: 0o600 });
           fs.chmodSync(bridgeToml, 0o600);
@@ -1141,7 +1141,7 @@ bridge_sender = "telegram-bridge"
           bridgeProc.unref();
           if (bridgeProc.pid) {
             ok(`Telegram bridge started (PID: ${bridgeProc.pid})`);
-            const pidFile = path.join(CONFIG_DIR, "telegram-bridge.pid");
+            const pidFile = path.join(CONFIG_DIR, "tg-bridge.pid");
             fs.writeFileSync(pidFile, String(bridgeProc.pid));
           } else {
             warn("Could not start Telegram bridge — start manually");
@@ -1765,7 +1765,7 @@ function cmdStop() {
   console.log("\n  QuadWork Stop\n");
 
   let stopped = 0;
-  if (stopPid("Telegram bridge", "telegram-bridge.pid")) stopped++;
+  if (stopPid("Telegram bridge", "tg-bridge.pid")) stopped++;
 
   // Stop per-project AgentChattr instances
   const config = readConfig();

--- a/bridges/discord/discord_bridge.py
+++ b/bridges/discord/discord_bridge.py
@@ -35,7 +35,7 @@ except ModuleNotFoundError:
 import discord
 import requests
 
-log = logging.getLogger("discord-bridge")
+log = logging.getLogger("dc-bridge")
 
 # ---------------------------------------------------------------------------
 # Config
@@ -46,7 +46,7 @@ DEFAULT_CONFIG = {
     "channel_id": "",
     "agentchattr_url": "http://127.0.0.1:8300",
     "poll_interval": 2,
-    "bridge_sender": "discord-bridge",
+    "bridge_sender": "dc",
     "cursor_file": "",
 }
 
@@ -145,7 +145,7 @@ def save_cursor(path):
 
 # Mutable dict so heartbeat thread sees re-registration updates.
 # bridge_sender is set from cfg during main() so all callers can read it.
-ac = {"token": "", "name": "", "bridge_sender": "discord-bridge", "known_names": set()}
+ac = {"token": "", "name": "", "bridge_sender": "dc", "known_names": set()}
 
 
 def ac_register(url, base=None, label="Discord Bridge"):

--- a/server/routes.discordBridge.test.js
+++ b/server/routes.discordBridge.test.js
@@ -32,7 +32,7 @@ try {
   assert.match(toml, /channel_id = "123456789"/);
   assert.match(toml, /agentchattr_url = "http:\/\/127\.0\.0\.1:8301"/);
   // Per-project cursor file
-  assert.match(toml, /cursor_file = ".*discord-bridge-cursor-testproject\.json"/);
+  assert.match(toml, /cursor_file = ".*dc-bridge-cursor-testproject\.json"/);
   // Must NOT emit a separate [agentchattr] section
   assert.equal(toml.includes("\n[agentchattr]\n"), false);
 
@@ -41,18 +41,18 @@ try {
     "[agents.head]\nlabel = \"Head\"\n\n[agents.dev]\nlabel = \"Dev\"\n";
   const first = patchAgentchattrConfigForDiscordBridge(baseConfig);
   assert.equal(first.changed, true);
-  assert.match(first.text, /^\[agents\.discord-bridge\]$/m);
+  assert.match(first.text, /^\[agents\.dc\]$/m);
   assert.match(first.text, /label = "Discord Bridge"/);
   // Second run is a no-op
   const second = patchAgentchattrConfigForDiscordBridge(first.text);
   assert.equal(second.changed, false);
   assert.equal(second.text, first.text);
-  // Hand-patched config is recognized
+  // #439: old slug [agents.discord-bridge] is migrated to [agents.dc]
   const handPatched =
     baseConfig + "\n[agents.discord-bridge]\nlabel = \"Discord Bridge\"\n";
   const third = patchAgentchattrConfigForDiscordBridge(handPatched);
-  assert.equal(third.changed, false);
-  assert.equal(third.text, handPatched);
+  assert.equal(third.changed, true);
+  assert.match(third.text, /^\[agents\.dc\]$/m);
 
   // 4) buildDiscordBridgeSpawnEnv strips Discord-specific env vars.
   const scrubbed = buildDiscordBridgeSpawnEnv({

--- a/server/routes.js
+++ b/server/routes.js
@@ -2430,6 +2430,11 @@ function resolveProjectAgentchattrUrl(cfg, project) {
 // silently killing AC→TG forwarding for that project.
 function buildTelegramBridgeToml(tg, projectId) {
   const cursorFile = path.join(CONFIG_DIR, `tg-bridge-cursor-${projectId}.json`);
+  // #439: migrate old cursor file so the bridge doesn't replay history
+  const oldCursor = path.join(CONFIG_DIR, `telegram-bridge-cursor-${projectId}.json`);
+  if (!fs.existsSync(cursorFile) && fs.existsSync(oldCursor)) {
+    fs.renameSync(oldCursor, cursorFile);
+  }
   return (
     `[telegram]\n` +
     `bot_token = "${tg.bot_token}"\n` +
@@ -2969,6 +2974,11 @@ function discordBridgeLog(projectId) {
 
 function buildDiscordBridgeToml(dc, projectId) {
   const cursorFile = path.join(CONFIG_DIR, `dc-bridge-cursor-${projectId}.json`);
+  // #439: migrate old cursor file so the bridge doesn't replay history
+  const oldCursor = path.join(CONFIG_DIR, `discord-bridge-cursor-${projectId}.json`);
+  if (!fs.existsSync(cursorFile) && fs.existsSync(oldCursor)) {
+    fs.renameSync(oldCursor, cursorFile);
+  }
   return (
     `[discord]\n` +
     `bot_token = "${dc.bot_token}"\n` +

--- a/server/routes.js
+++ b/server/routes.js
@@ -2394,7 +2394,7 @@ router.post("/api/rename", (req, res) => {
 const BRIDGE_DIR = path.join(CONFIG_DIR, "agentchattr-telegram");
 
 function telegramPidFile(projectId) {
-  return path.join(CONFIG_DIR, `telegram-bridge-${projectId}.pid`);
+  return path.join(CONFIG_DIR, `tg-bridge-${projectId}.pid`);
 }
 
 function telegramConfigToml(projectId) {
@@ -2402,7 +2402,7 @@ function telegramConfigToml(projectId) {
 }
 
 // #383: path to a project's AgentChattr config.toml. The install
-// handler patches this file to declare the `telegram-bridge` agent
+// handler patches this file to declare the `tg` agent
 // so AC's registry accepts the bridge's register call.
 function projectAgentchattrConfigPath(projectId) {
   return path.join(CONFIG_DIR, projectId, "agentchattr", "config.toml");
@@ -2429,7 +2429,7 @@ function resolveProjectAgentchattrUrl(cfg, project) {
 // AC message IDs advances the cursor past the other project's range,
 // silently killing AC→TG forwarding for that project.
 function buildTelegramBridgeToml(tg, projectId) {
-  const cursorFile = path.join(CONFIG_DIR, `telegram-bridge-cursor-${projectId}.json`);
+  const cursorFile = path.join(CONFIG_DIR, `tg-bridge-cursor-${projectId}.json`);
   return (
     `[telegram]\n` +
     `bot_token = "${tg.bot_token}"\n` +
@@ -2441,14 +2441,18 @@ function buildTelegramBridgeToml(tg, projectId) {
 
 // #383 Bug 3: AC's registry rejects any base name not pre-declared
 // in config.toml with `400 unknown base`. The bridge registers as
-// `telegram-bridge`, so every per-project AC config must declare it.
-// Idempotent: only appends if the section is not already present.
+// `tg` (#439: renamed from `telegram-bridge`), so every per-project
+// AC config must declare it. Idempotent: only appends if the section
+// is not already present. Also migrates old `[agents.telegram-bridge]`.
 function patchAgentchattrConfigForTelegramBridge(tomlText) {
-  if (/^\[agents\.telegram-bridge\]\s*$/m.test(tomlText)) {
-    return { text: tomlText, changed: false };
+  // #439: migrate old slug if present
+  const original = tomlText;
+  tomlText = tomlText.replace(/^\[agents\.telegram-bridge\]\s*$/m, "[agents.tg]");
+  if (/^\[agents\.tg\]\s*$/m.test(tomlText)) {
+    return { text: tomlText, changed: tomlText !== original };
   }
   const sep = tomlText.length === 0 || tomlText.endsWith("\n") ? "" : "\n";
-  const block = `\n[agents.telegram-bridge]\nlabel = "Telegram Bridge"\n`;
+  const block = `\n[agents.tg]\nlabel = "Telegram Bridge"\n`;
   return { text: tomlText + sep + block, changed: true };
 }
 
@@ -2470,7 +2474,7 @@ function buildTelegramBridgeSpawnEnv(parentEnv) {
 // config parse, auth failure) are recoverable instead of
 // /dev/null'd by `stdio: "ignore"`.
 function telegramBridgeLog(projectId) {
-  return path.join(CONFIG_DIR, `telegram-bridge-${projectId}.log`);
+  return path.join(CONFIG_DIR, `tg-bridge-${projectId}.log`);
 }
 
 // Tail the last N lines of a file without reading the whole thing
@@ -2720,7 +2724,7 @@ router.post("/api/telegram", async (req, res) => {
         });
       }
       // #383 Bug 3: ensure every known project's AC config declares
-      // the `telegram-bridge` agent. Without this, AC's registry
+      // the `tg` agent. Without this, AC's registry
       // rejects the bridge's register call with `400 unknown base`
       // and the bridge enters an infinite re-register loop.
       // Idempotent — append-only, skips configs that already have
@@ -2869,7 +2873,7 @@ router.post("/api/telegram", async (req, res) => {
         const acUrl = resolveProjectAgentchattrUrl(cfg, project);
         if (acUrl) {
           const acPort = new URL(acUrl).port || "8300";
-          await fetch(`http://127.0.0.1:${acPort}/api/deregister/telegram-bridge`, {
+          await fetch(`http://127.0.0.1:${acPort}/api/deregister/tg`, {
             method: "POST",
             signal: AbortSignal.timeout(3000),
           }).catch(() => {});
@@ -2952,7 +2956,7 @@ const DISCORD_BRIDGE_SRC = path.join(__dirname, "..", "bridges", "discord");
 const DISCORD_BRIDGE_DIR = path.join(CONFIG_DIR, "agentchattr-discord");
 
 function discordPidFile(projectId) {
-  return path.join(CONFIG_DIR, `discord-bridge-${projectId}.pid`);
+  return path.join(CONFIG_DIR, `dc-bridge-${projectId}.pid`);
 }
 
 function discordConfigToml(projectId) {
@@ -2960,11 +2964,11 @@ function discordConfigToml(projectId) {
 }
 
 function discordBridgeLog(projectId) {
-  return path.join(CONFIG_DIR, `discord-bridge-${projectId}.log`);
+  return path.join(CONFIG_DIR, `dc-bridge-${projectId}.log`);
 }
 
 function buildDiscordBridgeToml(dc, projectId) {
-  const cursorFile = path.join(CONFIG_DIR, `discord-bridge-cursor-${projectId}.json`);
+  const cursorFile = path.join(CONFIG_DIR, `dc-bridge-cursor-${projectId}.json`);
   return (
     `[discord]\n` +
     `bot_token = "${dc.bot_token}"\n` +
@@ -2975,11 +2979,14 @@ function buildDiscordBridgeToml(dc, projectId) {
 }
 
 function patchAgentchattrConfigForDiscordBridge(tomlText) {
-  if (/^\[agents\.discord-bridge\]\s*$/m.test(tomlText)) {
-    return { text: tomlText, changed: false };
+  // #439: migrate old slug if present
+  const original = tomlText;
+  tomlText = tomlText.replace(/^\[agents\.discord-bridge\]\s*$/m, "[agents.dc]");
+  if (/^\[agents\.dc\]\s*$/m.test(tomlText)) {
+    return { text: tomlText, changed: tomlText !== original };
   }
   const sep = tomlText.length === 0 || tomlText.endsWith("\n") ? "" : "\n";
-  const block = `\n[agents.discord-bridge]\nlabel = "Discord Bridge"\n`;
+  const block = `\n[agents.dc]\nlabel = "Discord Bridge"\n`;
   return { text: tomlText + sep + block, changed: true };
 }
 
@@ -3161,7 +3168,7 @@ router.post("/api/discord", async (req, res) => {
             `pip output tail:\n${pipOutput.split("\n").slice(-10).join("\n")}`,
         });
       }
-      // Patch all project AC configs with [agents.discord-bridge]
+      // Patch all project AC configs with [agents.dc]
       const patched = [];
       try {
         const cfgAll = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
@@ -3260,7 +3267,7 @@ router.post("/api/discord", async (req, res) => {
         const acUrl = resolveProjectAgentchattrUrl(cfg, project);
         if (acUrl) {
           const acPort = new URL(acUrl).port || "8300";
-          await fetch(`http://127.0.0.1:${acPort}/api/deregister/discord-bridge`, {
+          await fetch(`http://127.0.0.1:${acPort}/api/deregister/dc`, {
             method: "POST",
             signal: AbortSignal.timeout(3000),
           }).catch(() => {});
@@ -3388,7 +3395,7 @@ module.exports.parseActiveBatch = parseActiveBatch;
 // summarizeItems for the batch-progress fixture test.
 module.exports.buildNoPrRow = buildNoPrRow;
 module.exports.summarizeItems = summarizeItems;
-// #353: expose readLastLines for the telegram-bridge test.
+// #353: expose readLastLines for the tg-bridge test.
 module.exports.readLastLines = readLastLines;
 // #380: expose checkTelegramBridgePythonDeps so the bridge test can
 // exercise the venv-path interpreter argument round trip.

--- a/server/routes.telegramBridge.test.js
+++ b/server/routes.telegramBridge.test.js
@@ -183,7 +183,7 @@ try {
   assert.match(toml13, /agentchattr_url = "http:\/\/127\.0\.0\.1:8301"/);
   // #404: cursor_file must be per-project so multiple bridges
   // don't clobber each other's position.
-  assert.match(toml13, /cursor_file = ".*telegram-bridge-cursor-testproject\.json"/);
+  assert.match(toml13, /cursor_file = ".*tg-bridge-cursor-testproject\.json"/);
   // Must NOT emit a separate [agentchattr] section — the bridge
   // would silently ignore it.
   assert.equal(toml13.includes("\n[agentchattr]\n"), false);
@@ -196,19 +196,19 @@ try {
     "[agents.head]\nlabel = \"Head\"\n\n[agents.dev]\nlabel = \"Dev\"\n";
   const first = patchAgentchattrConfigForTelegramBridge(baseConfig);
   assert.equal(first.changed, true);
-  assert.match(first.text, /^\[agents\.telegram-bridge\]$/m);
+  assert.match(first.text, /^\[agents\.tg\]$/m);
   assert.match(first.text, /label = "Telegram Bridge"/);
   // Running a second time is a no-op.
   const second = patchAgentchattrConfigForTelegramBridge(first.text);
   assert.equal(second.changed, false);
   assert.equal(second.text, first.text);
-  // A config that was hand-patched during diagnosis is recognized
-  // as already-correct — do not clobber the operator's edit.
+  // #439: a config with old slug [agents.telegram-bridge] is migrated
+  // to [agents.tg] and flagged as changed.
   const handPatched =
     baseConfig + "\n[agents.telegram-bridge]\nlabel = \"Telegram Bridge\"\n";
   const third = patchAgentchattrConfigForTelegramBridge(handPatched);
-  assert.equal(third.changed, false);
-  assert.equal(third.text, handPatched);
+  assert.equal(third.changed, true);
+  assert.match(third.text, /^\[agents\.tg\]$/m);
 
   // 15) #383 Bug 4: buildTelegramBridgeSpawnEnv strips the three
   //     env vars the upstream bridge treats as higher-precedence

--- a/src/components/DiscordBridgeWidget.tsx
+++ b/src/components/DiscordBridgeWidget.tsx
@@ -67,7 +67,7 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
     if (patched.length > 0) {
       setRestartNotice(
         `Install Bridge patched ${patched.length} AgentChattr config(s) ` +
-        `(${patched.join(", ")}) to declare [agents.discord-bridge]. ` +
+        `(${patched.join(", ")}) to declare [agents.dc]. ` +
         `Click SERVER \u2192 Restart so AgentChattr picks up the new agent slug, ` +
         `then click Start again. Without the restart, Start will fail with a 400 registration loop.`,
       );

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -14,7 +14,7 @@ interface TelegramStatus {
   chat_id: string;
   bot_username: string;
   bridge_installed: boolean;
-  // #353: tail of ~/.quadwork/telegram-bridge-<projectId>.log
+  // #353: tail of ~/.quadwork/tg-bridge-<projectId>.log
   // populated by the server when running === false and the log
   // file has content, so runtime crashes after a successful
   // Start are still visible in the widget.
@@ -52,7 +52,7 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
   const [pollError, setPollError] = useState<string | null>(null);
   const [setupOpen, setSetupOpen] = useState(false);
   // #383: the Install Bridge handler now migrates every existing
-  // per-project AC `config.toml` to declare `[agents.telegram-bridge]`
+  // per-project AC `config.toml` to declare `[agents.tg]`
   // (required so AC's registry accepts the bridge's register call).
   // When that migration actually touches any configs, the operator
   // must click SERVER → Restart for AC to load the new agent slug;
@@ -84,7 +84,7 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
     if (patched.length > 0) {
       setRestartNotice(
         `Install Bridge patched ${patched.length} AgentChattr config(s) ` +
-        `(${patched.join(", ")}) to declare [agents.telegram-bridge]. ` +
+        `(${patched.join(", ")}) to declare [agents.tg]. ` +
         `Click SERVER → Restart so AgentChattr picks up the new agent slug, ` +
         `then click Start again. Without the restart, Start will fail with a 400 registration loop.`,
       );

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -38,15 +38,15 @@ color = "#da7756"
 label = "Builder"
 
 # #383: AC's registry rejects bases not declared in config.toml.
-# The Telegram bridge registers as `telegram-bridge`, so every
-# per-project AC config must declare it. The bridge has no
-# command/cwd of its own — it is a long-running external client
-# that posts to AC's HTTP API.
-[agents.telegram-bridge]
+# The Telegram bridge registers as `tg` (#439: renamed from
+# `telegram-bridge`), so every per-project AC config must declare
+# it. The bridge has no command/cwd of its own — it is a long-running
+# external client that posts to AC's HTTP API.
+[agents.tg]
 label = "Telegram Bridge"
 
-# #399: Discord bridge registers as `discord-bridge`.
-[agents.discord-bridge]
+# #399/#439: Discord bridge registers as `dc` (renamed from `discord-bridge`).
+[agents.dc]
 label = "Discord Bridge"
 
 [routing]


### PR DESCRIPTION
## Summary

- Shortens both bridge registration base names to fit the ≤4-char agent naming convention (`head`/`dev`/`re1`/`re2`) and stop overflowing the sender column
- `telegram-bridge` → `tg`, `discord-bridge` → `dc` (labels stay "Telegram Bridge" / "Discord Bridge")
- Config patchers include idempotent migration: old `[agents.telegram-bridge]`/`[agents.discord-bridge]` sections are automatically renamed to `[agents.tg]`/`[agents.dc]` on next bridge install or AC config patch
- Also committed to `realproject7/agentchattr-telegram` (upstream bridge default changed)

## What changed

| File | Change |
|------|--------|
| `templates/config.toml` | `[agents.tg]` and `[agents.dc]` |
| `server/routes.js` | All pid/log/cursor file paths, deregister API calls, config patchers with old→new migration |
| `bridges/discord/discord_bridge.py` | Default `bridge_sender` → `"dc"` |
| `bin/quadwork.js` | `bridge_sender`, cursor/pid file paths |
| `src/components/*.tsx` | Restart notice messages |
| `server/routes.*.test.js` | Updated assertions + migration test cases |

## Test plan

- [ ] Install Telegram bridge → verify AC registers as `tg`, sender column shows `tg`
- [ ] Install Discord bridge → verify AC registers as `dc`, sender column shows `dc`
- [ ] Existing project with old `[agents.telegram-bridge]` config → verify migration renames to `[agents.tg]` on next Install Bridge
- [ ] Echo prevention still works (bridge doesn't echo its own forwarded messages)
- [ ] `node server/routes.telegramBridge.test.js` — 15/15 pass
- [ ] `node server/routes.discordBridge.test.js` — 5/5 pass

Fixes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)