### PR TITLE
[#457] Migrate bridge slugs in AC config on startup and install

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1957,10 +1957,8 @@ server.listen(PORT, "127.0.0.1", () => {
         // Restart AC so it loads the new agent slugs
         setTimeout(async () => {
           try {
-            const r = await fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(p.id)}`, {
+            const r = await fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(p.id)}/restart`, {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ action: "restart" }),
             });
             if (r.ok) console.log(`[bridge-migrate] ${p.id}: restarted AC`);
             else console.warn(`[bridge-migrate] ${p.id}: AC restart returned ${r.status}`);

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,11 @@ const pty = require("node-pty");
 const { spawn } = require("child_process");
 const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH } = require("./config");
 const routes = require("./routes");
+const {
+  patchAgentchattrConfigForDiscordBridge,
+  patchAgentchattrConfigForTelegramBridge,
+  projectAgentchattrConfigPath,
+} = routes;
 const { waitForAgentChattrReady, registerAgent, deregisterAgent, startHeartbeat, stopHeartbeat } = require("./agentchattr-registry");
 const { patchAgentchattrCss } = require("./install-agentchattr");
 const { startQueueWatcher, stopQueueWatcher } = require("./queue-watcher");
@@ -1934,6 +1939,37 @@ server.listen(PORT, "127.0.0.1", () => {
     });
     const { dir: acDir } = resolveProjectChattr(p.id);
     if (acDir) patchAgentchattrCss(acDir);
+  }
+  // #457: migrate bridge slugs in AC configs on startup.
+  // Renames [agents.discord-bridge] → [agents.dc] and
+  // [agents.telegram-bridge] → [agents.tg] so bridges register
+  // under the short slug. Restarts AC for projects whose config changed.
+  for (const p of (startupCfg.projects || [])) {
+    const acPath = projectAgentchattrConfigPath(p.id);
+    if (!fs.existsSync(acPath)) continue;
+    try {
+      const before = fs.readFileSync(acPath, "utf-8");
+      const dc = patchAgentchattrConfigForDiscordBridge(before);
+      const tg = patchAgentchattrConfigForTelegramBridge(dc.text);
+      if (dc.changed || tg.changed) {
+        fs.writeFileSync(acPath, tg.text);
+        console.log(`[bridge-migrate] ${p.id}: migrated AC config slugs`);
+        // Restart AC so it loads the new agent slugs
+        setTimeout(async () => {
+          try {
+            const r = await fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(p.id)}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ action: "restart" }),
+            });
+            if (r.ok) console.log(`[bridge-migrate] ${p.id}: restarted AC`);
+            else console.warn(`[bridge-migrate] ${p.id}: AC restart returned ${r.status}`);
+          } catch (err) {
+            console.warn(`[bridge-migrate] ${p.id}: AC restart failed: ${err.message || err}`);
+          }
+        }, 3000);
+      }
+    } catch {}
   }
   // #416: start the AC health monitor
   startAcHealthMonitor();

--- a/server/routes.js
+++ b/server/routes.js
@@ -2581,10 +2581,8 @@ router.post("/api/telegram", async (req, res) => {
               // #457: restart AC so it loads the new agent slug
               setTimeout(async () => {
                 try {
-                  await fetch(`http://127.0.0.1:${serverPort}/api/agentchattr/${encodeURIComponent(proj.id)}`, {
+                  await fetch(`http://127.0.0.1:${serverPort}/api/agentchattr/${encodeURIComponent(proj.id)}/restart`, {
                     method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ action: "restart" }),
                   });
                 } catch {}
               }, 1000);
@@ -3037,10 +3035,8 @@ router.post("/api/discord", async (req, res) => {
               // #457: restart AC so it loads the new agent slug
               setTimeout(async () => {
                 try {
-                  await fetch(`http://127.0.0.1:${serverPort}/api/agentchattr/${encodeURIComponent(proj.id)}`, {
+                  await fetch(`http://127.0.0.1:${serverPort}/api/agentchattr/${encodeURIComponent(proj.id)}/restart`, {
                     method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ action: "restart" }),
                   });
                 } catch {}
               }, 1000);

--- a/server/routes.js
+++ b/server/routes.js
@@ -2560,16 +2560,14 @@ router.post("/api/telegram", async (req, res) => {
             `pip output tail:\n${pipOutput.split("\n").slice(-10).join("\n")}`,
         });
       }
-      // #383 Bug 3: ensure every known project's AC config declares
-      // the `tg` agent. Without this, AC's registry
-      // rejects the bridge's register call with `400 unknown base`
-      // and the bridge enters an infinite re-register loop.
-      // Idempotent — append-only, skips configs that already have
-      // the section. Does NOT restart AC servers; the operator
-      // must click SERVER → Restart to load the new agent slug.
+      // #383 Bug 3 / #457: ensure every known project's AC config
+      // declares the `tg` agent and migrates old `telegram-bridge`
+      // slug. Restarts AC for projects whose config changed so the
+      // new slug loads immediately.
       const patched = [];
       try {
         const cfgAll = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+        const serverPort = cfgAll.port || 8400;
         for (const proj of cfgAll.projects || []) {
           if (!proj || !proj.id) continue;
           const acPath = projectAgentchattrConfigPath(proj.id);
@@ -2580,6 +2578,16 @@ router.post("/api/telegram", async (req, res) => {
             if (changed) {
               fs.writeFileSync(acPath, text);
               patched.push(proj.id);
+              // #457: restart AC so it loads the new agent slug
+              setTimeout(async () => {
+                try {
+                  await fetch(`http://127.0.0.1:${serverPort}/api/agentchattr/${encodeURIComponent(proj.id)}`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ action: "restart" }),
+                  });
+                } catch {}
+              }, 1000);
             }
           } catch {}
         }
@@ -3010,10 +3018,12 @@ router.post("/api/discord", async (req, res) => {
             `pip output tail:\n${pipOutput.split("\n").slice(-10).join("\n")}`,
         });
       }
-      // Patch all project AC configs with [agents.dc]
+      // #457: Patch all project AC configs with [agents.dc] and
+      // migrate old `discord-bridge` slug. Restart AC for changed projects.
       const patched = [];
       try {
         const cfgAll = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+        const serverPort = cfgAll.port || 8400;
         for (const proj of cfgAll.projects || []) {
           if (!proj || !proj.id) continue;
           const acPath = projectAgentchattrConfigPath(proj.id);
@@ -3024,6 +3034,16 @@ router.post("/api/discord", async (req, res) => {
             if (changed) {
               fs.writeFileSync(acPath, text);
               patched.push(proj.id);
+              // #457: restart AC so it loads the new agent slug
+              setTimeout(async () => {
+                try {
+                  await fetch(`http://127.0.0.1:${serverPort}/api/agentchattr/${encodeURIComponent(proj.id)}`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ action: "restart" }),
+                  });
+                } catch {}
+              }, 1000);
             }
           } catch {}
         }
@@ -3253,6 +3273,7 @@ module.exports.checkDiscordBridgePythonDeps = checkDiscordBridgePythonDeps;
 module.exports.buildDiscordBridgeToml = buildDiscordBridgeToml;
 module.exports.patchAgentchattrConfigForDiscordBridge = patchAgentchattrConfigForDiscordBridge;
 module.exports.buildDiscordBridgeSpawnEnv = buildDiscordBridgeSpawnEnv;
+module.exports.projectAgentchattrConfigPath = projectAgentchattrConfigPath;
 // #236: expose sendViaWebSocket so the chat-ws-send regression test
 // can verify the ack/body/error paths against a fake AC ws server.
 module.exports.sendViaWebSocket = sendViaWebSocket;


### PR DESCRIPTION
## Summary
- Adds startup-time migration that renames `[agents.discord-bridge]` → `[agents.dc]` and `[agents.telegram-bridge]` → `[agents.tg]` in all project AC configs
- Both bridge install handlers now restart AC after patching configs so the new slugs load immediately
- Exports `projectAgentchattrConfigPath` from routes.js for use in startup migration

Fixes #457

## Test plan
- [ ] Verify all 3 project AC configs have `[agents.dc]` and `[agents.tg]` after server startup
- [ ] Verify Discord bridge registers as `dc` in AC chat
- [ ] Verify Telegram bridge registers as `tg` in AC chat
- [ ] Verify migration is idempotent (running twice doesn't duplicate sections)
- [ ] Verify AC auto-restarts after config migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)