### PR TITLE
[#507] Add Discord community link to README + home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ has a working clone, the legacy shared install can be removed safely via
 `npx quadwork cleanup --legacy` (which refuses to run if any project is
 still on the legacy install).
 
+## ─ Community
+
+Want to talk with the creator? [Join Hunt Town](https://discord.gg/syhbYPk3Wq) and find @project7.
+
 ## ─ License
 
 MIT

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -145,6 +145,20 @@ export default function HomeDashboard() {
               <span className="text-sm">+ New Project</span>
             </Link>
           </div>
+
+          {/* #507: subtle Discord community link */}
+          <div className="mt-4 mb-8 lg:mb-4 text-[11px] text-text-muted">
+            Want to talk with the creator?{" "}
+            <a
+              href="https://discord.gg/syhbYPk3Wq"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-text hover:text-accent transition-colors"
+            >
+              Join Hunt Town
+            </a>{" "}
+            and find @project7.
+          </div>
         </div>
 
         {/* Right column: activity feed — scrolls independently on desktop */}


### PR DESCRIPTION
## Summary
- Added a Community section to `README.md` with the Hunt Town Discord invite link and @project7 mention
- Added a subtle one-line community link below the project cards grid on the home dashboard (`HomeDashboard.tsx`)
- Both link to https://discord.gg/syhbYPk3Wq

## Test plan
- [ ] Verify README renders the Community section with a clickable Discord link
- [ ] Verify home dashboard shows the community link below the project cards
- [ ] Link opens Discord invite in a new tab
- [ ] Style is subtle — matches surrounding text size and muted color

Fixes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)