### PR TITLE
[#480] Fix wizard back-navigation marking in-progress steps as done

### DIFF
--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -247,7 +247,13 @@ export default function SetupWizard() {
   const goToStep = useCallback((targetIdx: number) => {
     setSteps((prev) => prev.map((s, i) => {
       if (i === targetIdx) return { ...s, status: "active" as StepStatus };
-      if (i === currentStep) return { ...s, status: "done" as StepStatus };
+      // #480: Only keep "done" if the step was already completed.
+      // In-progress/active steps revert to "pending" on back-navigation.
+      if (i === currentStep) {
+        return s.status === "done"
+          ? s
+          : { ...s, status: "pending" as StepStatus };
+      }
       return s;
     }));
     setCurrentStep(targetIdx);


### PR DESCRIPTION
## Summary

- **Bug**: `goToStep()` unconditionally marked the departing step as `"done"` when navigating backward, making in-progress/unvalidated steps appear completed
- **Fix**: Preserve the step's existing status — already-done steps stay done, active/pending steps revert to `"pending"` instead of being falsely marked complete
- No test framework is configured in this project; verified via `next build` (passes cleanly)

Fixes #480

## Test plan

- [ ] Start the setup wizard, advance to step 2 (GitHub Repo) without completing it
- [ ] Click back to step 1 (Project Name)
- [ ] Verify step 2 does NOT show a green checkmark — it should revert to pending
- [ ] Complete step 2 properly, advance to step 3, then click back to step 2
- [ ] Verify step 2 retains its completed checkmark (it was genuinely done)
- [ ] Verify forward resume-navigation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)