### PR TITLE
[#506] Refresh Discord bridge script from package on startup

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1983,6 +1983,20 @@ server.listen(PORT, "127.0.0.1", () => {
       }
     } catch {}
   }
+  // #506: refresh Discord bridge script from the npm package on startup.
+  // The Telegram bridge uses git-fetch + pin, but Discord uses a file-copy
+  // pattern. Without this, upgrading QuadWork leaves a stale on-disk script
+  // missing fixes shipped in newer versions.
+  const DISCORD_BRIDGE_SRC = path.join(__dirname, "..", "bridges", "discord", "discord_bridge.py");
+  const DISCORD_BRIDGE_DEST = path.join(os.homedir(), ".quadwork", "agentchattr-discord", "discord_bridge.py");
+  if (fs.existsSync(DISCORD_BRIDGE_SRC) && fs.existsSync(path.dirname(DISCORD_BRIDGE_DEST))) {
+    try {
+      fs.copyFileSync(DISCORD_BRIDGE_SRC, DISCORD_BRIDGE_DEST);
+      console.log("[bridge-refresh] refreshed Discord bridge script from package");
+    } catch (err) {
+      console.warn(`[bridge-refresh] failed to refresh Discord bridge script: ${err.message || err}`);
+    }
+  }
   // #470: patch stale bridge_sender defaults in on-disk bridge scripts.
   // The AC config migration (#457) renames the agent sections, but the
   // bridge scripts themselves may still have old defaults if the operator

--- a/server/routes.js
+++ b/server/routes.js
@@ -3066,20 +3066,19 @@ router.post("/api/discord", async (req, res) => {
       const venvPip = path.join(venvDir, "bin", "pip");
       let pipOutput = "";
       try {
-        // Copy from bundled package dir (not clone — #397 decision)
-        if (!fs.existsSync(path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py"))) {
-          fs.cpSync(DISCORD_BRIDGE_SRC, DISCORD_BRIDGE_DIR, { recursive: true });
-        } else {
-          // On upgrade: overwrite script, keep venv
-          fs.cpSync(
-            path.join(DISCORD_BRIDGE_SRC, "discord_bridge.py"),
-            path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py"),
-          );
-          fs.cpSync(
-            path.join(DISCORD_BRIDGE_SRC, "requirements.txt"),
-            path.join(DISCORD_BRIDGE_DIR, "requirements.txt"),
-          );
+        // #506: always copy bundled bridge files (not just on first install)
+        // so re-installing after a QuadWork upgrade refreshes the script.
+        if (!fs.existsSync(DISCORD_BRIDGE_DIR)) {
+          fs.mkdirSync(DISCORD_BRIDGE_DIR, { recursive: true });
         }
+        fs.cpSync(
+          path.join(DISCORD_BRIDGE_SRC, "discord_bridge.py"),
+          path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py"),
+        );
+        fs.cpSync(
+          path.join(DISCORD_BRIDGE_SRC, "requirements.txt"),
+          path.join(DISCORD_BRIDGE_DIR, "requirements.txt"),
+        );
         if (!fs.existsSync(venvPython)) {
           execFileSync("python3", ["-m", "venv", venvDir], { encoding: "utf-8", timeout: 60000 });
         }


### PR DESCRIPTION
## Summary
- On QuadWork startup, auto-copy `bridges/discord/discord_bridge.py` from the npm package to `~/.quadwork/agentchattr-discord/` so upgrades refresh the on-disk script without manual re-install
- Simplify the Install Bridge handler to always overwrite the script and requirements (not just on first install), ensuring re-installs pick up the latest code
- Venv at `~/.quadwork/agentchattr-discord/.venv` is preserved in both paths — no re-pip-install needed

## Changes
- `server/index.js` — added startup block that copies bundled `discord_bridge.py` to the on-disk location if both source and target dir exist
- `server/routes.js` — simplified install case to always copy script + requirements instead of branching on first-install vs re-install

## Test plan
- [ ] Upgrade QuadWork → restart → verify `~/.quadwork/agentchattr-discord/discord_bridge.py` matches shipped version
- [ ] Run Install Bridge from UI → verify script is refreshed
- [ ] Verify venv is preserved (no re-pip-install)
- [ ] Verify Telegram bridge refresh (#470) still works independently

Fixes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)