### PR TITLE
[#477] Force xterm repaint after scrollback replay

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -181,6 +181,11 @@ export default function TerminalPanel({
     let reattachAttempts = 0;
     const MAX_REATTACH = 5;
 
+    // #477: track whether we've done a post-replay fit. After the
+    // scrollback replay data is written, xterm needs a fit() to
+    // repaint — otherwise idle terminals appear blank until resize.
+    let needsPostReplayFit = false;
+
     const connect = async () => {
       const base = await resolveBase();
       if (cancelled) return;
@@ -191,6 +196,7 @@ export default function TerminalPanel({
 
       ws.onopen = () => {
         reattachAttempts = 0;
+        needsPostReplayFit = true;
         ws.send(
           JSON.stringify({
             type: "resize",
@@ -206,6 +212,13 @@ export default function TerminalPanel({
 
       ws.onmessage = (e) => {
         term.write(e.data);
+        // #477: after the first data write (scrollback replay), force
+        // a fit() so xterm repaints. Without this, idle terminals stay
+        // blank until a browser resize event triggers repaint.
+        if (needsPostReplayFit) {
+          needsPostReplayFit = false;
+          requestAnimationFrame(() => fit());
+        }
         const cb = onActivityRef.current;
         if (cb) cb();
       };


### PR DESCRIPTION
## Summary

- **Bug**: Idle agent terminals appeared blank after navigating away and back — scrollback data was in xterm's buffer but never rendered until a browser resize event triggered `fit()`
- **Fix**: After the first WS data write (scrollback replay), trigger `requestAnimationFrame(() => fit())` to force xterm to recalculate viewport layout and repaint. A `needsPostReplayFit` flag ensures this only fires once per connection.

Fixes #477

## Test plan

- [ ] Navigate to a project with idle agents, switch to another page, then navigate back
- [ ] Verify idle terminals show their content immediately (no blank screen)
- [ ] Verify active terminals still render correctly during ongoing output
- [ ] Verify browser resize still works as before
- [ ] Verify reconnect/reattach after agent restart still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)