### PR TITLE
[#492] Fix setup wizard for empty repos

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -876,7 +876,8 @@ async function setupAgents(rl, repo) {
   const headCheck = run(`git -C "${absDir}" rev-parse HEAD 2>&1`);
   if (!headCheck || headCheck.includes("fatal")) {
     run(`git -C "${absDir}" commit --allow-empty -m "Initial commit (created by QuadWork setup)"`);
-    run(`git -C "${absDir}" push origin main 2>&1`);
+    const defaultBranch = run(`git -C "${absDir}" symbolic-ref --short HEAD 2>&1`) || "main";
+    run(`git -C "${absDir}" push origin ${defaultBranch} 2>&1`);
   }
 
   const worktrees = {};

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -872,6 +872,13 @@ async function setupAgents(rl, repo) {
   log(`Project: ${projectName}`);
   const wtSpinner = spinner("Creating worktrees and seeding files...");
 
+  // Empty repos have no commits — git worktree add requires at least one.
+  const headCheck = run(`git -C "${absDir}" rev-parse HEAD 2>&1`);
+  if (!headCheck || headCheck.includes("fatal")) {
+    run(`git -C "${absDir}" commit --allow-empty -m "Initial commit (created by QuadWork setup)"`);
+    run(`git -C "${absDir}" push origin main 2>&1`);
+  }
+
   const worktrees = {};
   let wtFailed = null;
   for (const agent of AGENTS) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -1881,6 +1881,12 @@ router.post("/api/setup", (req, res) => {
         const clone = exec("gh", ["repo", "clone", body.repo, workingDir]);
         if (!clone.ok) return res.json({ ok: false, error: `Clone failed: ${clone.output}` });
       }
+      // Empty repos have no commits — git worktree add requires at least one.
+      const headCheck = exec("git", ["rev-parse", "HEAD"], { cwd: workingDir });
+      if (!headCheck.ok) {
+        exec("git", ["commit", "--allow-empty", "-m", "Initial commit (created by QuadWork setup)"], { cwd: workingDir });
+        exec("git", ["push", "origin", "main"], { cwd: workingDir });
+      }
       // Sibling dirs: ../projectName-head/, ../projectName-re1/, etc. (matches CLI wizard)
       const projectName = path.basename(workingDir);
       const parentDir = path.dirname(workingDir);

--- a/server/routes.js
+++ b/server/routes.js
@@ -1885,7 +1885,9 @@ router.post("/api/setup", (req, res) => {
       const headCheck = exec("git", ["rev-parse", "HEAD"], { cwd: workingDir });
       if (!headCheck.ok) {
         exec("git", ["commit", "--allow-empty", "-m", "Initial commit (created by QuadWork setup)"], { cwd: workingDir });
-        exec("git", ["push", "origin", "main"], { cwd: workingDir });
+        const branchResult = exec("git", ["symbolic-ref", "--short", "HEAD"], { cwd: workingDir });
+        const defaultBranch = branchResult.ok ? branchResult.output : "main";
+        exec("git", ["push", "origin", defaultBranch], { cwd: workingDir });
       }
       // Sibling dirs: ../projectName-head/, ../projectName-re1/, etc. (matches CLI wizard)
       const projectName = path.basename(workingDir);


### PR DESCRIPTION
## Summary
- Before creating worktrees, check if the repo has any commits (`git rev-parse HEAD`)
- If no commits exist, auto-create an empty initial commit and push it to main
- Applied to both CLI wizard (`bin/quadwork.js`) and web wizard (`server/routes.js`)

Fixes #492

## Test plan
- [ ] Create a fresh empty GitHub repo, run setup wizard — should auto-commit and create worktrees successfully
- [ ] Run setup wizard on an existing repo with commits — no change in behavior (skip auto-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)