### PR TITLE
[#441] Add Auto toggle to Keep Mac Awake linked to batch lifecycle

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -220,7 +220,6 @@ function SystemSection({ projectId }: { projectId: string }) {
   const [awakeAuto, setAwakeAuto] = useState(false);
   const [awakeAutoStatus, setAwakeAutoStatus] = useState<string | null>(null);
   const awakeAutoRef = useRef(false);
-  const awakeAutoLoadedRef = useRef(false);
   const prevBatchRef = useRef<{ complete: boolean; hasItems: boolean } | null>(null);
   // Track manual stop so auto doesn't re-start until next batch transition
   const manualStopRef = useRef(false);
@@ -313,16 +312,20 @@ function SystemSection({ projectId }: { projectId: string }) {
       .catch(() => {});
   };
 
-  // #441: Auto toggle — load persisted state from config
+  // #441: Auto toggle — load persisted state from config.
+  // Reset all auto state on project switch so stale refs from the
+  // previous project don't leak.
   useEffect(() => {
-    if (awakeAutoLoadedRef.current) return;
+    setAwakeAuto(false);
+    setAwakeAutoStatus(null);
+    prevBatchRef.current = null;
+    manualStopRef.current = false;
     fetch("/api/config")
       .then((r) => (r.ok ? r.json() : null))
       .then((cfg) => {
         if (!cfg) return;
         const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
         if (entry?.awake_auto) setAwakeAuto(true);
-        awakeAutoLoadedRef.current = true;
       })
       .catch(() => {});
   }, [projectId]);

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   NOTIFICATION_SOUND_OPTIONS,
   type NotificationSoundChoice,
@@ -201,7 +201,10 @@ function formatTime(seconds: number): string {
   return `${m}m`;
 }
 
-function SystemSection() {
+const AWAKE_AUTO_POLL_MS = 30_000;
+const AWAKE_AUTO_DEFAULT_HOURS = 8;
+
+function SystemSection({ projectId }: { projectId: string }) {
   const [active, setActive] = useState(false);
   const [remaining, setRemaining] = useState<number | null>(null);
   const [platform, setPlatform] = useState<string>("");
@@ -212,6 +215,18 @@ function SystemSection() {
   const [hoursDraft, setHoursDraft] = useState<string>(String(KEEP_AWAKE_HOURS_DEFAULT));
   const [untilStopped, setUntilStopped] = useState<boolean>(false);
   const [showHelp, setShowHelp] = useState(false);
+
+  // #441: Auto toggle — auto-start/stop caffeinate linked to batch lifecycle
+  const [awakeAuto, setAwakeAuto] = useState(false);
+  const [awakeAutoStatus, setAwakeAutoStatus] = useState<string | null>(null);
+  const awakeAutoRef = useRef(false);
+  const awakeAutoLoadedRef = useRef(false);
+  const prevBatchRef = useRef<{ complete: boolean; hasItems: boolean } | null>(null);
+  // Track manual stop so auto doesn't re-start until next batch transition
+  const manualStopRef = useRef(false);
+  const activeRef = useRef(false);
+  activeRef.current = active;
+  awakeAutoRef.current = awakeAuto;
   // #425 / quadwork#311: per-subsection header-level help popovers.
   // These replace the old `?` that lived inside the Keep Awake
   // presets popup (which disappeared while Awake was active) and
@@ -288,6 +303,8 @@ function SystemSection() {
   };
 
   const stop = () => {
+    // #441: track manual stop so auto doesn't re-start until next batch transition
+    manualStopRef.current = true;
     fetch("/api/caffeinate/stop", { method: "POST" })
       .then(() => {
         setActive(false);
@@ -295,6 +312,117 @@ function SystemSection() {
       })
       .catch(() => {});
   };
+
+  // #441: Auto toggle — load persisted state from config
+  useEffect(() => {
+    if (awakeAutoLoadedRef.current) return;
+    fetch("/api/config")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (!cfg) return;
+        const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+        if (entry?.awake_auto) setAwakeAuto(true);
+        awakeAutoLoadedRef.current = true;
+      })
+      .catch(() => {});
+  }, [projectId]);
+
+  // #441: Toggle + persist awake_auto
+  const toggleAwakeAuto = useCallback(async () => {
+    const next = !awakeAuto;
+    setAwakeAuto(next);
+    if (!next) {
+      setAwakeAutoStatus(null);
+      prevBatchRef.current = null;
+      manualStopRef.current = false;
+    }
+    try {
+      const r = await fetch("/api/config");
+      if (!r.ok) return;
+      const cfg = await r.json();
+      const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+      if (entry) {
+        entry.awake_auto = next;
+        await fetch("/api/config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(cfg),
+        });
+      }
+    } catch { /* non-fatal */ }
+  }, [awakeAuto, projectId]);
+
+  // #441: Auto start helper — uses configured hours or 8h default
+  const autoStart = useCallback(() => {
+    const raw = parseFloat(hoursDraft);
+    const hours = Number.isFinite(raw) ? clampKeepAwakeHours(raw) : AWAKE_AUTO_DEFAULT_HOURS;
+    const seconds = Math.round(hours * 3600);
+    fetch("/api/caffeinate/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ duration: seconds }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.ok) {
+          setActive(true);
+          setRemaining(seconds);
+          manualStopRef.current = false;
+        }
+      })
+      .catch(() => {});
+  }, [hoursDraft]);
+
+  // #441: Auto stop helper
+  const autoStop = useCallback(() => {
+    fetch("/api/caffeinate/stop", { method: "POST" })
+      .then(() => {
+        setActive(false);
+        setRemaining(null);
+      })
+      .catch(() => {});
+  }, []);
+
+  // #441: Batch lifecycle polling (same pattern as ScheduledTriggerWidget)
+  useEffect(() => {
+    if (!awakeAuto) return;
+    const check = async () => {
+      if (!awakeAutoRef.current) return;
+      try {
+        const r = await fetch(`/api/batch-progress?project=${encodeURIComponent(projectId)}`);
+        if (!r.ok) return;
+        const data = await r.json();
+        const hasItems = data.items.length > 0;
+        const prev = prevBatchRef.current;
+        prevBatchRef.current = { complete: data.complete, hasItems };
+
+        // First poll — active batch + not already awake → auto-start
+        if (!prev) {
+          if (hasItems && !data.complete && !activeRef.current) {
+            autoStart();
+            setAwakeAutoStatus("Batch active — auto-started caffeinate.");
+          }
+          return;
+        }
+
+        // Batch just completed → auto-stop
+        if (hasItems && data.complete && !prev.complete && activeRef.current) {
+          autoStop();
+          setAwakeAutoStatus("Batch complete — awake paused.");
+          manualStopRef.current = false;
+        }
+
+        // New batch started (complete→active or empty→active) → auto-start
+        if (hasItems && !data.complete && (prev.complete || !prev.hasItems) && !activeRef.current && !manualStopRef.current) {
+          autoStart();
+          setAwakeAutoStatus("New batch detected — auto-started caffeinate.");
+        }
+      } catch { /* non-fatal */ }
+    };
+    check();
+    const interval = setInterval(check, AWAKE_AUTO_POLL_MS);
+    return () => clearInterval(interval);
+  }, [awakeAuto, projectId, autoStart, autoStop]);
 
   // #425 / quadwork#311: Keep Awake is now a standalone subsection
   // and renders even on non-darwin (the button just hides). The
@@ -323,10 +451,28 @@ function SystemSection() {
               onClick={() => setShowKeepAwakeHelp((s) => !s)}
               className="w-3.5 h-3.5 rounded-full border border-border text-[9px] leading-none text-text-muted hover:text-accent hover:border-accent inline-flex items-center justify-center"
             >?</button>
+            {/* #441: Auto toggle — linked to batch lifecycle */}
+            <button
+              type="button"
+              onClick={toggleAwakeAuto}
+              title={awakeAuto ? "Auto-awake ON: caffeinate starts/stops with batch lifecycle" : "Auto-awake OFF: manual Start/Stop only"}
+              className={`ml-1 px-1.5 py-0.5 text-[10px] border transition-colors ${
+                awakeAuto
+                  ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
+                  : "border-border text-text-muted hover:text-text hover:border-accent"
+              }`}
+            >
+              Auto {awakeAuto ? "●" : "○"}
+            </button>
           </div>
           {showKeepAwakeHelp && (
             <div className="absolute left-0 top-4 z-30 w-64 p-2 text-[10px] leading-snug text-text bg-bg-surface border border-border rounded shadow-lg">
               <b>Keep Mac Awake</b> runs macOS <code>caffeinate</code> to stop the screen, disk, and system idle timers from sleeping your Mac during an overnight run. Make sure the laptop is plugged in — caffeinate blocks sleep but not battery drain.
+            </div>
+          )}
+          {awakeAutoStatus && (
+            <div className="text-[10px] text-accent bg-accent/5 border border-border/50 px-1.5 py-0.5 mt-0.5">
+              {awakeAutoStatus}
             </div>
           )}
           <div className="text-[10px] text-text-muted leading-tight">
@@ -515,7 +661,7 @@ export default function ControlBar({ projectId }: ControlBarProps) {
       <div className="flex flex-col md:flex-row md:items-start gap-2 md:gap-6">
         <ServerSection projectId={projectId} />
         <div className="border-t border-border/40 md:border-t-0 md:w-px md:h-auto md:self-stretch md:bg-border" />
-        <SystemSection />
+        <SystemSection projectId={projectId} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds an **Auto** toggle to the Keep Mac Awake section, mirroring the Scheduled Trigger's Auto toggle from #408
- When Auto is ON, caffeinate auto-starts when a batch becomes active and auto-stops when the batch completes
- Operator turns on both Auto toggles (trigger + awake) once and walks away — both start/stop together with batch lifecycle

## What changed

`src/components/ControlBar.tsx`:
- `SystemSection` now accepts `projectId` prop
- Added `awake_auto` config persistence (read on mount, toggle writes to `/api/config`)
- Batch lifecycle polling every 30s via `/api/batch-progress` — detects active/complete/new-batch transitions
- Auto-start caffeinate with configured hours (default 8h) on batch active
- Auto-stop on batch complete, toggle stays ON waiting for next batch
- Manual Stop sets `manualStopRef` so auto doesn't re-start mid-batch (prevents fighting the toggle)
- Auto button in header matching trigger's `Auto ●/○` style
- Status flash messages for auto-start/stop events

## Test plan

- [ ] Toggle Auto ON → verify `awake_auto: true` persisted in config.json
- [ ] Auto ON + active batch → caffeinate starts within 30s
- [ ] Batch completes (all items merged) → caffeinate stops, toggle stays ON
- [ ] New batch starts → caffeinate restarts
- [ ] Manual Stop while Auto ON → auto doesn't re-start until next batch transition
- [ ] Auto OFF → manual Start/Stop only (no behavior change)
- [ ] Server restart with Auto ON + active batch → caffeinate starts on first poll
- [ ] Non-darwin → Auto toggle hidden (entire Keep Mac Awake section hidden)
- [ ] Build passes with no TS errors

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)