### PR TITLE
[#487] Extend chat token resync to recover from 5xx/502

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -146,6 +146,20 @@ router.get("/api/chat", async (req, res) => {
     if (!r.ok) return res.status(r.status).json({ error: `AgentChattr returned ${r.status}` });
     res.json(await r.json());
   } catch (err) {
+    // #487: fetch threw (ECONNREFUSED, DNS failure, etc.) — AC is
+    // unreachable. Resync the token and retry once; AC may have
+    // restarted with a new session token by the time the retry fires.
+    if (projectId) {
+      try { await syncChattrToken(projectId); } catch {}
+      const { token: refreshed } = getChattrConfig(projectId);
+      if (refreshed && refreshed !== token) {
+        try {
+          const retry = await fetch(buildUrl(refreshed), { headers: chatAuthHeaders(refreshed) });
+          if (!retry.ok) return res.status(retry.status).json({ error: `AgentChattr returned ${retry.status}` });
+          return res.json(await retry.json());
+        } catch {}
+      }
+    }
     res.status(502).json({ error: "AgentChattr unreachable", detail: err.message });
   }
 });

--- a/server/routes.js
+++ b/server/routes.js
@@ -132,7 +132,9 @@ router.get("/api/chat", async (req, res) => {
     const r = await fetch(buildUrl(token), { headers: chatAuthHeaders(token) });
     // #448: on 401/403, re-sync the session token from AC and retry
     // once. The stored token may be stale after an AC restart.
-    if ((r.status === 401 || r.status === 403) && projectId) {
+    // #487: also retry on 5xx — a temporary AC outage (e.g. 502) may
+    // precede a restart that regenerates the session token.
+    if ((r.status === 401 || r.status === 403 || r.status >= 500) && projectId) {
       try { await syncChattrToken(projectId); } catch {}
       const { token: refreshed } = getChattrConfig(projectId);
       if (refreshed && refreshed !== token) {
@@ -972,8 +974,16 @@ router.post("/api/chat", async (req, res) => {
     // the token from AgentChattr's HTML and retry once before giving
     // up. This is the actual fix for the "401 after restart" report
     // in #230 (the cache was stuck on an old token).
-    if (err && err.code === "EAGENTCHATTR_401") {
-      console.warn(`[chat] ws auth failed for project ${projectId}, re-syncing session token and retrying...`);
+    //
+    // #487: also attempt resync on generic ws errors (connection
+    // refused, ECONNRESET, timeout, etc.) — a 502/5xx from a
+    // temporary AC outage may resolve after a token refresh once AC
+    // is back.
+    const isAuthError = err && err.code === "EAGENTCHATTR_401";
+    const isConnError = !isAuthError && err;
+    if ((isAuthError || isConnError) && projectId) {
+      const tag = isAuthError ? "ws auth failed" : "ws connection error";
+      console.warn(`[chat] ${tag} for project ${projectId}, re-syncing session token and retrying...`);
       try { await syncChattrToken(projectId); }
       catch (syncErr) { console.warn(`[chat] syncChattrToken failed: ${syncErr.message}`); }
       const { token: refreshed } = getChattrConfig(projectId);
@@ -983,10 +993,13 @@ router.post("/api/chat", async (req, res) => {
           return res.json({ ok: true, resynced: true, message: retry.message });
         } catch (retryErr) {
           console.warn(`[chat] retry after token resync failed: ${retryErr.message}`);
-          return res.status(401).json({ error: "AgentChattr auth failed (token resync did not help)", detail: retryErr.message });
+          const status = isAuthError ? 401 : 502;
+          return res.status(status).json({ error: "AgentChattr send failed (token resync did not help)", detail: retryErr.message });
         }
       }
-      return res.status(401).json({ error: "AgentChattr auth failed", detail: err.message });
+      if (isAuthError) {
+        return res.status(401).json({ error: "AgentChattr auth failed", detail: err.message });
+      }
     }
     console.warn(`[chat] send failed for project ${projectId}: ${err && err.message}`);
     return res.status(502).json({ error: "AgentChattr unreachable", detail: err && err.message });


### PR DESCRIPTION
## Summary
- **GET `/api/chat`**: extends the resync-and-retry condition from `401 || 403` to also include `>= 500`, covering 502 and other 5xx from temporary AC outages
- **POST `/api/chat`** (WebSocket path): previously only retried on ws close code 4003 (`EAGENTCHATTR_401`); now also attempts token resync on generic connection errors (ECONNREFUSED, ECONNRESET, timeout) so the operator auto-recovers once AC is back

## Test plan
- [x] Existing `routes.chatWsSend.test.js` passes (5 cases)
- [ ] Manual: stop AC, attempt send from dashboard (should get 502), restart AC → next send auto-recovers via resync
- [ ] Manual: verify 401/403 path still works as before (no regression)

Fixes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)