### PR TITLE
[#472] Setup wizard: clickable completed steps for back-navigation

### DIFF
--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -227,27 +227,18 @@ export default function SetupWizard() {
   const [furthestStep, setFurthestStep] = useState(0);
 
   const goNext = useCallback(() => {
-    // If we're behind the furthest completed step (editing a past
-    // step), skip forward to the next incomplete step instead of
-    // advancing one-by-one through already-done steps.
-    const nextIncomplete = (() => {
-      for (let i = currentStep + 1; i < INITIAL_STEPS.length; i++) {
-        // steps state isn't readable inside this callback's closure
-        // at the time of the setSteps call, so use furthestStep as
-        // the proxy: anything <= furthestStep was already completed.
-        if (i > furthestStep) return i;
-      }
-      // All subsequent steps are done — go one past current
-      return currentStep + 1;
-    })();
+    // #472: if we're behind the furthest step (editing a past step),
+    // skip forward to where the operator left off instead of walking
+    // through already-completed intermediate steps one by one.
+    const target = currentStep < furthestStep ? furthestStep : currentStep + 1;
 
     setSteps((prev) => prev.map((s, i) => {
       if (i === currentStep) return { ...s, status: "done" as StepStatus };
-      if (i === nextIncomplete) return { ...s, status: "active" as StepStatus };
+      if (i === target) return { ...s, status: "active" as StepStatus };
       return s;
     }));
-    setCurrentStep(nextIncomplete);
-    setFurthestStep((f) => Math.max(f, nextIncomplete));
+    setCurrentStep(target);
+    setFurthestStep((f) => Math.max(f, target));
   }, [currentStep, furthestStep]);
 
   // #472: navigate back to a completed step for editing. The

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -231,6 +231,18 @@ export default function SetupWizard() {
     setCurrentStep((c) => c + 1);
   }, [currentStep]);
 
+  // #472: navigate back to a completed step for editing. The
+  // previously-active step becomes "done" (values preserved in
+  // state) and the target step becomes "active" again.
+  const goToStep = useCallback((targetIdx: number) => {
+    setSteps((prev) => prev.map((s, i) => {
+      if (i === targetIdx) return { ...s, status: "active" as StepStatus };
+      if (i === currentStep) return { ...s, status: "done" as StepStatus };
+      return s;
+    }));
+    setCurrentStep(targetIdx);
+  }, [currentStep]);
+
   const apiCall = async (step: string, body: Record<string, unknown>) => {
     setLoading(true);
     try {
@@ -474,29 +486,39 @@ export default function SetupWizard() {
         <div className="flex-1 flex gap-6 p-6 overflow-y-auto">
           {/* Step sidebar */}
           <div className="w-44 shrink-0">
-            {steps.map((s, i) => (
-              <div key={s.id} className="flex items-start gap-2 py-2">
-                <span className={`w-5 h-5 flex items-center justify-center text-[10px] border shrink-0 mt-0.5 ${
-                  s.status === "done" ? "border-accent text-accent" :
-                  s.status === "error" ? "border-error text-error" :
-                  s.status === "active" ? "border-accent text-accent bg-accent/10" :
-                  s.status === "skipped" ? "border-border text-text-muted line-through" :
-                  "border-border text-text-muted"
-                }`}>
-                  {s.status === "done" ? "\u2713" : s.status === "error" ? "!" : i + 1}
-                </span>
-                <div>
-                  <span className={`text-[11px] block leading-tight ${
-                    s.status === "active" ? "text-text font-semibold" :
-                    s.status === "done" ? "text-accent" :
-                    "text-text-muted"
+            {steps.map((s, i) => {
+              const isClickable = s.status === "done";
+              return (
+                <div
+                  key={s.id}
+                  className={`flex items-start gap-2 py-2 ${isClickable ? "cursor-pointer group" : ""}`}
+                  onClick={isClickable ? () => goToStep(i) : undefined}
+                  role={isClickable ? "button" : undefined}
+                  tabIndex={isClickable ? 0 : undefined}
+                  onKeyDown={isClickable ? (e) => { if (e.key === "Enter" || e.key === " ") goToStep(i); } : undefined}
+                >
+                  <span className={`w-5 h-5 flex items-center justify-center text-[10px] border shrink-0 mt-0.5 ${
+                    s.status === "done" ? "border-accent text-accent" :
+                    s.status === "error" ? "border-error text-error" :
+                    s.status === "active" ? "border-accent text-accent bg-accent/10" :
+                    s.status === "skipped" ? "border-border text-text-muted line-through" :
+                    "border-border text-text-muted"
                   }`}>
-                    {s.label}
+                    {s.status === "done" ? "\u2713" : s.status === "error" ? "!" : i + 1}
                   </span>
-                  <span className="text-[10px] text-text-muted block">{s.subtitle}</span>
+                  <div>
+                    <span className={`text-[11px] block leading-tight ${
+                      s.status === "active" ? "text-text font-semibold" :
+                      s.status === "done" ? "text-accent group-hover:text-text" :
+                      "text-text-muted"
+                    }`}>
+                      {s.label}
+                    </span>
+                    <span className="text-[10px] text-text-muted block">{s.subtitle}</span>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           {/* Step content */}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -222,14 +222,33 @@ export default function SetupWizard() {
     setSteps((prev) => prev.map((s, i) => (i === idx ? { ...s, ...updates } : s)));
   }, []);
 
+  // #472: track the furthest step reached so back-navigation can
+  // skip already-completed steps when proceeding forward again.
+  const [furthestStep, setFurthestStep] = useState(0);
+
   const goNext = useCallback(() => {
+    // If we're behind the furthest completed step (editing a past
+    // step), skip forward to the next incomplete step instead of
+    // advancing one-by-one through already-done steps.
+    const nextIncomplete = (() => {
+      for (let i = currentStep + 1; i < INITIAL_STEPS.length; i++) {
+        // steps state isn't readable inside this callback's closure
+        // at the time of the setSteps call, so use furthestStep as
+        // the proxy: anything <= furthestStep was already completed.
+        if (i > furthestStep) return i;
+      }
+      // All subsequent steps are done — go one past current
+      return currentStep + 1;
+    })();
+
     setSteps((prev) => prev.map((s, i) => {
       if (i === currentStep) return { ...s, status: "done" as StepStatus };
-      if (i === currentStep + 1) return { ...s, status: "active" as StepStatus };
+      if (i === nextIncomplete) return { ...s, status: "active" as StepStatus };
       return s;
     }));
-    setCurrentStep((c) => c + 1);
-  }, [currentStep]);
+    setCurrentStep(nextIncomplete);
+    setFurthestStep((f) => Math.max(f, nextIncomplete));
+  }, [currentStep, furthestStep]);
 
   // #472: navigate back to a completed step for editing. The
   // previously-active step becomes "done" (values preserved in


### PR DESCRIPTION
## Summary
- Completed steps (green checkmark) in the setup wizard sidebar are now clickable, allowing operators to go back and edit previous steps
- Form state is fully preserved — going back doesn't reset values in later steps
- Added `cursor-pointer` + `hover:text-accent` visual feedback, plus keyboard support (Enter/Space)
- Current and future steps remain non-clickable

Fixes #472

## Test plan
- [ ] Click a completed step (green checkmark) — navigates back to that step's form
- [ ] Form is pre-populated with previously entered values
- [ ] Edit a value and click Next — proceeds normally
- [ ] Future step values are preserved (not cleared on back-navigation)
- [ ] Current and future steps remain non-clickable
- [ ] Keyboard navigation works (Tab to focus, Enter/Space to activate)
- [ ] No regression to forward-only wizard flow
- [ ] Frontend builds cleanly, all server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)