### PR TITLE
[#467] Fix Send button vertical centering in chat input bar

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -539,7 +539,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
           <button
             onClick={send}
             disabled={sending || !input.trim()}
-            className="shrink-0 px-2 py-1 text-[11px] font-mono text-accent border border-accent/40 rounded hover:bg-accent/10 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            className="shrink-0 px-2 py-2 text-[11px] font-mono text-accent border border-accent/40 rounded hover:bg-accent/10 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
             title="Send (Enter)"
           >
             {sending ? "…" : "Send"}


### PR DESCRIPTION
## Summary
- Match Send button vertical padding (`py-1` → `py-2`) to the textarea's `py-2` so the button aligns properly at single-line height
- Container keeps `items-end` so the button stays bottom-aligned when textarea expands to multi-line via Shift+Enter

Fixes #467

## Test plan
- [ ] Send button is vertically centered at single-line input height
- [ ] Send button stays bottom-aligned when textarea expands to multi-line
- [ ] Button click area and disabled state unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)