### PR TITLE
[#462] Fix auto-trigger first-poll gap on already-complete batch

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -405,6 +405,11 @@ function SystemSection({ projectId }: { projectId: string }) {
             autoStart();
             setAwakeAutoStatus("Batch active — auto-started caffeinate.");
           }
+          // #462: First poll — batch already complete but caffeinate still running → auto-stop
+          if (hasItems && data.complete && activeRef.current) {
+            autoStop();
+            setAwakeAutoStatus("Batch complete — awake paused.");
+          }
           return;
         }
 

--- a/src/components/ScheduledTriggerWidget.tsx
+++ b/src/components/ScheduledTriggerWidget.tsx
@@ -346,6 +346,13 @@ export default function ScheduledTriggerWidget({ projectId }: ScheduledTriggerWi
           });
           await load();
         }
+        // #462: First poll — batch already complete but trigger still running → auto-stop
+        if (hasItems && data.complete && triggerRef.current?.enabled) {
+          await fetch(`/api/triggers/${encodeURIComponent(projectId)}/stop`, { method: "POST" });
+          setAutoTriggered(false);
+          setAutoStatus("Batch complete — trigger paused. Waiting for next batch.");
+          await load();
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- Fix first-poll gap in `ScheduledTriggerWidget.tsx` `checkBatchLifecycle()`: auto-stop trigger when batch is already complete on page load/refresh
- Fix same gap in `ControlBar.tsx` Keep Mac Awake auto-toggle: auto-stop caffeinate when batch is already complete on remount
- Both fixes are in the `!prev` (first-poll) block — adds check for "already complete + still running → auto-stop"

Fixes #462

## Test plan
- [ ] Batch completes while page is open → trigger auto-stops (existing, regression check)
- [ ] Batch completes while page is NOT open, user returns → trigger auto-stops within 30s
- [ ] Page refresh during completed batch with trigger running → trigger auto-stops within 30s
- [ ] Server restart during completed batch with auto ON → trigger does NOT auto-start
- [ ] Same behavior verified for Keep Mac Awake auto-toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)