### PR TITLE
[#511] Fix terminal blank-content with aggressive fit interval

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -181,10 +181,12 @@ export default function TerminalPanel({
     let reattachAttempts = 0;
     const MAX_REATTACH = 5;
 
-    // #477: track whether we've done a post-replay fit. After the
-    // scrollback replay data is written, xterm needs a fit() to
-    // repaint — otherwise idle terminals appear blank until resize.
-    let needsPostReplayFit = false;
+    // #511: aggressive post-replay fit strategy. A single rAF fit
+    // isn't enough — the container may not have final CSS dimensions
+    // when the first WS message arrives. Retry fit() on an interval
+    // for the first 2s after connect to cover slow layout, SSR
+    // hydration delays, and lazy container sizing.
+    let postReplayFitTimer: ReturnType<typeof setInterval> | null = null;
 
     const connect = async () => {
       const base = await resolveBase();
@@ -196,7 +198,19 @@ export default function TerminalPanel({
 
       ws.onopen = () => {
         reattachAttempts = 0;
-        needsPostReplayFit = true;
+        // #511: start the aggressive fit interval on connect. Fires
+        // fit() every 500ms for 2s (4 attempts) to catch containers
+        // that aren't layout-resolved yet when scrollback arrives.
+        if (postReplayFitTimer) clearInterval(postReplayFitTimer);
+        let fitAttempts = 0;
+        postReplayFitTimer = setInterval(() => {
+          fit();
+          fitAttempts++;
+          if (fitAttempts >= 4) {
+            clearInterval(postReplayFitTimer!);
+            postReplayFitTimer = null;
+          }
+        }, 500);
         ws.send(
           JSON.stringify({
             type: "resize",
@@ -212,13 +226,6 @@ export default function TerminalPanel({
 
       ws.onmessage = (e) => {
         term.write(e.data);
-        // #477: after the first data write (scrollback replay), force
-        // a fit() so xterm repaints. Without this, idle terminals stay
-        // blank until a browser resize event triggers repaint.
-        if (needsPostReplayFit) {
-          needsPostReplayFit = false;
-          requestAnimationFrame(() => fit());
-        }
         const cb = onActivityRef.current;
         if (cb) cb();
       };
@@ -267,6 +274,7 @@ export default function TerminalPanel({
 
     return () => {
       cancelled = true;
+      if (postReplayFitTimer) clearInterval(postReplayFitTimer);
       observer.disconnect();
       wsRef.current?.close();
       term.dispose();

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -231,6 +231,12 @@ export default function TerminalPanel({
       };
 
       ws.onclose = async (e) => {
+        // #511: clear any running fit interval so it doesn't overlap
+        // with a new session's fit loop on reattach.
+        if (postReplayFitTimer) {
+          clearInterval(postReplayFitTimer);
+          postReplayFitTimer = null;
+        }
         if (cancelled) return;
         // #368: bounded polling probe of /api/sessions. A single
         // fixed-delay probe is timing-fragile — if the server-side


### PR DESCRIPTION
## Summary
- Replaces the single `requestAnimationFrame(() => fit())` post-replay strategy with a 500ms interval that runs `fit()` 4 times over 2s after WS connect
- Covers slow CSS layout resolution, SSR hydration delays, and lazy container sizing that caused idle terminals to appear blank until browser resize
- Interval is cleaned up on completion, disconnect, and component unmount

Fixes #511

## Test plan
- [ ] Page load → all 4 agent terminals show content immediately (no blank panels)
- [ ] Navigate away → back → all terminals show content (no blank)
- [ ] No resize needed to reveal content
- [ ] Active AND idle agents both render correctly
- [ ] No regressions to terminal reattach behavior (#368)

🤖 Generated with [Claude Code](https://claude.com/claude-code)