### PR TITLE
[#471] Add inter-project Bulletin Board

### DIFF
--- a/server/bulletin.js
+++ b/server/bulletin.js
@@ -75,6 +75,10 @@ function createPost({ from_project, from_agent, to_project, content, status }) {
   const month = currentMonth();
   const filePath = monthFilePath(month);
 
+  // Escape bare "---" lines in content so they don't corrupt the
+  // post delimiter when the file is parsed back.
+  const safeContent = content.replace(/^---$/gm, "\\-\\-\\-");
+
   const block = [
     "---",
     `## [${postId}] ${from_project} → ${to_project} | ${now}`,
@@ -82,7 +86,7 @@ function createPost({ from_project, from_agent, to_project, content, status }) {
     `To: ${to_project}`,
     `Status: ${status || "open"}`,
     "",
-    content,
+    safeContent,
     "",
     "---",
     "",
@@ -170,7 +174,8 @@ function parsePost(block) {
   const repliesStart = block.indexOf("\n> **Reply**");
   const closingDash = block.lastIndexOf("\n---");
   const contentEnd = repliesStart !== -1 ? repliesStart : (closingDash !== -1 ? closingDash : block.length);
-  const content = block.slice(statusEnd + 1, contentEnd).trim();
+  // Unescape "---" lines that were escaped on write.
+  const content = block.slice(statusEnd + 1, contentEnd).trim().replace(/^\\-\\-\\-$/gm, "---");
 
   // Extract replies
   const replies = [];
@@ -208,7 +213,7 @@ function readPosts({ month, project, status } = {}) {
   const text = fs.readFileSync(filePath, "utf-8");
   // Split on "---" delimiters — each post is between two delimiters
   const blocks = text.split(/^---$/m).filter((b) => b.trim());
-  const posts = blocks.map(parsePost).filter(Boolean);
+  const posts = blocks.map(parsePost).filter(Boolean).reverse();
 
   let filtered = posts;
   if (project) {
@@ -233,6 +238,8 @@ function readLatestPosts(limit = 10) {
     const text = fs.readFileSync(f, "utf-8");
     const blocks = text.split(/^---$/m).filter((b) => b.trim());
     const posts = blocks.map(parsePost).filter(Boolean);
+    // Reverse so newest posts within this month come first
+    posts.reverse();
     all.push(...posts);
     if (all.length >= limit) break;
   }

--- a/server/bulletin.js
+++ b/server/bulletin.js
@@ -1,0 +1,250 @@
+/**
+ * Bulletin Board — inter-project communication (#471).
+ *
+ * Stores posts as markdown in ~/.quadwork/bulletin/YYYY-MM.md with
+ * a JSON counter file (index.json) for sequential post IDs per project.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const BULLETIN_DIR = path.join(os.homedir(), ".quadwork", "bulletin");
+const INDEX_PATH = path.join(BULLETIN_DIR, "index.json");
+
+/** Ensure the bulletin directory exists. */
+function ensureDir() {
+  if (!fs.existsSync(BULLETIN_DIR)) fs.mkdirSync(BULLETIN_DIR, { recursive: true });
+}
+
+/** Two-letter uppercase prefix from project ID (e.g. "quadwork" → "QW"). */
+function projectPrefix(projectId) {
+  const clean = projectId.replace(/[^a-zA-Z0-9]/g, "");
+  if (clean.length === 0) return "XX";
+  if (clean.length === 1) return clean.toUpperCase().padEnd(2, "X");
+  return clean.slice(0, 2).toUpperCase();
+}
+
+/** Current month key: "YYYY-MM". */
+function currentMonth() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Read the counter index. Returns { [projectId]: number }. */
+function readIndex() {
+  ensureDir();
+  if (!fs.existsSync(INDEX_PATH)) return {};
+  try { return JSON.parse(fs.readFileSync(INDEX_PATH, "utf-8")); } catch { return {}; }
+}
+
+/** Increment counter for a project, return the new number. */
+function nextCounter(projectId) {
+  const idx = readIndex();
+  const n = (idx[projectId] || 0) + 1;
+  idx[projectId] = n;
+  fs.writeFileSync(INDEX_PATH, JSON.stringify(idx, null, 2));
+  return n;
+}
+
+/** Generate a post ID like "QW-0042". */
+function generatePostId(projectId) {
+  const n = nextCounter(projectId);
+  return `${projectPrefix(projectId)}-${String(n).padStart(4, "0")}`;
+}
+
+/** Path to a monthly bulletin file. */
+function monthFilePath(month) {
+  return path.join(BULLETIN_DIR, `${month}.md`);
+}
+
+/** Format a date as "YYYY-MM-DD HH:MM". */
+function formatDate(d) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Append a new post to the current month's bulletin file.
+ * Returns the generated post ID.
+ */
+function createPost({ from_project, from_agent, to_project, content, status }) {
+  ensureDir();
+  const postId = generatePostId(from_project);
+  const now = formatDate(new Date());
+  const month = currentMonth();
+  const filePath = monthFilePath(month);
+
+  const block = [
+    "---",
+    `## [${postId}] ${from_project} → ${to_project} | ${now}`,
+    `From: ${from_agent}@${from_project}`,
+    `To: ${to_project}`,
+    `Status: ${status || "open"}`,
+    "",
+    content,
+    "",
+    "---",
+    "",
+  ].join("\n");
+
+  fs.appendFileSync(filePath, block);
+  return { post_id: postId, month };
+}
+
+/**
+ * Append a reply to an existing post. Searches all monthly files
+ * starting from the most recent.
+ */
+function addReply(postId, { from_project, from_agent, content }) {
+  ensureDir();
+  const files = bulletinFiles();
+  for (const f of files) {
+    const text = fs.readFileSync(f, "utf-8");
+    const marker = `## [${postId}]`;
+    const idx = text.indexOf(marker);
+    if (idx === -1) continue;
+
+    // Find the closing "---" after this post
+    const closingIdx = text.indexOf("\n---", idx + marker.length);
+    if (closingIdx === -1) continue;
+
+    const now = formatDate(new Date());
+    const replyBlock = `\n> **Reply** ${from_agent}@${from_project} | ${now}\n> ${content.replace(/\n/g, "\n> ")}\n`;
+
+    const updated = text.slice(0, closingIdx) + replyBlock + text.slice(closingIdx);
+    fs.writeFileSync(f, updated);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Update the status of a post (open → closed or vice versa).
+ */
+function updateStatus(postId, newStatus) {
+  ensureDir();
+  const files = bulletinFiles();
+  for (const f of files) {
+    const text = fs.readFileSync(f, "utf-8");
+    const marker = `## [${postId}]`;
+    if (!text.includes(marker)) continue;
+
+    const updated = text.replace(
+      new RegExp(`(## \\[${postId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\][\\s\\S]*?Status: )\\w+`),
+      `$1${newStatus}`
+    );
+    if (updated !== text) {
+      fs.writeFileSync(f, updated);
+      return true;
+    }
+  }
+  return false;
+}
+
+/** List all bulletin files sorted newest first. */
+function bulletinFiles() {
+  ensureDir();
+  return fs.readdirSync(BULLETIN_DIR)
+    .filter((f) => /^\d{4}-\d{2}\.md$/.test(f))
+    .sort()
+    .reverse()
+    .map((f) => path.join(BULLETIN_DIR, f));
+}
+
+/**
+ * Parse a single post block into a structured object.
+ * Input: the text between two "---" delimiters (inclusive of header).
+ */
+function parsePost(block) {
+  const headerMatch = block.match(/## \[([A-Z]{2}-\d{4})\] (\S+) → (\S+) \| (.+)/);
+  if (!headerMatch) return null;
+  const [, id, from_project, to_project, date] = headerMatch;
+
+  const fromMatch = block.match(/From: (.+)/);
+  const statusMatch = block.match(/Status: (\w+)/);
+  const from_agent = fromMatch ? fromMatch[1] : "";
+
+  // Extract content: everything between the Status line and replies/closing
+  const statusEnd = block.indexOf("\n", block.indexOf("Status:"));
+  const repliesStart = block.indexOf("\n> **Reply**");
+  const closingDash = block.lastIndexOf("\n---");
+  const contentEnd = repliesStart !== -1 ? repliesStart : (closingDash !== -1 ? closingDash : block.length);
+  const content = block.slice(statusEnd + 1, contentEnd).trim();
+
+  // Extract replies
+  const replies = [];
+  const replyRegex = /> \*\*Reply\*\* (.+?) \| (.+)\n((?:> .*\n?)*)/g;
+  let m;
+  while ((m = replyRegex.exec(block)) !== null) {
+    replies.push({
+      from: m[1],
+      date: m[2],
+      content: m[3].replace(/^> /gm, "").trim(),
+    });
+  }
+
+  return {
+    id,
+    from_project,
+    to_project,
+    from_agent,
+    date,
+    status: statusMatch ? statusMatch[1] : "open",
+    content,
+    replies,
+  };
+}
+
+/**
+ * Read and parse posts from a specific month.
+ * Optionally filter by project (from or to) and status.
+ */
+function readPosts({ month, project, status } = {}) {
+  const m = month || currentMonth();
+  const filePath = monthFilePath(m);
+  if (!fs.existsSync(filePath)) return { posts: [], month: m };
+
+  const text = fs.readFileSync(filePath, "utf-8");
+  // Split on "---" delimiters — each post is between two delimiters
+  const blocks = text.split(/^---$/m).filter((b) => b.trim());
+  const posts = blocks.map(parsePost).filter(Boolean);
+
+  let filtered = posts;
+  if (project) {
+    filtered = filtered.filter(
+      (p) => p.from_project === project || p.to_project === project
+    );
+  }
+  if (status && status !== "all") {
+    filtered = filtered.filter((p) => p.status === status);
+  }
+
+  return { posts: filtered, month: m };
+}
+
+/**
+ * Read latest N posts across all months (for the home page panel).
+ */
+function readLatestPosts(limit = 10) {
+  const files = bulletinFiles();
+  const all = [];
+  for (const f of files) {
+    const text = fs.readFileSync(f, "utf-8");
+    const blocks = text.split(/^---$/m).filter((b) => b.trim());
+    const posts = blocks.map(parsePost).filter(Boolean);
+    all.push(...posts);
+    if (all.length >= limit) break;
+  }
+  return all.slice(0, limit);
+}
+
+module.exports = {
+  createPost,
+  addReply,
+  updateStatus,
+  readPosts,
+  readLatestPosts,
+  projectPrefix,
+  BULLETIN_DIR,
+};

--- a/server/routes.js
+++ b/server/routes.js
@@ -3296,6 +3296,75 @@ router.put("/api/project/:projectId/agent-models/:agentId", (req, res) => {
   }
 });
 
+// ─── Bulletin Board (#471) ──────────────────────────────────────────────────
+const bulletin = require("./bulletin");
+
+router.get("/api/bulletin", (_req, res) => {
+  try {
+    const { month, project, status } = _req.query;
+    const result = bulletin.readPosts({ month, project, status });
+    return res.json(result);
+  } catch (err) {
+    return res.json({ posts: [], error: err.message });
+  }
+});
+
+router.get("/api/bulletin/latest", (_req, res) => {
+  try {
+    const limit = parseInt(_req.query.limit) || 10;
+    const posts = bulletin.readLatestPosts(limit);
+    return res.json({ posts });
+  } catch (err) {
+    return res.json({ posts: [], error: err.message });
+  }
+});
+
+router.post("/api/bulletin", (req, res) => {
+  const { from_project, from_agent, to_project, content, status } = req.body || {};
+  if (!from_project || !from_agent || !to_project || !content) {
+    return res.status(400).json({ ok: false, error: "Missing required fields: from_project, from_agent, to_project, content" });
+  }
+  if (content.length > 10000) {
+    return res.status(413).json({ ok: false, error: "Content too long (max 10000 chars)" });
+  }
+  try {
+    const result = bulletin.createPost({ from_project, from_agent, to_project, content, status });
+    return res.json({ ok: true, ...result });
+  } catch (err) {
+    return res.json({ ok: false, error: err.message });
+  }
+});
+
+router.post("/api/bulletin/:postId/reply", (req, res) => {
+  const { postId } = req.params;
+  const { from_project, from_agent, content } = req.body || {};
+  if (!from_project || !from_agent || !content) {
+    return res.status(400).json({ ok: false, error: "Missing required fields: from_project, from_agent, content" });
+  }
+  try {
+    const found = bulletin.addReply(postId, { from_project, from_agent, content });
+    if (!found) return res.status(404).json({ ok: false, error: `Post ${postId} not found` });
+    return res.json({ ok: true });
+  } catch (err) {
+    return res.json({ ok: false, error: err.message });
+  }
+});
+
+router.put("/api/bulletin/:postId/status", (req, res) => {
+  const { postId } = req.params;
+  const { status } = req.body || {};
+  if (!status || !["open", "closed"].includes(status)) {
+    return res.status(400).json({ ok: false, error: "status must be 'open' or 'closed'" });
+  }
+  try {
+    const found = bulletin.updateStatus(postId, status);
+    if (!found) return res.status(404).json({ ok: false, error: `Post ${postId} not found` });
+    return res.json({ ok: true });
+  } catch (err) {
+    return res.json({ ok: false, error: err.message });
+  }
+});
+
 module.exports = router;
 // #341: export parseActiveBatch for unit tests. No production callers
 // outside this file; the export is strictly for the node:assert

--- a/src/components/BulletinBoard.tsx
+++ b/src/components/BulletinBoard.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface BulletinReply {
+  from: string;
+  date: string;
+  content: string;
+}
+
+interface BulletinPost {
+  id: string;
+  from_project: string;
+  to_project: string;
+  from_agent: string;
+  date: string;
+  status: string;
+  content: string;
+  replies: BulletinReply[];
+}
+
+interface BulletinBoardProps {
+  projectId?: string;
+  onClose: () => void;
+}
+
+export default function BulletinBoard({ projectId, onClose }: BulletinBoardProps) {
+  const [posts, setPosts] = useState<BulletinPost[]>([]);
+  const [tab, setTab] = useState<"inbox" | "sent" | "all">("all");
+  const [month, setMonth] = useState(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  });
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showNewPost, setShowNewPost] = useState(false);
+  const [projects, setProjects] = useState<string[]>([]);
+  const [newTo, setNewTo] = useState("");
+  const [newContent, setNewContent] = useState("");
+  const [error, setError] = useState("");
+
+  const fetchPosts = useCallback(() => {
+    const params = new URLSearchParams({ month });
+    if (projectId && tab === "inbox") params.set("project", projectId);
+    else if (projectId && tab === "sent") params.set("project", projectId);
+    fetch(`/api/bulletin?${params}`)
+      .then((r) => r.json())
+      .then((data) => {
+        let filtered = data.posts || [];
+        if (projectId && tab === "inbox") {
+          filtered = filtered.filter((p: BulletinPost) => p.to_project === projectId);
+        } else if (projectId && tab === "sent") {
+          filtered = filtered.filter((p: BulletinPost) => p.from_project === projectId);
+        }
+        setPosts(filtered);
+      })
+      .catch(() => setPosts([]));
+  }, [month, projectId, tab]);
+
+  useEffect(() => { fetchPosts(); }, [fetchPosts]);
+
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.projects) {
+          setProjects(data.projects.map((p: { id: string }) => p.id));
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleCreate = () => {
+    if (!projectId || !newTo || !newContent.trim()) return;
+    setError("");
+    fetch("/api/bulletin", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from_project: projectId,
+        from_agent: "operator",
+        to_project: newTo,
+        content: newContent.trim(),
+      }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.ok) {
+          setNewTo("");
+          setNewContent("");
+          setShowNewPost(false);
+          fetchPosts();
+        } else {
+          setError(data.error || "Failed to create post");
+        }
+      })
+      .catch(() => setError("Network error"));
+  };
+
+  const handleStatusToggle = (postId: string, currentStatus: string) => {
+    const newStatus = currentStatus === "open" ? "closed" : "open";
+    fetch(`/api/bulletin/${postId}/status`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: newStatus }),
+    })
+      .then((r) => r.json())
+      .then((data) => { if (data.ok) fetchPosts(); })
+      .catch(() => {});
+  };
+
+  // Month navigation
+  const adjustMonth = (delta: number) => {
+    const [y, m] = month.split("-").map(Number);
+    const d = new Date(y, m - 1 + delta);
+    setMonth(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div
+        className="bg-bg-surface border border-border w-full max-w-2xl max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2 border-b border-border">
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-semibold text-text uppercase tracking-wider">Bulletin Board</span>
+            {projectId && (
+              <div className="flex gap-1">
+                {(["inbox", "sent", "all"] as const).map((t) => (
+                  <button
+                    key={t}
+                    onClick={() => setTab(t)}
+                    className={`text-[10px] px-2 py-0.5 ${tab === t ? "bg-accent/20 text-accent" : "text-text-muted hover:text-text"}`}
+                  >
+                    {t.charAt(0).toUpperCase() + t.slice(1)}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {projectId && (
+              <button
+                onClick={() => setShowNewPost(!showNewPost)}
+                className="text-[10px] px-2 py-0.5 text-accent hover:text-text border border-accent/30 hover:border-accent"
+              >
+                {showNewPost ? "Cancel" : "+ New Post"}
+              </button>
+            )}
+            <button onClick={onClose} className="text-text-muted hover:text-text text-xs px-1">x</button>
+          </div>
+        </div>
+
+        {/* Month navigation */}
+        <div className="flex items-center justify-center gap-3 px-4 py-1.5 border-b border-border/50 text-[10px] text-text-muted">
+          <button onClick={() => adjustMonth(-1)} className="hover:text-text">{"<"}</button>
+          <span className="text-text tabular-nums">{month}</span>
+          <button onClick={() => adjustMonth(1)} className="hover:text-text">{">"}</button>
+        </div>
+
+        {/* New post form */}
+        {showNewPost && projectId && (
+          <div className="px-4 py-2 border-b border-border bg-bg-surface">
+            <div className="flex gap-2 mb-2">
+              <span className="text-[10px] text-text-muted shrink-0 pt-0.5">To:</span>
+              <select
+                value={newTo}
+                onChange={(e) => setNewTo(e.target.value)}
+                className="text-[11px] bg-bg border border-border text-text px-1 py-0.5 flex-1"
+              >
+                <option value="">Select project...</option>
+                {projects.filter((p) => p !== projectId).map((p) => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+            </div>
+            <textarea
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+              placeholder="Message content..."
+              className="w-full text-[11px] bg-bg border border-border text-text px-2 py-1 resize-none h-20"
+            />
+            {error && <div className="text-[10px] text-error mt-1">{error}</div>}
+            <div className="flex justify-end mt-1">
+              <button
+                onClick={handleCreate}
+                disabled={!newTo || !newContent.trim()}
+                className="text-[10px] px-3 py-0.5 bg-accent text-bg font-semibold hover:bg-accent/80 disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                Post
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Posts list */}
+        <div className="flex-1 overflow-y-auto">
+          {posts.length === 0 && (
+            <div className="px-4 py-6 text-[11px] text-text-muted text-center">
+              No posts for {month}
+            </div>
+          )}
+          {posts.map((post) => (
+            <div key={post.id} className="border-b border-border/50 last:border-b-0">
+              <button
+                onClick={() => setExpandedId(expandedId === post.id ? null : post.id)}
+                className="w-full text-left px-4 py-2 hover:bg-bg/50 flex items-center gap-3"
+              >
+                <span className="text-[10px] text-accent font-mono shrink-0">{post.id}</span>
+                <span className="text-[10px] text-text-muted shrink-0">
+                  {post.from_project} {">"} {post.to_project}
+                </span>
+                <span className="text-[10px] text-text-muted shrink-0 tabular-nums">
+                  {post.date?.slice(0, 10)}
+                </span>
+                <span
+                  className={`text-[9px] px-1 py-px shrink-0 ${
+                    post.status === "open"
+                      ? "bg-accent/15 text-accent"
+                      : "bg-text-muted/15 text-text-muted"
+                  }`}
+                >
+                  {post.status}
+                </span>
+                <span className="text-[10px] text-text truncate min-w-0">
+                  {post.content.slice(0, 80)}
+                </span>
+              </button>
+
+              {expandedId === post.id && (
+                <div className="px-4 pb-3 pt-1">
+                  <div className="text-[10px] text-text-muted mb-1">
+                    From: {post.from_agent} | {post.date}
+                  </div>
+                  <div className="text-[11px] text-text whitespace-pre-wrap mb-2 bg-bg p-2 border border-border/50">
+                    {post.content}
+                  </div>
+
+                  {post.replies.length > 0 && (
+                    <div className="ml-3 border-l border-border/50 pl-3 mb-2">
+                      {post.replies.map((r, i) => (
+                        <div key={i} className="mb-2">
+                          <div className="text-[9px] text-text-muted">{r.from} | {r.date}</div>
+                          <div className="text-[10px] text-text whitespace-pre-wrap">{r.content}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  <button
+                    onClick={() => handleStatusToggle(post.id, post.status)}
+                    className="text-[9px] text-text-muted hover:text-text border border-border px-2 py-0.5"
+                  >
+                    Mark as {post.status === "open" ? "closed" : "open"}
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/BulletinButton.tsx
+++ b/src/components/BulletinButton.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import InfoTooltip from "./InfoTooltip";
+import BulletinBoard from "./BulletinBoard";
+
+const REFRESH_MS = 30000;
+
+export default function BulletinButton({ projectId }: { projectId: string }) {
+  const [inboxCount, setInboxCount] = useState(0);
+  const [open, setOpen] = useState(false);
+
+  const fetchCount = useCallback(() => {
+    const month = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    })();
+    fetch(`/api/bulletin?month=${month}&project=${encodeURIComponent(projectId)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const posts = data.posts || [];
+        const inbox = posts.filter(
+          (p: { to_project: string; status: string }) =>
+            p.to_project === projectId && p.status === "open"
+        );
+        setInboxCount(inbox.length);
+      })
+      .catch(() => {});
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchCount();
+    const iv = setInterval(fetchCount, REFRESH_MS);
+    return () => clearInterval(iv);
+  }, [fetchCount]);
+
+  return (
+    <>
+      <div className="border border-border bg-bg-surface">
+        <div className="flex items-center justify-between px-3 h-7 border-b border-border">
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] text-text-muted uppercase tracking-wider">
+              Bulletin Board
+            </span>
+            <InfoTooltip>
+              <b>Bulletin Board</b> — a shared message board for cross-project
+              coordination. Agents from any project can post updates that agents
+              in other projects can read. Use post IDs (e.g. QW-0042) to
+              reference specific messages when instructing agents.
+            </InfoTooltip>
+          </div>
+          {inboxCount > 0 && (
+            <span className="text-[9px] bg-accent/20 text-accent px-1.5 py-px">
+              {inboxCount} open
+            </span>
+          )}
+        </div>
+        <div className="px-3 py-2">
+          <button
+            onClick={() => setOpen(true)}
+            className="text-[10px] text-accent hover:text-text transition-colors"
+          >
+            View Bulletin {"\u2192"}
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <BulletinBoard
+          projectId={projectId}
+          onClose={() => { setOpen(false); fetchCount(); }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import HomeEmptyState from "./HomeEmptyState";
+import InfoTooltip from "./InfoTooltip";
+import BulletinBoard from "./BulletinBoard";
 
 interface Project {
   id: string;
@@ -140,39 +142,119 @@ export default function HomeDashboard() {
         </Link>
       </div>
 
-      {/* Activity feed */}
-      <div className="mb-6">
-        <h2 className="text-xs text-text-muted uppercase tracking-wider mb-3">Recent Activity</h2>
-        <div className="border border-border bg-bg-surface">
-          {activity.length === 0 && (
-            <div className="px-3 py-3 text-[11px] text-text-muted">No recent activity</div>
-          )}
-          {activity.map((item, i) => (
-            <div
-              key={`${item.time}-${i}`}
-              className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
-            >
-              <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
-                {item.time?.slice(0, 5) || ""}
-              </span>
-              <span className="text-accent shrink-0 font-semibold w-12">
-                {item.projectName}
-              </span>
-              <span className="text-[#ffcc00] shrink-0 font-semibold w-12">
-                {/* #420 / quadwork#307: widen column + mirror the
-                    RE1/RE2 short labels PR #272 (#263) already uses
-                    in the chat sender column. w-6 was 24px and
-                    overflowed re1/re2 into the adjacent
-                    message text column. */}
-                {item.actor}
-              </span>
-              <span className="text-text truncate min-w-0">
-                {item.text}
-              </span>
-            </div>
-          ))}
+      {/* #471: Two-column grid — Recent Activity | Bulletin Board */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        {/* Activity feed */}
+        <div>
+          <h2 className="text-xs text-text-muted uppercase tracking-wider mb-3">Recent Activity</h2>
+          <div className="border border-border bg-bg-surface">
+            {activity.length === 0 && (
+              <div className="px-3 py-3 text-[11px] text-text-muted">No recent activity</div>
+            )}
+            {activity.map((item, i) => (
+              <div
+                key={`${item.time}-${i}`}
+                className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
+              >
+                <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
+                  {item.time?.slice(0, 5) || ""}
+                </span>
+                <span className="text-accent shrink-0 font-semibold w-12">
+                  {item.projectName}
+                </span>
+                <span className="text-[#ffcc00] shrink-0 font-semibold w-12">
+                  {item.actor}
+                </span>
+                <span className="text-text truncate min-w-0">
+                  {item.text}
+                </span>
+              </div>
+            ))}
+          </div>
         </div>
+
+        {/* Bulletin Board panel */}
+        <HomeBulletinPanel />
       </div>
+    </div>
+  );
+}
+
+interface BulletinPostSummary {
+  id: string;
+  from_project: string;
+  to_project: string;
+  date: string;
+  status: string;
+  content: string;
+}
+
+function HomeBulletinPanel() {
+  const [posts, setPosts] = useState<BulletinPostSummary[]>([]);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/bulletin/latest?limit=10")
+      .then((r) => r.json())
+      .then((data) => setPosts(data.posts || []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <h2 className="text-xs text-text-muted uppercase tracking-wider">Bulletin Board</h2>
+        <InfoTooltip>
+          <b>Bulletin Board</b> — cross-project messages posted by agents.
+          When an agent in one project needs to communicate with agents in
+          another project, they post here. Click a post to see details, then
+          instruct the relevant project&apos;s agents to act on it.
+        </InfoTooltip>
+      </div>
+      <div className="border border-border bg-bg-surface">
+        {posts.length === 0 && (
+          <div className="px-3 py-3 text-[11px] text-text-muted">No bulletin posts yet</div>
+        )}
+        {posts.map((post) => (
+          <div
+            key={post.id}
+            className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
+          >
+            <span className="text-accent shrink-0 font-mono text-[10px] w-16">
+              {post.id}
+            </span>
+            <span className="text-text-muted shrink-0 w-20 text-[10px]">
+              {post.from_project} {">"} {post.to_project}
+            </span>
+            <span className="text-text-muted shrink-0 w-16 tabular-nums text-[10px]">
+              {post.date?.slice(0, 10)}
+            </span>
+            <span
+              className={`text-[9px] px-1 py-px shrink-0 ${
+                post.status === "open"
+                  ? "bg-accent/15 text-accent"
+                  : "bg-text-muted/15 text-text-muted"
+              }`}
+            >
+              {post.status}
+            </span>
+            <span className="text-text truncate min-w-0 text-[10px]">
+              {post.content.slice(0, 60)}
+            </span>
+          </div>
+        ))}
+        {posts.length > 0 && (
+          <div className="px-3 py-1.5">
+            <button
+              onClick={() => setShowModal(true)}
+              className="text-[10px] text-accent hover:text-text transition-colors"
+            >
+              View All {"\u2192"}
+            </button>
+          </div>
+        )}
+      </div>
+      {showModal && <BulletinBoard onClose={() => setShowModal(false)} />}
     </div>
   );
 }

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -8,6 +8,7 @@ import DiscordBridgeWidget from "./DiscordBridgeWidget";
 import LoopGuardWidget from "./LoopGuardWidget";
 import ProjectHistoryWidget from "./ProjectHistoryWidget";
 import AgentModelsWidget from "./AgentModelsWidget";
+import BulletinButton from "./BulletinButton";
 
 /**
  * Bottom-right quadrant of the project dashboard (#208).
@@ -54,6 +55,7 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
         {/* Right column: Telegram Bridge → Loop Guard → Project
             History. Scrolls independently of the left column. */}
         <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto flex flex-col gap-2">
+          <BulletinButton projectId={projectId} />
           <AgentModelsWidget projectId={projectId} />
           <TelegramBridgeWidget projectId={projectId} />
           <DiscordBridgeWidget projectId={projectId} />

--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -89,3 +89,11 @@ Head owns this file — do not edit it. Read it when you need context on the bat
 - **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
 - **Do NOT send ANY message to @head between assignment and merge request** — no acks, no status updates.
 - **After merge confirmation from Head**: do NOT reply. The loop is COMPLETE — silence is required.
+
+## Bulletin Board
+
+A shared message board at `~/.quadwork/bulletin/` enables cross-project coordination.
+- Monthly files: `~/.quadwork/bulletin/YYYY-MM.md`
+- Post format: `[PREFIX-NUMBER] project > target | date`
+- To read a post: use Read tool on the current month's bulletin file and search for the post ID
+- Only Head should write posts. Dev should read posts when instructed by the operator.

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -101,3 +101,12 @@ When the operator asks you in chat to start a task or batch:
 - **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
 - **Do NOT reply to acknowledgments** — if Dev says "on it" or similar, do NOT respond. Wait silently for the PR.
 - **After merge**: send ONE message: "@dev PR #<number> merged. Issue #<number> closed." — no further replies needed.
+
+## Bulletin Board
+
+A shared message board at `~/.quadwork/bulletin/` enables cross-project coordination.
+- Monthly files: `~/.quadwork/bulletin/YYYY-MM.md`
+- Post format: `[PREFIX-NUMBER] project > target | date`
+- To read a post: use Read tool on the current month's bulletin file and search for the post ID
+- To write a post: the operator will instruct you via chat. Append to the current month's file following the format.
+- Head may write posts to communicate cross-project updates. Dev and Reviewers should only read posts when instructed.

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -105,3 +105,11 @@ Run this once at the start of each session.
 - **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
 - Only send unsolicited messages when delivering a completed review verdict. But ALWAYS reply when the operator addresses you directly — even if the message is not a review request. The operator may be asking about your status, giving instructions, or testing connectivity.
 - **After merge confirmation from Head**: do NOT reply. The loop is complete — no acknowledgment needed.
+
+## Bulletin Board
+
+A shared message board at `~/.quadwork/bulletin/` enables cross-project coordination.
+- Monthly files: `~/.quadwork/bulletin/YYYY-MM.md`
+- Post format: `[PREFIX-NUMBER] project > target | date`
+- To read a post: use Read tool on the current month's bulletin file and search for the post ID
+- Only Head should write posts. Reviewers should read posts when instructed by the operator.

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -105,3 +105,11 @@ Run this once at the start of each session.
 - **No acknowledgment messages between agents** — don't send "on it", "noted", "standing by" to other agents. This rule does NOT apply to operator messages — always reply to the operator.
 - Only send unsolicited messages when delivering a completed review verdict. But ALWAYS reply when the operator addresses you directly — even if the message is not a review request. The operator may be asking about your status, giving instructions, or testing connectivity.
 - **After merge confirmation from Head**: do NOT reply. The loop is complete — no acknowledgment needed.
+
+## Bulletin Board
+
+A shared message board at `~/.quadwork/bulletin/` enables cross-project coordination.
+- Monthly files: `~/.quadwork/bulletin/YYYY-MM.md`
+- Post format: `[PREFIX-NUMBER] project > target | date`
+- To read a post: use Read tool on the current month's bulletin file and search for the post ID
+- Only Head should write posts. Reviewers should read posts when instructed by the operator.


### PR DESCRIPTION
## Summary
- **Server**: `server/bulletin.js` provides file-based bulletin storage at `~/.quadwork/bulletin/` with monthly markdown files, sequential post IDs (e.g. `QW-0042`), reply threading, and open/closed status tracking. API endpoints added to `server/routes.js`: `GET/POST /api/bulletin`, `POST /api/bulletin/:id/reply`, `PUT /api/bulletin/:id/status`
- **Project page**: `BulletinButton` widget in Operator Features right column shows open-post count and opens the `BulletinBoard` modal with Inbox/Sent/All tabs, New Post form, month navigation, and status toggle
- **Home page**: Recent Activity section split into two-column grid; right column shows latest bulletin posts across all projects with status badges
- **Seed files**: All four agent seeds updated with Bulletin Board instructions (Head writes, others read-only)

Fixes #471

## Test plan
- [ ] Create a bulletin post from project page modal — verify entry appended to `~/.quadwork/bulletin/YYYY-MM.md`
- [ ] Post IDs auto-increment per project from `index.json`
- [ ] Monthly file auto-created on first post of a new month
- [ ] Reply to a post — verify reply appears under original post
- [ ] Toggle status open/closed — verify update persists
- [ ] Home page shows latest posts in the right column grid
- [ ] Inbox tab filters posts addressed to the current project
- [ ] `@head read bulletin post QW-0001` — agent can read the file via Read tool
- [ ] All existing server tests pass
- [ ] Frontend builds cleanly with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)