### PR TITLE
[#502] Fix idle agent -2 suffix accumulation from heartbeat timeout

### DIFF
--- a/server/agentchattr-registry.js
+++ b/server/agentchattr-registry.js
@@ -101,7 +101,7 @@ async function deregisterAgent(serverPort, name, token) {
 /**
  * Start a per-agent heartbeat that POSTs /api/heartbeat/{name} every 5s
  * with bearer auth. AgentChattr considers an agent crashed and removes
- * it after ~60s without a heartbeat, so without this every registered
+ * it after ~120s without a heartbeat, so without this every registered
  * QuadWork agent silently disappears from the channel one minute after
  * registration.
  *

--- a/server/index.js
+++ b/server/index.js
@@ -2042,7 +2042,7 @@ server.listen(PORT, "127.0.0.1", () => {
   // #478 + #502: patch deployed AgentChattr instances to support force-replace
   // on register and fix idle-agent crash timeout.
   for (const p of (startupCfg.projects || [])) {
-    const acDir = p.agentchattr_dir || path.join(os.homedir(), ".quadwork", p.id, "agentchattr");
+    const acDir = resolveProjectChattr(p.id).dir;
     // Patch registry.py: add force parameter to register()
     const regPath = path.join(acDir, "registry.py");
     if (fs.existsSync(regPath)) {

--- a/server/index.js
+++ b/server/index.js
@@ -2039,8 +2039,8 @@ server.listen(PORT, "127.0.0.1", () => {
       }
     }
   }
-  // #478: patch deployed AgentChattr instances to support force-replace
-  // on register. Prevents ghost slot accumulation after restarts.
+  // #478 + #502: patch deployed AgentChattr instances to support force-replace
+  // on register and fix idle-agent crash timeout.
   for (const p of (startupCfg.projects || [])) {
     const acDir = p.agentchattr_dir || path.join(os.homedir(), ".quadwork", p.id, "agentchattr");
     // Patch registry.py: add force parameter to register()
@@ -2058,17 +2058,35 @@ server.listen(PORT, "127.0.0.1", () => {
           reg = reg.replace(
             "            self._expire_reserved()\n\n            # Find next free slot",
             "            self._expire_reserved()\n\n" +
-            "            # quadwork#478: force-replace — expire all existing slots for this\n" +
-            "            # base so the new registration always lands at slot 1.\n" +
+            "            # quadwork#478 + #502: force-replace — expire all existing slots\n" +
+            "            # for this base so the new registration always lands at slot 1.\n" +
+            "            # Also clear _reserved entries: after a crash-timeout the old name\n" +
+            "            # lives only in _reserved, so without this the grace period still\n" +
+            "            # blocks slot 1 and the agent gets a -2 suffix.\n" +
             "            if force:\n" +
             "                ghosts = [n for n, i in self._instances.items() if i.base == base]\n" +
             "                for name in ghosts:\n" +
             "                    del self._instances[name]\n" +
-            "                    self._reserved[name] = time.time()\n\n" +
+            "                stale_reserved = [rn for rn in self._reserved\n" +
+            "                                  if self._parse_name(rn)[0] == base]\n" +
+            "                for rn in stale_reserved:\n" +
+            "                    del self._reserved[rn]\n\n" +
             "            # Find next free slot",
           );
           fs.writeFileSync(regPath, reg);
           console.log(`[ghost-fix] ${p.id}: patched registry.py with force-replace support`);
+        } else if (!reg.includes("stale_reserved")) {
+          // #502: upgrade existing force-replace patch to also clear _reserved
+          reg = reg.replace(
+            /( +)for name in ghosts:\n\1    del self\._instances\[name\]\n\1    self\._reserved\[name\] = time\.time\(\)/,
+            "$1for name in ghosts:\n$1    del self._instances[name]\n" +
+            "$1stale_reserved = [rn for rn in self._reserved\n" +
+            "$1                  if self._parse_name(rn)[0] == base]\n" +
+            "$1for rn in stale_reserved:\n" +
+            "$1    del self._reserved[rn]",
+          );
+          fs.writeFileSync(regPath, reg);
+          console.log(`[ghost-fix] ${p.id}: upgraded registry.py force-replace to clear _reserved (#502)`);
         }
       } catch (err) {
         console.warn(`[ghost-fix] ${p.id}: failed to patch registry.py: ${err.message}`);
@@ -2089,6 +2107,27 @@ server.listen(PORT, "127.0.0.1", () => {
         }
       } catch (err) {
         console.warn(`[ghost-fix] ${p.id}: failed to patch app.py: ${err.message}`);
+      }
+    }
+    // #502: increase crash timeout from 15s to 120s for idle agent tolerance
+    if (fs.existsSync(appPath)) {
+      try {
+        let app = fs.readFileSync(appPath, "utf-8");
+        if (app.includes("_CRASH_TIMEOUT = 15")) {
+          app = app.replace(
+            "_CRASH_TIMEOUT = 15",
+            "_CRASH_TIMEOUT = 120",
+          );
+          // Fix the misleading comment too
+          app = app.replace(
+            "# Crash timeout: if a wrapper hasn't heartbeated for 60s,\n",
+            "# Crash timeout: if a wrapper hasn't heartbeated for 120s,\n",
+          );
+          fs.writeFileSync(appPath, app);
+          console.log(`[idle-fix] ${p.id}: increased crash timeout to 120s (#502)`);
+        }
+      } catch (err) {
+        console.warn(`[idle-fix] ${p.id}: failed to patch app.py crash timeout: ${err.message}`);
       }
     }
   }


### PR DESCRIPTION
## Summary

- **force-replace now clears `_reserved`**: After crash-timeout deregisters an idle agent, its name moves to `_reserved` (grace period). The existing `force=true` logic only cleared `_instances`, so re-registration still found slot 1 blocked → `-2` suffix. Now `force=true` also clears `_reserved` entries for the base, ensuring slot 1 is always reclaimed.
- **Crash timeout increased from 15s to 120s**: The 15s timeout (with a misleading "60s" comment) was too aggressive — just 3 missed 5s heartbeats triggered a spurious disconnect. 120s tolerates brief OS sleep / process scheduling delays while still detecting actual crashes within 2 minutes.
- **Bootstrap patches updated**: Already-deployed AC instances get both fixes on next QW server start. Existing `#478` force-replace patches are upgraded in-place.

Also fixes the `~60s` comment in `agentchattr-registry.js` to match actual timeout.

## Test plan

- [ ] Start agents, leave idle for 8+ hours — verify no `-2` suffix or `disconnected (timeout)` spam
- [ ] Kill an agent CLI process — verify disconnect message appears within ~2 minutes
- [ ] Restart QW server — verify bootstrap patches apply (check `[ghost-fix]` and `[idle-fix]` console logs)
- [ ] With a previously patched AC instance, verify the `stale_reserved` upgrade path fires

Fixes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)