### PR TITLE
[#444] Pin agentchattr-telegram to a known commit

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -26,6 +26,8 @@ const AGENTCHATTR_REPO = "https://github.com/bcurts/agentchattr.git";
 // a loud warning instead of hard-failing — see installAgentChattr
 // below.
 const AGENTCHATTR_PIN = "3e71d4267572579e7ffeb83576645f90932c1849";
+// #444: same pattern for realproject7/agentchattr-telegram.
+const AGENTCHATTR_TELEGRAM_PIN = "4a6b45f1794c612328b9d5ee6d6fcb3f77015abc";
 
 // ─── ANSI Helpers ──────────────────────────────────────────────────────────
 
@@ -1047,7 +1049,14 @@ async function setupAddons(rl, setup, configTomlPath) {
       const cloneSpinner = spinner("Cloning agentchattr-telegram...");
       const cloneResult = run(`git clone https://github.com/realproject7/agentchattr-telegram.git "${telegramDir}" 2>&1`);
       cloneSpinner.stop(cloneResult !== null);
-      if (!cloneResult) warn("You can set it up manually later");
+      if (!cloneResult) { warn("You can set it up manually later"); }
+      else {
+        // #444: pin to a known commit, same pattern as AGENTCHATTR_PIN
+        const pinResult = run(`git -C "${telegramDir}" checkout -B pinned ${AGENTCHATTR_TELEGRAM_PIN} 2>&1`, { timeout: 30000 });
+        if (pinResult === null) {
+          try { console.warn(`[quadwork] WARNING: could not check out agentchattr-telegram pin ${AGENTCHATTR_TELEGRAM_PIN} at ${telegramDir}; falling back to default branch.`); } catch {}
+        }
+      }
     } else {
       ok("agentchattr-telegram already present");
     }
@@ -2011,6 +2020,33 @@ function cmdDoctor() {
   } catch (err) {
     console.log(`  (could not enumerate projects: ${err.message})`);
   }
+  // #444: agentchattr-telegram pin status
+  console.log("");
+  console.log(`agentchattr-telegram pin: ${AGENTCHATTR_TELEGRAM_PIN}`);
+  const tgBridgeDir = path.join(CONFIG_DIR, "agentchattr-telegram");
+  if (!fs.existsSync(tgBridgeDir)) {
+    console.log("  [skip] agentchattr-telegram: not installed");
+  } else {
+    const tgSha = cloneShaAt(tgBridgeDir);
+    if (!tgSha) {
+      console.log(`  [warn] agentchattr-telegram: ${tgBridgeDir} — not a git clone`);
+    } else {
+      const tgBranch = cloneBranchAt(tgBridgeDir);
+      let tgTag;
+      if (tgSha !== AGENTCHATTR_TELEGRAM_PIN) {
+        tgTag = "DIFF";
+      } else if (!tgBranch) {
+        tgTag = "DETACH";
+      } else if (tgBranch !== "pinned") {
+        tgTag = "BR  ";
+      } else {
+        tgTag = "OK  ";
+      }
+      const tgBranchLabel = tgBranch ? `branch=${tgBranch}` : "branch=(detached)";
+      console.log(`  [${tgTag}] ${tgSha} ${tgBranchLabel} (${tgBridgeDir})`);
+    }
+  }
+
   console.log("");
   console.log("Legend: [OK  ] on pin + on `pinned` branch; [BR  ] on pin but on a non-`pinned` named branch; [DETACH] on pin but in detached HEAD (re-run quadwork start to auto-migrate); [DIFF] off-pin (re-clone manually to re-sync)");
   console.log("");

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -90,14 +90,18 @@ Notes about the loop:
 - Post the release URL in the project chat so the batch reviewers can
   verify the auto-generated notes look sane.
 
-## Bumping the AgentChattr pin (#348)
+## Bumping the AgentChattr pins (#348, #444)
 
-QuadWork installs AgentChattr via `git clone` and then checks out
-a pinned commit declared in `bin/quadwork.js`:
+QuadWork installs AgentChattr and agentchattr-telegram via `git clone`
+and then checks out pinned commits declared in `bin/quadwork.js`:
 
 ```js
 const AGENTCHATTR_PIN = "<commit-sha>";
+const AGENTCHATTR_TELEGRAM_PIN = "<commit-sha>";
 ```
+
+The telegram pin is also declared in `server/routes.js` for the
+Install Bridge dashboard handler.
 
 Every fresh `npx quadwork` install produces a byte-identical
 AgentChattr clone at this commit, so two users installing on
@@ -110,8 +114,10 @@ new QuadWork release that needs a newer AgentChattr:
    dashboard end-to-end against at least one real project.
    Verify `quadwork doctor` shows the new pin and reports every
    per-project clone in-sync (see below).
-3. Update `AGENTCHATTR_PIN` in `bin/quadwork.js` to the new
-   commit and commit it as part of the same release PR.
+3. Update `AGENTCHATTR_PIN` and/or `AGENTCHATTR_TELEGRAM_PIN`
+   in `bin/quadwork.js` (and `server/routes.js` for the telegram
+   pin) to the new commit(s) and commit as part of the same
+   release PR.
 4. Note the bump in the release changelog so operators know
    what upstream changes are rolling in.
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -2392,6 +2392,9 @@ router.post("/api/rename", (req, res) => {
 // ─── Telegram ──────────────────────────────────────────────────────────────
 
 const BRIDGE_DIR = path.join(CONFIG_DIR, "agentchattr-telegram");
+// #444: pin agentchattr-telegram to a known commit (same pattern as
+// AGENTCHATTR_PIN in bin/quadwork.js for bcurts/agentchattr).
+const AGENTCHATTR_TELEGRAM_PIN = "4a6b45f1794c612328b9d5ee6d6fcb3f77015abc";
 
 function telegramPidFile(projectId) {
   return path.join(CONFIG_DIR, `tg-bridge-${projectId}.pid`);
@@ -2699,6 +2702,12 @@ router.post("/api/telegram", async (req, res) => {
       try {
         if (!fs.existsSync(BRIDGE_DIR)) {
           execFileSync("gh", ["repo", "clone", "realproject7/agentchattr-telegram", BRIDGE_DIR], { encoding: "utf-8", timeout: 30000 });
+          // #444: pin to a known commit after clone
+          try {
+            execFileSync("git", ["-C", BRIDGE_DIR, "checkout", "-B", "pinned", AGENTCHATTR_TELEGRAM_PIN], { encoding: "utf-8", timeout: 30000 });
+          } catch {
+            console.warn(`[telegram] WARNING: could not check out agentchattr-telegram pin ${AGENTCHATTR_TELEGRAM_PIN}; falling back to default branch.`);
+          }
         }
         // #380: create the dedicated venv if missing. `python3 -m venv`
         // builds a fresh isolated environment that bypasses PEP 668


### PR DESCRIPTION
## Summary

- `realproject7/agentchattr-telegram` was cloned without any pin — two users installing a week apart got different versions of the bridge script
- Adds `AGENTCHATTR_TELEGRAM_PIN` constant (pinned to `4a6b45f` — the #439 bridge_sender rename) in both `bin/quadwork.js` and `server/routes.js`
- Both clone sites (CLI setup wizard + Install Bridge dashboard handler) now checkout `-B pinned <PIN>` after clone, with fallback to default branch on failure
- `quadwork doctor` reports pin status for agentchattr-telegram alongside the existing AgentChattr report
- `docs/RELEASING.md` updated to document both pins in the bump procedure

## What changed

| File | Change |
|------|--------|
| `bin/quadwork.js` | Pin constant, checkout after clone in setup, doctor report |
| `server/routes.js` | Pin constant, checkout after clone in Install Bridge |
| `docs/RELEASING.md` | Document both pins |

## Test plan

- [ ] Fresh clone via setup wizard → verify agentchattr-telegram lands on branch `pinned` at `4a6b45f`
- [ ] Fresh clone via Install Bridge → same verification
- [ ] `quadwork doctor` → shows agentchattr-telegram pin status with `[OK  ]`
- [ ] Existing installs without pin → doctor shows `[DIFF]` (expected, operator re-clones manually)

Fixes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)