### PR TITLE
[#516] Server-side auto-stop for trigger and caffeinate on batch completion

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1318,11 +1318,13 @@ async function sendTriggerMessage(projectId) {
         if (bp && bp.complete) {
           console.log(`[auto-trigger] ${projectId}: batch complete, auto-stopped`);
           stopTrigger(projectId);
-          // Also stop caffeinate if running (#441 companion fix)
-          if (caffeinateProcess.process) {
+          // Also stop caffeinate if no other triggers remain running
+          // (#441 companion fix). caffeinateProcess is global (not
+          // project-scoped), so only kill it when all work is done.
+          if (caffeinateProcess.process && triggers.size === 0) {
             try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
             caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
-            console.log(`[auto-trigger] ${projectId}: caffeinate auto-stopped`);
+            console.log(`[auto-trigger] ${projectId}: caffeinate auto-stopped (no active triggers remain)`);
           }
           return;
         }

--- a/server/index.js
+++ b/server/index.js
@@ -1301,6 +1301,38 @@ ALL: Communicate via this chat by tagging agents. Your terminal is NOT visible.`
 async function sendTriggerMessage(projectId) {
   const cfg = readConfig();
   const project = cfg.projects && cfg.projects.find((p) => p.id === projectId);
+
+  // #516: server-side auto-stop — check batch progress before sending.
+  // When trigger_auto is enabled, skip the message and stop the trigger
+  // (plus caffeinate) if the batch is already complete. This covers the
+  // case where the operator is on a different page and the client-side
+  // ScheduledTriggerWidget is not mounted to detect completion.
+  if (project && project.trigger_auto) {
+    const qwPort = cfg.port || 8400;
+    try {
+      const bpRes = await fetch(
+        `http://127.0.0.1:${qwPort}/api/batch-progress?project=${encodeURIComponent(projectId)}`
+      );
+      if (bpRes.ok) {
+        const bp = await bpRes.json();
+        if (bp && bp.complete) {
+          console.log(`[auto-trigger] ${projectId}: batch complete, auto-stopped`);
+          stopTrigger(projectId);
+          // Also stop caffeinate if running (#441 companion fix)
+          if (caffeinateProcess.process) {
+            try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
+            caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
+            console.log(`[auto-trigger] ${projectId}: caffeinate auto-stopped`);
+          }
+          return;
+        }
+      }
+    } catch (err) {
+      // Non-fatal — if batch-progress fails, proceed with the message
+      console.error(`[auto-trigger] ${projectId}: batch-progress check failed:`, err.message);
+    }
+  }
+
   const message = (project && project.trigger_message) || DEFAULT_MESSAGE;
 
   // #401 / quadwork#277: route trigger sends through the local

--- a/server/index.js
+++ b/server/index.js
@@ -1755,6 +1755,44 @@ function syncTriggersFromConfig() {
   }
 }
 
+// #516: server-side batch-completion poller. Checks every 30s whether
+// any trigger_auto project's batch is complete, and auto-stops the
+// trigger (plus caffeinate when no triggers remain). This runs
+// independently of the trigger tick interval, so completion is
+// detected within 30s even if the operator is on a different page.
+
+const AUTO_STOP_POLL_INTERVAL_MS = 30_000;
+
+async function autoStopPollingTick() {
+  const cfg = readConfig();
+  if (!cfg.projects) return;
+
+  for (const project of cfg.projects) {
+    if (!project.trigger_auto || !triggers.has(project.id)) continue;
+    const qwPort = cfg.port || 8400;
+    try {
+      const res = await fetch(
+        `http://127.0.0.1:${qwPort}/api/batch-progress?project=${encodeURIComponent(project.id)}`
+      );
+      if (!res.ok) continue;
+      const bp = await res.json();
+      if (bp && bp.complete) {
+        console.log(`[auto-trigger] ${project.id}: batch complete, auto-stopped (poller)`);
+        stopTrigger(project.id);
+        if (caffeinateProcess.process && triggers.size === 0) {
+          try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
+          caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
+          console.log(`[auto-trigger] ${project.id}: caffeinate auto-stopped (no active triggers remain)`);
+        }
+      }
+    } catch {
+      // Non-fatal — retry on next tick
+    }
+  }
+}
+
+setInterval(autoStopPollingTick, AUTO_STOP_POLL_INTERVAL_MS);
+
 // #422 / quadwork#310: auto-continue after loop guard.
 //
 // Per opted-in project, poll AC's /api/status every 10s. When we see


### PR DESCRIPTION
## Summary
- Adds a batch-progress check to `sendTriggerMessage` — when `trigger_auto` is enabled, the server checks `/api/batch-progress` before each trigger tick
- If the batch is complete, auto-stops both the trigger and caffeinate server-side, independent of which page the operator is viewing
- Logs `[auto-trigger] <project>: batch complete, auto-stopped` on stop
- Client-side `ScheduledTriggerWidget` auto-stop preserved as a faster supplement when the page is active
- Batch-progress check failure is non-fatal — proceeds with the message if the check fails

Fixes #516

## Test plan
- [ ] Batch completes while operator is on a different project page → trigger auto-stops within one tick
- [ ] Batch completes while operator is on the home page → same
- [ ] Batch completes while operator IS on the project page → auto-stops immediately (existing client-side behavior)
- [ ] Caffeinate auto-stops when batch completes
- [ ] Log line appears: `[auto-trigger] <project>: batch complete, auto-stopped`
- [ ] Non-auto triggers (trigger_auto not set) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)