### PR TITLE
[#488] Home page: two-column layout

### DIFF
--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -58,10 +58,11 @@ export default function HomeDashboard() {
   }, []);
 
   return (
-    <div className="h-full overflow-y-auto p-6">
+    <div className="h-full overflow-y-auto lg:overflow-hidden lg:flex lg:flex-col p-6">
       {/* #488: two-column layout at lg+ — hero+projects left, activity right.
-          Collapses to current stacked layout below lg. */}
-      <div className="lg:grid lg:grid-cols-[1fr_340px] lg:gap-6 lg:h-[calc(100%-1rem)]">
+          Collapses to current stacked layout below lg. Flex-1 + min-h-0
+          lets the grid fill remaining height without a magic calc. */}
+      <div className="lg:grid lg:grid-cols-[1fr_340px] lg:gap-6 lg:flex-1 lg:min-h-0">
         {/* Left column: hero + header + project cards */}
         <div className="lg:overflow-y-auto lg:min-h-0">
           {/* #229: friendly empty-state hero. Only rendered after

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -59,27 +59,27 @@ export default function HomeDashboard() {
 
   return (
     <div className="h-full overflow-y-auto p-6">
-      {/* #229: friendly empty-state hero. Only rendered after
-          /api/projects resolves successfully — we don't want to
-          flash the "no projects" onboarding CTA to existing users
-          while the first fetch is in flight, or when the API
-          errored and we have no idea which branch to show. */}
-      {projectsState === "loaded" && (
-        <div className="mb-6">
-          <HomeEmptyState hasProjects={projects.length > 0} />
-        </div>
-      )}
-      {projectsState === "error" && (
-        <div className="mb-6 border border-error/30 bg-error/5 text-error text-[11px] px-3 py-2">
-          Could not load projects from /api/projects. The dashboard may be out of date — check the server logs and reload.
-        </div>
-      )}
-
       {/* #488: two-column layout at lg+ — hero+projects left, activity right.
           Collapses to current stacked layout below lg. */}
-      <div className="lg:grid lg:grid-cols-[1fr_340px] lg:gap-6 lg:h-[calc(100%-4rem)]">
-        {/* Left column: header + project cards */}
+      <div className="lg:grid lg:grid-cols-[1fr_340px] lg:gap-6 lg:h-[calc(100%-1rem)]">
+        {/* Left column: hero + header + project cards */}
         <div className="lg:overflow-y-auto lg:min-h-0">
+          {/* #229: friendly empty-state hero. Only rendered after
+              /api/projects resolves successfully — we don't want to
+              flash the "no projects" onboarding CTA to existing users
+              while the first fetch is in flight, or when the API
+              errored and we have no idea which branch to show. */}
+          {projectsState === "loaded" && (
+            <div className="mb-6">
+              <HomeEmptyState hasProjects={projects.length > 0} />
+            </div>
+          )}
+          {projectsState === "error" && (
+            <div className="mb-6 border border-error/30 bg-error/5 text-error text-[11px] px-3 py-2">
+              Could not load projects from /api/projects. The dashboard may be out of date — check the server logs and reload.
+            </div>
+          )}
+
           {/* Header */}
           <div className="mb-6">
             <h1 className="text-lg font-semibold text-text tracking-tight">Projects</h1>

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -75,102 +75,109 @@ export default function HomeDashboard() {
         </div>
       )}
 
-      {/* Header */}
-      <div className="mb-6">
-        <h1 className="text-lg font-semibold text-text tracking-tight">Projects</h1>
-        <p className="text-xs text-text-muted mt-1">
-          {projects.length} configured project{projects.length !== 1 ? "s" : ""}
-        </p>
-      </div>
+      {/* #488: two-column layout at lg+ — hero+projects left, activity right.
+          Collapses to current stacked layout below lg. */}
+      <div className="lg:grid lg:grid-cols-[1fr_340px] lg:gap-6 lg:h-[calc(100%-4rem)]">
+        {/* Left column: header + project cards */}
+        <div className="lg:overflow-y-auto lg:min-h-0">
+          {/* Header */}
+          <div className="mb-6">
+            <h1 className="text-lg font-semibold text-text tracking-tight">Projects</h1>
+            <p className="text-xs text-text-muted mt-1">
+              {projects.length} configured project{projects.length !== 1 ? "s" : ""}
+            </p>
+          </div>
 
-      {/* Project cards grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 mb-8">
-        {projects.map((project) => (
-          <Link
-            key={project.id}
-            href={`/project/${project.id}`}
-            className="block border border-border bg-bg-surface p-4 hover:bg-[#1a1a1a] transition-colors group"
-          >
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2">
-                <span
-                  className={`w-1.5 h-1.5 rounded-full ${
-                    project.state === "active" ? "bg-accent" : "bg-text-muted"
-                  }`}
-                />
-                <span className="text-sm font-semibold text-text">{project.name}</span>
-                <span className="text-[10px] text-text-muted">
-                  {project.state}
+          {/* Project cards grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 mb-8 lg:mb-0">
+            {projects.map((project) => (
+              <Link
+                key={project.id}
+                href={`/project/${project.id}`}
+                className="block border border-border bg-bg-surface p-4 hover:bg-[#1a1a1a] transition-colors group"
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`w-1.5 h-1.5 rounded-full ${
+                        project.state === "active" ? "bg-accent" : "bg-text-muted"
+                      }`}
+                    />
+                    <span className="text-sm font-semibold text-text">{project.name}</span>
+                    <span className="text-[10px] text-text-muted">
+                      {project.state}
+                    </span>
+                  </div>
+                  <span className="text-[10px] text-text-muted opacity-0 group-hover:opacity-100 transition-opacity">
+                    open →
+                  </span>
+                </div>
+
+                <div className="flex gap-4 text-[11px] mb-2">
+                  <div>
+                    <span className="text-text-muted">agents</span>
+                    <span className="ml-1.5 text-text">{project.agentCount}</span>
+                  </div>
+                  <div>
+                    <span className="text-text-muted">PRs</span>
+                    <span className="ml-1.5 text-text">{project.openPrs}</span>
+                  </div>
+                  <div>
+                    <span className="text-text-muted">repo</span>
+                    <span className="ml-1.5 text-text">{project.repo}</span>
+                  </div>
+                </div>
+
+                {project.lastActivity && (
+                  <div className="text-[10px] text-text-muted">
+                    last activity: {timeAgo(project.lastActivity)}
+                  </div>
+                )}
+              </Link>
+            ))}
+
+            {/* + New Project */}
+            <Link
+              href="/setup"
+              className="border border-dashed border-border p-4 flex items-center justify-center text-text-muted hover:text-text hover:border-text-muted transition-colors min-h-[88px]"
+            >
+              <span className="text-sm">+ New Project</span>
+            </Link>
+          </div>
+        </div>
+
+        {/* Right column: activity feed — scrolls independently on desktop */}
+        <div className="lg:overflow-y-auto lg:min-h-0 mb-6 lg:mb-0">
+          <h2 className="text-xs text-text-muted uppercase tracking-wider mb-3">Recent Activity</h2>
+          <div className="border border-border bg-bg-surface">
+            {activity.length === 0 && (
+              <div className="px-3 py-3 text-[11px] text-text-muted">No recent activity</div>
+            )}
+            {activity.map((item, i) => (
+              <div
+                key={`${item.time}-${i}`}
+                className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
+              >
+                <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
+                  {item.time?.slice(0, 5) || ""}
+                </span>
+                <span className="text-accent shrink-0 font-semibold w-12">
+                  {item.projectName}
+                </span>
+                <span className="text-[#ffcc00] shrink-0 font-semibold w-12">
+                  {/* #420 / quadwork#307: widen column + mirror the
+                      RE1/RE2 short labels PR #272 (#263) already uses
+                      in the chat sender column. w-6 was 24px and
+                      overflowed re1/re2 into the adjacent
+                      message text column. */}
+                  {item.actor}
+                </span>
+                <span className="text-text truncate min-w-0">
+                  {item.text}
                 </span>
               </div>
-              <span className="text-[10px] text-text-muted opacity-0 group-hover:opacity-100 transition-opacity">
-                open →
-              </span>
-            </div>
-
-            <div className="flex gap-4 text-[11px] mb-2">
-              <div>
-                <span className="text-text-muted">agents</span>
-                <span className="ml-1.5 text-text">{project.agentCount}</span>
-              </div>
-              <div>
-                <span className="text-text-muted">PRs</span>
-                <span className="ml-1.5 text-text">{project.openPrs}</span>
-              </div>
-              <div>
-                <span className="text-text-muted">repo</span>
-                <span className="ml-1.5 text-text">{project.repo}</span>
-              </div>
-            </div>
-
-            {project.lastActivity && (
-              <div className="text-[10px] text-text-muted">
-                last activity: {timeAgo(project.lastActivity)}
-              </div>
-            )}
-          </Link>
-        ))}
-
-        {/* + New Project */}
-        <Link
-          href="/setup"
-          className="border border-dashed border-border p-4 flex items-center justify-center text-text-muted hover:text-text hover:border-text-muted transition-colors min-h-[88px]"
-        >
-          <span className="text-sm">+ New Project</span>
-        </Link>
-      </div>
-
-      {/* Activity feed */}
-      <div className="mb-6">
-        <h2 className="text-xs text-text-muted uppercase tracking-wider mb-3">Recent Activity</h2>
-        <div className="border border-border bg-bg-surface">
-          {activity.length === 0 && (
-            <div className="px-3 py-3 text-[11px] text-text-muted">No recent activity</div>
-          )}
-          {activity.map((item, i) => (
-            <div
-              key={`${item.time}-${i}`}
-              className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
-            >
-              <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
-                {item.time?.slice(0, 5) || ""}
-              </span>
-              <span className="text-accent shrink-0 font-semibold w-12">
-                {item.projectName}
-              </span>
-              <span className="text-[#ffcc00] shrink-0 font-semibold w-12">
-                {/* #420 / quadwork#307: widen column + mirror the
-                    RE1/RE2 short labels PR #272 (#263) already uses
-                    in the chat sender column. w-6 was 24px and
-                    overflowed re1/re2 into the adjacent
-                    message text column. */}
-                {item.actor}
-              </span>
-              <span className="text-text truncate min-w-0">
-                {item.text}
-              </span>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Desktop (`lg+`): hero + projects on the left, recent activity feed on the right (340px fixed-width column with independent scroll)
- Below `lg`: collapses to the existing stacked single-column layout — no regression
- Both columns scroll independently when content overflows
- No changes to hero, project card, or activity feed content/markup

## Test plan
- [ ] Desktop: verify two-column layout with hero+projects left, activity right
- [ ] Resize below `lg` breakpoint: verify fallback to stacked single-column
- [ ] Long activity list: verify right column scrolls independently
- [ ] No visual regressions on project cards, hero, or empty state

Fixes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)