### PR TITLE
[#510] Add Claude Opus 4.7 to agent model dropdown

### DIFF
--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -52,6 +52,7 @@ const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> = {
   ],
   claude: [
     { value: "", label: "(CLI default)" },
+    { value: "claude-opus-4-7", label: "claude-opus-4-7" },
     { value: "claude-opus-4-6", label: "claude-opus-4-6" },
     { value: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
     { value: "claude-haiku-4-5-20251001", label: "claude-haiku-4-5" },


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` to the Claude model dropdown in `AgentModelsWidget.tsx`, placed above Opus 4.6 (newest first)
- Default remains "(CLI default)" — no existing projects affected
- No server-side changes needed; the model string passes through to `--model` on the CLI

Fixes #510

## Test plan
- [ ] Open Agent Models modal → Claude dropdown shows `claude-opus-4-7` as an option
- [ ] Select Opus 4.7 and restart → agent launches with `--model claude-opus-4-7`
- [ ] Default for new projects remains "(CLI default)"
- [ ] Existing Opus 4.6 selections are unaffected
- [ ] Codex model options unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)