### PR TITLE
[#501] Filter system/status noise from bridge forwarding

### DIFF
--- a/bridges/discord/discord_bridge.py
+++ b/bridges/discord/discord_bridge.py
@@ -18,6 +18,7 @@ import atexit
 import json
 import logging
 import os
+import re
 import signal
 import sys
 import threading
@@ -213,6 +214,60 @@ def start_heartbeat(url):
 
 
 # ---------------------------------------------------------------------------
+# #501: message filter — suppress AC housekeeping noise from bridge output
+# ---------------------------------------------------------------------------
+
+_NOISE_PATTERNS = [
+    re.compile(r"^.+ is online$"),
+    re.compile(r"disconnected \(timeout\)"),
+    re.compile(r"^.+ disconnected$"),
+    re.compile(r"auto-recovered"),
+    re.compile(r"Resuming agent conversation"),
+]
+
+# Dedup guard: (sender, text) → timestamp of last forward
+_last_forwarded: dict[tuple[str, str], float] = {}
+_DEDUP_WINDOW = 60  # seconds
+
+
+def _should_forward(msg: dict) -> bool:
+    """Return True if this AC message should be forwarded to Discord/Telegram."""
+    sender = msg.get("sender", "")
+    text = msg.get("text", "")
+    msg_type = msg.get("type", "chat")
+
+    # Skip join/leave system messages (online, disconnected, timeout)
+    if msg_type in ("join", "leave"):
+        return False
+
+    # Skip system sender entirely
+    if sender == "system":
+        return False
+
+    # Pattern-based filter for edge cases
+    for pat in _NOISE_PATTERNS:
+        if pat.search(text):
+            return False
+
+    # Dedup: suppress identical (sender, text) within window
+    key = (sender, text)
+    now = time.time()
+    last = _last_forwarded.get(key)
+    if last is not None and now - last < _DEDUP_WINDOW:
+        return False
+    _last_forwarded[key] = now
+
+    # Prune stale dedup entries periodically
+    if len(_last_forwarded) > 500:
+        cutoff = now - _DEDUP_WINDOW
+        stale = [k for k, t in _last_forwarded.items() if t < cutoff]
+        for k in stale:
+            del _last_forwarded[k]
+
+    return True
+
+
+# ---------------------------------------------------------------------------
 # AC → Discord polling
 # ---------------------------------------------------------------------------
 
@@ -305,12 +360,12 @@ async def poll_ac_to_discord(cfg, channel):
                         commit_cursor()
                         continue
 
-                    # Skip system auto-recovery messages
-                    if sender == "system":
+                    if not text:
                         commit_cursor()
                         continue
 
-                    if not text:
+                    # #501: skip system/status noise and dedup
+                    if not _should_forward(msg):
                         commit_cursor()
                         continue
 

--- a/bridges/discord/discord_bridge.py
+++ b/bridges/discord/discord_bridge.py
@@ -231,7 +231,7 @@ _DEDUP_WINDOW = 60  # seconds
 
 
 def _should_forward(msg: dict) -> bool:
-    """Return True if this AC message should be forwarded to Discord/Telegram."""
+    """Return True if this AC message should be forwarded. Pure check, no side effects."""
     sender = msg.get("sender", "")
     text = msg.get("text", "")
     msg_type = msg.get("type", "chat")
@@ -255,16 +255,21 @@ def _should_forward(msg: dict) -> bool:
     last = _last_forwarded.get(key)
     if last is not None and now - last < _DEDUP_WINDOW:
         return False
-    _last_forwarded[key] = now
+
+    return True
+
+
+def _mark_forwarded(msg: dict):
+    """Record that a message was successfully forwarded. Call after delivery."""
+    key = (msg.get("sender", ""), msg.get("text", ""))
+    _last_forwarded[key] = time.time()
 
     # Prune stale dedup entries periodically
     if len(_last_forwarded) > 500:
-        cutoff = now - _DEDUP_WINDOW
+        cutoff = time.time() - _DEDUP_WINDOW
         stale = [k for k, t in _last_forwarded.items() if t < cutoff]
         for k in stale:
             del _last_forwarded[k]
-
-    return True
 
 
 # ---------------------------------------------------------------------------
@@ -384,6 +389,7 @@ async def poll_ac_to_discord(cfg, channel):
                         # Only commit cursor + mark forwarded AFTER
                         # successful Discord delivery.
                         forwarded_ids.add(msg_id)
+                        _mark_forwarded(msg)
                         commit_cursor()
                         # Trim the set if it grows too large
                         if len(forwarded_ids) > MAX_FORWARDED:

--- a/server/routes.js
+++ b/server/routes.js
@@ -2301,7 +2301,7 @@ router.post("/api/rename", (req, res) => {
 const BRIDGE_DIR = path.join(CONFIG_DIR, "agentchattr-telegram");
 // #444: pin agentchattr-telegram to a known commit (same pattern as
 // AGENTCHATTR_PIN in bin/quadwork.js for bcurts/agentchattr).
-const AGENTCHATTR_TELEGRAM_PIN = "4a6b45f1794c612328b9d5ee6d6fcb3f77015abc";
+const AGENTCHATTR_TELEGRAM_PIN = "09bb557aa4a069687aa6f4d6d08a0df02ae87463";
 
 function telegramPidFile(projectId) {
   return path.join(CONFIG_DIR, `tg-bridge-${projectId}.pid`);

--- a/server/routes.js
+++ b/server/routes.js
@@ -2301,7 +2301,7 @@ router.post("/api/rename", (req, res) => {
 const BRIDGE_DIR = path.join(CONFIG_DIR, "agentchattr-telegram");
 // #444: pin agentchattr-telegram to a known commit (same pattern as
 // AGENTCHATTR_PIN in bin/quadwork.js for bcurts/agentchattr).
-const AGENTCHATTR_TELEGRAM_PIN = "09bb557aa4a069687aa6f4d6d08a0df02ae87463";
+const AGENTCHATTR_TELEGRAM_PIN = "918687a0704a49d5dec9ac4c52e1759bb565eb10";
 
 function telegramPidFile(projectId) {
   return path.join(CONFIG_DIR, `tg-bridge-${projectId}.pid`);


### PR DESCRIPTION
## Summary

- **Discord bridge**: Added `_should_forward()` filter that skips join/leave messages, system sender, pattern-matched noise (online, disconnected, auto-recovered, Resuming agent conversation), and deduplicates identical messages within 60s
- **Telegram bridge**: Same filter added to source repo, pin bumped to `09bb557`
- Existing deployed Telegram bridges will pick up the filter on next re-install via the updated pin

## Test plan

- [ ] Verify `head is online` messages NOT forwarded to Discord/Telegram
- [ ] Verify `re1 disconnected (timeout)` NOT forwarded
- [ ] Verify system auto-recovery messages NOT forwarded
- [ ] Verify actual agent work messages (PR reviews, assignments, merge notifications) still forwarded
- [ ] Verify duplicate consecutive messages (same sender+text within 60s) suppressed
- [ ] Re-install Telegram bridge and verify new pin applies

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)