### PR TITLE
[#466] Add image attachment support in chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "express": "^5.2.1",
+        "multer": "^2.1.1",
         "next": "16.2.1",
         "node-pty": "^1.2.0-beta.12",
         "react": "19.2.4",
@@ -2288,6 +2289,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2629,6 +2636,23 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2825,6 +2849,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -6155,6 +6194,68 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -6851,6 +6952,20 @@
         "react": ">=18"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7039,6 +7154,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -7397,6 +7532,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -7877,6 +8029,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -8112,6 +8270,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "express": "^5.2.1",
+    "multer": "^2.1.1",
     "next": "16.2.1",
     "node-pty": "^1.2.0-beta.12",
     "react": "19.2.4",

--- a/server/queue-watcher.js
+++ b/server/queue-watcher.js
@@ -41,7 +41,7 @@ const POLL_INTERVAL_MS = 1000;
  * `dev`, `head`, `re1`, `re2`. The helper does not
  * validate — upstream already controls who may register.
  */
-function buildInjectionPrompt(agentName, { channel, jobId, customPrompt } = {}) {
+function buildInjectionPrompt(agentName, { channel, jobId, customPrompt, attachments } = {}) {
   if (customPrompt && typeof customPrompt === "string" && customPrompt.trim()) {
     // Operator-supplied prompts already control the identity
     // wording; leave them alone.
@@ -55,12 +55,20 @@ function buildInjectionPrompt(agentName, { channel, jobId, customPrompt } = {}) 
     );
   }
   const ch = channel || "general";
-  return (
+  let prompt =
     `You are @${agentName} in this AgentChattr instance. ` +
     `mcp read #${ch} with sender: "${agentName}" — ` +
     `look for @${agentName} mentions (NOT @claude). ` +
-    `You were mentioned, take appropriate action.`
-  );
+    `You were mentioned, take appropriate action.`;
+  // #466: include attachment paths so image-capable agents can read them
+  if (Array.isArray(attachments) && attachments.length > 0) {
+    for (const att of attachments) {
+      if (att && att.path) {
+        prompt += ` Image attached: ${att.path} — use Read tool to view it.`;
+      }
+    }
+  }
+  return prompt;
 }
 
 /**

--- a/server/queue-watcher.js
+++ b/server/queue-watcher.js
@@ -47,19 +47,20 @@ function buildInjectionPrompt(agentName, { channel, jobId, customPrompt, attachm
     // wording; leave them alone.
     return customPrompt.trim();
   }
+  let prompt;
   if (jobId) {
-    return (
+    prompt =
       `You are @${agentName} in this AgentChattr instance. ` +
       `mcp read job_id=${jobId} with sender: "${agentName}" — ` +
-      `you (@${agentName}) were mentioned in a job thread, take appropriate action.`
-    );
+      `you (@${agentName}) were mentioned in a job thread, take appropriate action.`;
+  } else {
+    const ch = channel || "general";
+    prompt =
+      `You are @${agentName} in this AgentChattr instance. ` +
+      `mcp read #${ch} with sender: "${agentName}" — ` +
+      `look for @${agentName} mentions (NOT @claude). ` +
+      `You were mentioned, take appropriate action.`;
   }
-  const ch = channel || "general";
-  let prompt =
-    `You are @${agentName} in this AgentChattr instance. ` +
-    `mcp read #${ch} with sender: "${agentName}" — ` +
-    `look for @${agentName} mentions (NOT @claude). ` +
-    `You were mentioned, take appropriate action.`;
   // #466: include attachment paths so image-capable agents can read them
   if (Array.isArray(attachments) && attachments.length > 0) {
     for (const att of attachments) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -1000,7 +1000,7 @@ const ALLOWED_MIME = new Set(["image/png", "image/jpeg", "image/gif", "image/web
 const uploadStorage = multer.diskStorage({
   destination: (req, _file, cb) => {
     const projectId = req.query.project || "";
-    if (!projectId) return cb(new Error("Missing project"));
+    if (!projectId || /[/\\]/.test(projectId)) return cb(new Error("Invalid project"));
     const dir = path.join(CONFIG_DIR, projectId, "uploads");
     fs.mkdirSync(dir, { recursive: true });
     cb(null, dir);

--- a/server/routes.js
+++ b/server/routes.js
@@ -8,6 +8,8 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
+const multer = require("multer");
+
 const router = express.Router();
 
 const CONFIG_DIR = path.join(os.homedir(), ".quadwork");
@@ -989,6 +991,53 @@ router.post("/api/chat", async (req, res) => {
     console.warn(`[chat] send failed for project ${projectId}: ${err && err.message}`);
     return res.status(502).json({ error: "AgentChattr unreachable", detail: err && err.message });
   }
+});
+
+// ─── Image upload (#466) ──────────────────────────────────────────────────
+
+const UPLOAD_MAX_BYTES = 10 * 1024 * 1024; // 10MB
+const ALLOWED_MIME = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const uploadStorage = multer.diskStorage({
+  destination: (req, _file, cb) => {
+    const projectId = req.query.project || "";
+    if (!projectId) return cb(new Error("Missing project"));
+    const dir = path.join(CONFIG_DIR, projectId, "uploads");
+    fs.mkdirSync(dir, { recursive: true });
+    cb(null, dir);
+  },
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname) || ".png";
+    cb(null, `upload-${Date.now()}${ext}`);
+  },
+});
+const upload = multer({
+  storage: uploadStorage,
+  limits: { fileSize: UPLOAD_MAX_BYTES },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME.has(file.mimetype)) cb(null, true);
+    else cb(new Error(`Unsupported type: ${file.mimetype}`));
+  },
+});
+
+router.post("/api/upload", upload.single("file"), (req, res) => {
+  if (!req.file) return res.status(400).json({ error: "No file uploaded" });
+  return res.json({
+    ok: true,
+    path: req.file.path,
+    name: req.file.filename,
+  });
+});
+
+// Serve uploaded images for thumbnail rendering
+router.get("/api/uploads/:project/:filename", (req, res) => {
+  const { project, filename } = req.params;
+  // Sanitize to prevent directory traversal
+  if (/[/\\]/.test(project) || /[/\\]/.test(filename)) {
+    return res.status(400).json({ error: "Invalid path" });
+  }
+  const filePath = path.join(CONFIG_DIR, project, "uploads", filename);
+  if (!fs.existsSync(filePath)) return res.status(404).json({ error: "Not found" });
+  res.sendFile(filePath);
 });
 
 // ─── Projects (dashboard aggregation) ──────────────────────────────────────

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -241,7 +241,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const uploadFile = async (file: File) => {
-    if (uploading || !projectId) return;
+    if (!projectId) return;
     setUploading(true);
     try {
       const form = new FormData();
@@ -261,6 +261,12 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
       setSendError((err as Error).message);
     } finally {
       setUploading(false);
+    }
+  };
+
+  const uploadFiles = (files: File[]) => {
+    for (const file of files) {
+      if (file.type.startsWith("image/")) uploadFile(file);
     }
   };
 
@@ -589,24 +595,25 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
             onPaste={(e) => {
               const items = e.clipboardData?.items;
               if (!items) return;
+              const imageFiles: File[] = [];
               for (const item of Array.from(items)) {
                 if (item.type.startsWith("image/")) {
-                  e.preventDefault();
                   const file = item.getAsFile();
-                  if (file) uploadFile(file);
-                  return;
+                  if (file) imageFiles.push(file);
                 }
+              }
+              if (imageFiles.length > 0) {
+                e.preventDefault();
+                uploadFiles(imageFiles);
               }
             }}
             onDrop={(e) => {
               const files = e.dataTransfer?.files;
               if (!files) return;
-              for (const file of Array.from(files)) {
-                if (file.type.startsWith("image/")) {
-                  e.preventDefault();
-                  uploadFile(file);
-                  return;
-                }
+              const imageFiles = Array.from(files).filter((f) => f.type.startsWith("image/"));
+              if (imageFiles.length > 0) {
+                e.preventDefault();
+                uploadFiles(imageFiles);
               }
             }}
             onDragOver={(e) => {
@@ -621,10 +628,11 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
             ref={fileInputRef}
             type="file"
             accept="image/png,image/jpeg,image/gif,image/webp"
+            multiple
             className="hidden"
             onChange={(e) => {
-              const file = e.target.files?.[0];
-              if (file) uploadFile(file);
+              const files = e.target.files;
+              if (files && files.length > 0) uploadFiles(Array.from(files));
               e.target.value = "";
             }}
           />

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -3,6 +3,11 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import ProjectChatEmptyState from "./ProjectChatEmptyState";
 
+interface Attachment {
+  path: string;
+  name: string;
+}
+
 interface Message {
   id: number;
   sender: string;
@@ -10,6 +15,7 @@ interface Message {
   time: string;
   channel: string;
   type?: string;
+  attachments?: Attachment[];
 }
 
 const SENDER_COLORS: Record<string, string> = {
@@ -229,6 +235,35 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
 
+  // #466: image attachments — pending uploads for the current message
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const uploadFile = async (file: File) => {
+    if (uploading || !projectId) return;
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const r = await fetch(`/api/upload?project=${encodeURIComponent(projectId)}`, {
+        method: "POST",
+        body: form,
+      });
+      if (!r.ok) {
+        const data = await r.json().catch(() => ({ error: `${r.status}` }));
+        setSendError(data.error || `Upload failed: ${r.status}`);
+        return;
+      }
+      const data = await r.json();
+      setAttachments((prev) => [...prev, { path: data.path, name: data.name }]);
+    } catch (err) {
+      setSendError((err as Error).message);
+    } finally {
+      setUploading(false);
+    }
+  };
+
   // #344: auto-grow the chat textarea to fit its content up to
   // ~6 lines, then scroll internally. Reset to 'auto' first so
   // shrinking after a deletion works — reading scrollHeight on a
@@ -246,7 +281,7 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
   // Send message
   const send = () => {
     const raw = input.trim();
-    if (!raw || sending) return;
+    if ((!raw && attachments.length === 0) || sending) return;
     // #228: if the operator didn't direct the message to a known
     // agent, prepend `@head ` so the message has somewhere to go.
     // #426: only check the START of the message — a mention buried
@@ -269,12 +304,14 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
         text,
         channel,
         sender: "user",
+        ...(attachments.length > 0 ? { attachments } : {}),
         ...(replyTo ? { reply_to: replyTo.id } : {}),
       }),
     })
       .then((r) => {
         if (!r.ok) throw new Error(`Send failed: ${r.status}`);
         setInput("");
+        setAttachments([]);
         setReplyTo(null);
         setTimeout(fetchMessages, 300);
       })
@@ -377,6 +414,24 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
             </span>
             <span className="text-text break-words min-w-0 whitespace-pre-wrap flex-1">
               {renderMessageWithMentions(msg.text)}
+              {msg.attachments && msg.attachments.length > 0 && (
+                <span className="flex gap-2 mt-1">
+                  {msg.attachments.map((att) => (
+                    <a
+                      key={att.name}
+                      href={`/api/uploads/${encodeURIComponent(projectId || "")}/${encodeURIComponent(att.name)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <img
+                        src={`/api/uploads/${encodeURIComponent(projectId || "")}/${encodeURIComponent(att.name)}`}
+                        alt={att.name}
+                        className="max-w-[200px] max-h-[150px] object-cover border border-border rounded hover:border-accent transition-colors"
+                      />
+                    </a>
+                  ))}
+                </span>
+              )}
             </span>
             {/* #397 / quadwork#262: reply affordance — small grey,
                 hover-revealed so it doesn't visually compete with the
@@ -531,20 +586,93 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
                 if (replyTo) setReplyTo(null);
               }
             }}
+            onPaste={(e) => {
+              const items = e.clipboardData?.items;
+              if (!items) return;
+              for (const item of Array.from(items)) {
+                if (item.type.startsWith("image/")) {
+                  e.preventDefault();
+                  const file = item.getAsFile();
+                  if (file) uploadFile(file);
+                  return;
+                }
+              }
+            }}
+            onDrop={(e) => {
+              const files = e.dataTransfer?.files;
+              if (!files) return;
+              for (const file of Array.from(files)) {
+                if (file.type.startsWith("image/")) {
+                  e.preventDefault();
+                  uploadFile(file);
+                  return;
+                }
+              }
+            }}
+            onDragOver={(e) => {
+              if (e.dataTransfer?.types?.includes("Files")) e.preventDefault();
+            }}
             placeholder={`Message #${channel}...`}
             disabled={sending}
             className="flex-1 bg-transparent px-2 py-2 text-[12px] font-mono text-text placeholder:text-text-muted outline-none focus:ring-1 focus:ring-accent disabled:opacity-50 resize-none overflow-y-auto leading-snug"
             style={{ maxHeight: 120 }}
           />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) uploadFile(file);
+              e.target.value = "";
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="shrink-0 px-1.5 py-2 text-[13px] text-text-muted hover:text-accent transition-colors disabled:opacity-30"
+            title="Attach image"
+          >
+            📎
+          </button>
           <button
             onClick={send}
-            disabled={sending || !input.trim()}
+            disabled={sending || (!input.trim() && attachments.length === 0)}
             className="shrink-0 px-2 py-2 text-[11px] font-mono text-accent border border-accent/40 rounded hover:bg-accent/10 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
             title="Send (Enter)"
           >
             {sending ? "…" : "Send"}
           </button>
         </div>
+        {/* #466: attachment thumbnail previews */}
+        {(attachments.length > 0 || uploading) && (
+          <div className="flex gap-2 px-2 py-1 flex-wrap">
+            {attachments.map((att, i) => (
+              <div key={att.name} className="relative group">
+                <img
+                  src={`/api/uploads/${encodeURIComponent(projectId || "")}/${encodeURIComponent(att.name)}`}
+                  alt={att.name}
+                  className="h-16 max-w-[200px] object-cover border border-border rounded"
+                />
+                <button
+                  type="button"
+                  onClick={() => setAttachments((prev) => prev.filter((_, j) => j !== i))}
+                  className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-bg border border-border rounded-full text-[10px] text-text-muted hover:text-error opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+                  title="Remove"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {uploading && (
+              <div className="h-16 w-16 border border-border rounded flex items-center justify-center">
+                <span className="text-[10px] text-text-muted animate-pulse">...</span>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `POST /api/upload` endpoint (multer, 10MB limit, PNG/JPEG/GIF/WebP) storing files to `~/.quadwork/<project>/uploads/`
- Add `GET /api/uploads/:project/:filename` for serving uploaded images
- Chat panel supports clipboard paste (Cmd+V), drag/drop, and 📎 file picker for image uploads
- Thumbnail previews in compose area with remove buttons
- Thumbnail rendering in message history (clickable to open full size)
- Attachments included in chat send payload and passed through to AC
- Queue watcher includes attachment file paths in agent injection prompt

Fixes #466

## Test plan
- [ ] Cmd+V paste of a screenshot → thumbnail preview → Send includes attachment
- [ ] Drag and drop an image file → same flow
- [ ] 📎 button → file picker → same flow
- [ ] Thumbnail renders in chat message history for messages with attachments
- [ ] Files stored at `~/.quadwork/<project>/uploads/`
- [ ] File size limit enforced (10MB)
- [ ] Multiple images per message supported
- [ ] Agent receives file path and can Read the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)