### PR TITLE
[#470] Fix stale bridge scripts after upgrade

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1050,15 +1050,18 @@ async function setupAddons(rl, setup, configTomlPath) {
       const cloneResult = run(`git clone https://github.com/realproject7/agentchattr-telegram.git "${telegramDir}" 2>&1`);
       cloneSpinner.stop(cloneResult !== null);
       if (!cloneResult) { warn("You can set it up manually later"); }
-      else {
-        // #444: pin to a known commit, same pattern as AGENTCHATTR_PIN
-        const pinResult = run(`git -C "${telegramDir}" checkout -B pinned ${AGENTCHATTR_TELEGRAM_PIN} 2>&1`, { timeout: 30000 });
-        if (pinResult === null) {
-          try { console.warn(`[quadwork] WARNING: could not check out agentchattr-telegram pin ${AGENTCHATTR_TELEGRAM_PIN} at ${telegramDir}; falling back to default branch.`); } catch {}
-        }
-      }
     } else {
       ok("agentchattr-telegram already present");
+    }
+    // #444 / #470: pin to a known commit — on fresh clone AND on
+    // upgrade (existing clone may be on an older pin with stale
+    // bridge_sender defaults).
+    if (fs.existsSync(telegramDir)) {
+      run(`git -C "${telegramDir}" fetch origin 2>&1`, { timeout: 30000 });
+      const pinResult = run(`git -C "${telegramDir}" checkout -B pinned ${AGENTCHATTR_TELEGRAM_PIN} 2>&1`, { timeout: 30000 });
+      if (pinResult === null) {
+        try { console.warn(`[quadwork] WARNING: could not check out agentchattr-telegram pin ${AGENTCHATTR_TELEGRAM_PIN} at ${telegramDir}; falling back to default branch.`); } catch {}
+      }
     }
 
     if (fs.existsSync(telegramDir)) {

--- a/server/index.js
+++ b/server/index.js
@@ -1980,6 +1980,23 @@ server.listen(PORT, "127.0.0.1", () => {
       }
     } catch {}
   }
+  // #470: patch stale bridge_sender defaults in on-disk bridge scripts.
+  // The AC config migration (#457) renames the agent sections, but the
+  // bridge scripts themselves may still have old defaults if the operator
+  // upgraded QuadWork without re-installing the bridges.
+  const BRIDGE_SLUG_PATCHES = [
+    { file: path.join(os.homedir(), ".quadwork", "agentchattr-telegram", "telegram_bridge.py"), old: '"telegram-bridge"', replacement: '"tg"' },
+    { file: path.join(os.homedir(), ".quadwork", "agentchattr-discord", "discord_bridge.py"), old: '"discord-bridge"', replacement: '"dc"' },
+  ];
+  for (const { file, old, replacement } of BRIDGE_SLUG_PATCHES) {
+    try {
+      if (!fs.existsSync(file)) continue;
+      const content = fs.readFileSync(file, "utf-8");
+      if (!content.includes(old)) continue;
+      fs.writeFileSync(file, content.replaceAll(old, replacement));
+      console.log(`[bridge-migrate] patched stale bridge_sender in ${path.basename(file)}`);
+    } catch {}
+  }
   // #416: start the AC health monitor
   startAcHealthMonitor();
 });

--- a/server/routes.js
+++ b/server/routes.js
@@ -2574,12 +2574,15 @@ router.post("/api/telegram", async (req, res) => {
       try {
         if (!fs.existsSync(BRIDGE_DIR)) {
           execFileSync("gh", ["repo", "clone", "realproject7/agentchattr-telegram", BRIDGE_DIR], { encoding: "utf-8", timeout: 30000 });
-          // #444: pin to a known commit after clone
-          try {
-            execFileSync("git", ["-C", BRIDGE_DIR, "checkout", "-B", "pinned", AGENTCHATTR_TELEGRAM_PIN], { encoding: "utf-8", timeout: 30000 });
-          } catch {
-            console.warn(`[telegram] WARNING: could not check out agentchattr-telegram pin ${AGENTCHATTR_TELEGRAM_PIN}; falling back to default branch.`);
-          }
+        }
+        // #444 / #470: pin to a known commit — on fresh clone AND on
+        // upgrade (existing clone may be on an older pin with stale
+        // bridge_sender defaults).
+        try {
+          execFileSync("git", ["-C", BRIDGE_DIR, "fetch", "origin"], { encoding: "utf-8", timeout: 30000 });
+          execFileSync("git", ["-C", BRIDGE_DIR, "checkout", "-B", "pinned", AGENTCHATTR_TELEGRAM_PIN], { encoding: "utf-8", timeout: 30000 });
+        } catch {
+          console.warn(`[telegram] WARNING: could not check out agentchattr-telegram pin ${AGENTCHATTR_TELEGRAM_PIN}; falling back to default branch.`);
         }
         // #380: create the dedicated venv if missing. `python3 -m venv`
         // builds a fresh isolated environment that bypasses PEP 668


### PR DESCRIPTION
## Summary
- **Telegram Install Bridge**: now fetches + re-pins on every install, not just fresh clones — existing installs pick up the renamed `bridge_sender` default from the updated pin
- **Startup migration fallback**: server startup scans on-disk bridge scripts (`telegram_bridge.py`, `discord_bridge.py`) for stale `"telegram-bridge"` / `"discord-bridge"` defaults and patches them in-place to `"tg"` / `"dc"`
- Discord Install Bridge already re-copies the script on upgrade (no change needed)

Fixes #470

## Test plan
- [ ] Fresh install: bridges register as `tg` / `dc` from the start
- [ ] Upgrade from pre-1.8.0 with stale on-disk scripts: startup patches defaults automatically
- [ ] Click "Install Bridge" on telegram widget: fetches + re-pins to correct commit
- [ ] All existing tests pass (`node --test server/*.test.*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)