### PR TITLE
[#518] Auto-toggle for Telegram + Discord bridges

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1298,6 +1298,34 @@ Dev: Work on assigned ticket or address review feedback.
 RE1/RE2: Review open PRs. If Dev pushed fixes, re-review. Post verdict on PR AND notify here.
 ALL: Communicate via this chat by tagging agents. Your terminal is NOT visible.`;
 
+// #518: stop Telegram + Discord bridges when batch completes (server-side).
+// Called from sendTriggerMessage and autoStopPollingTick so bridges stop
+// even when the operator is on a different page.
+async function autoStopBridges(projectId, project, qwPort) {
+  if (project?.telegram_auto) {
+    try {
+      await fetch(`http://127.0.0.1:${qwPort}/api/telegram?action=stop`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_id: projectId }),
+        signal: AbortSignal.timeout(5000),
+      });
+      console.log(`[auto-bridge] ${projectId}: telegram bridge auto-stopped`);
+    } catch { /* non-fatal */ }
+  }
+  if (project?.discord_auto) {
+    try {
+      await fetch(`http://127.0.0.1:${qwPort}/api/discord?action=stop`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_id: projectId }),
+        signal: AbortSignal.timeout(5000),
+      });
+      console.log(`[auto-bridge] ${projectId}: discord bridge auto-stopped`);
+    } catch { /* non-fatal */ }
+  }
+}
+
 async function sendTriggerMessage(projectId) {
   const cfg = readConfig();
   const project = cfg.projects && cfg.projects.find((p) => p.id === projectId);
@@ -1326,6 +1354,8 @@ async function sendTriggerMessage(projectId) {
             caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
             console.log(`[auto-trigger] ${projectId}: caffeinate auto-stopped (no active triggers remain)`);
           }
+          // #518: also stop bridges when batch completes
+          await autoStopBridges(projectId, project, qwPort);
           return;
         }
       }
@@ -1760,6 +1790,8 @@ function syncTriggersFromConfig() {
 // trigger (plus caffeinate when no triggers remain). This runs
 // independently of the trigger tick interval, so completion is
 // detected within 30s even if the operator is on a different page.
+// #518: also checks telegram_auto / discord_auto projects for bridge
+// auto-stop even when no trigger is active.
 
 const AUTO_STOP_POLL_INTERVAL_MS = 30_000;
 
@@ -1768,7 +1800,9 @@ async function autoStopPollingTick() {
   if (!cfg.projects) return;
 
   for (const project of cfg.projects) {
-    if (!project.trigger_auto || !triggers.has(project.id)) continue;
+    const hasTriggerAuto = project.trigger_auto && triggers.has(project.id);
+    const hasBridgeAuto = project.telegram_auto || project.discord_auto;
+    if (!hasTriggerAuto && !hasBridgeAuto) continue;
     const qwPort = cfg.port || 8400;
     try {
       const res = await fetch(
@@ -1777,13 +1811,17 @@ async function autoStopPollingTick() {
       if (!res.ok) continue;
       const bp = await res.json();
       if (bp && bp.complete) {
-        console.log(`[auto-trigger] ${project.id}: batch complete, auto-stopped (poller)`);
-        stopTrigger(project.id);
-        if (caffeinateProcess.process && triggers.size === 0) {
-          try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
-          caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
-          console.log(`[auto-trigger] ${project.id}: caffeinate auto-stopped (no active triggers remain)`);
+        if (hasTriggerAuto) {
+          console.log(`[auto-trigger] ${project.id}: batch complete, auto-stopped (poller)`);
+          stopTrigger(project.id);
+          if (caffeinateProcess.process && triggers.size === 0) {
+            try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
+            caffeinateProcess = { process: null, pid: null, startedAt: null, duration: null };
+            console.log(`[auto-trigger] ${project.id}: caffeinate auto-stopped (no active triggers remain)`);
+          }
         }
+        // #518: also stop bridges when batch completes
+        await autoStopBridges(project.id, project, qwPort);
       }
     } catch {
       // Non-fatal — retry on next tick

--- a/server/index.js
+++ b/server/index.js
@@ -1298,9 +1298,10 @@ Dev: Work on assigned ticket or address review feedback.
 RE1/RE2: Review open PRs. If Dev pushed fixes, re-review. Post verdict on PR AND notify here.
 ALL: Communicate via this chat by tagging agents. Your terminal is NOT visible.`;
 
-// #518: stop Telegram + Discord bridges when batch completes (server-side).
-// Called from sendTriggerMessage and autoStopPollingTick so bridges stop
-// even when the operator is on a different page.
+// #518: server-side bridge lifecycle helpers. Stop and start Telegram +
+// Discord bridges so they respond to batch transitions even when the
+// operator is on a different project page.
+
 async function autoStopBridges(projectId, project, qwPort) {
   if (project?.telegram_auto) {
     try {
@@ -1325,6 +1326,53 @@ async function autoStopBridges(projectId, project, qwPort) {
     } catch { /* non-fatal */ }
   }
 }
+
+async function autoStartBridges(projectId, project, qwPort) {
+  if (project?.telegram_auto) {
+    try {
+      // Check if already running before starting
+      const st = await fetch(
+        `http://127.0.0.1:${qwPort}/api/telegram?project=${encodeURIComponent(projectId)}`,
+        { signal: AbortSignal.timeout(5000) }
+      );
+      if (st.ok) {
+        const data = await st.json();
+        if (data.running) return; // already running
+        if (!data.configured) return; // not configured — can't start
+      }
+      await fetch(`http://127.0.0.1:${qwPort}/api/telegram?action=start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_id: projectId }),
+        signal: AbortSignal.timeout(10000),
+      });
+      console.log(`[auto-bridge] ${projectId}: telegram bridge auto-started`);
+    } catch { /* non-fatal */ }
+  }
+  if (project?.discord_auto) {
+    try {
+      const st = await fetch(
+        `http://127.0.0.1:${qwPort}/api/discord?project=${encodeURIComponent(projectId)}`,
+        { signal: AbortSignal.timeout(5000) }
+      );
+      if (st.ok) {
+        const data = await st.json();
+        if (data.running) return;
+        if (!data.configured) return;
+      }
+      await fetch(`http://127.0.0.1:${qwPort}/api/discord?action=start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_id: projectId }),
+        signal: AbortSignal.timeout(10000),
+      });
+      console.log(`[auto-bridge] ${projectId}: discord bridge auto-started`);
+    } catch { /* non-fatal */ }
+  }
+}
+
+// Track previous batch state per project for bridge auto-start detection
+const _bridgeBatchPrev = new Map();
 
 async function sendTriggerMessage(projectId) {
   const cfg = readConfig();
@@ -1790,8 +1838,9 @@ function syncTriggersFromConfig() {
 // trigger (plus caffeinate when no triggers remain). This runs
 // independently of the trigger tick interval, so completion is
 // detected within 30s even if the operator is on a different page.
-// #518: also checks telegram_auto / discord_auto projects for bridge
-// auto-stop even when no trigger is active.
+// #518: also handles telegram_auto / discord_auto bridge lifecycle
+// (both start and stop) so bridges respond to batch transitions
+// even when the operator is viewing a different project page.
 
 const AUTO_STOP_POLL_INTERVAL_MS = 30_000;
 
@@ -1810,6 +1859,10 @@ async function autoStopPollingTick() {
       );
       if (!res.ok) continue;
       const bp = await res.json();
+      const hasItems = bp.items && bp.items.length > 0;
+      const prev = _bridgeBatchPrev.get(project.id);
+      _bridgeBatchPrev.set(project.id, { complete: bp.complete, hasItems });
+
       if (bp && bp.complete) {
         if (hasTriggerAuto) {
           console.log(`[auto-trigger] ${project.id}: batch complete, auto-stopped (poller)`);
@@ -1821,7 +1874,17 @@ async function autoStopPollingTick() {
           }
         }
         // #518: also stop bridges when batch completes
-        await autoStopBridges(project.id, project, qwPort);
+        if (hasBridgeAuto) {
+          await autoStopBridges(project.id, project, qwPort);
+        }
+      }
+
+      // #518: detect batch-start transition → auto-start bridges
+      if (hasBridgeAuto && hasItems && !bp.complete) {
+        const isNewBatch = !prev || prev.complete || !prev.hasItems;
+        if (isNewBatch) {
+          await autoStartBridges(project.id, project, qwPort);
+        }
       }
     } catch {
       // Non-fatal — retry on next tick

--- a/src/components/DiscordBridgeWidget.tsx
+++ b/src/components/DiscordBridgeWidget.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import InfoTooltip from "./InfoTooltip";
 import DiscordSetupModal from "./DiscordSetupModal";
+
+interface BatchState {
+  complete: boolean;
+  items: { issue_number: number }[];
+}
 
 interface DiscordBridgeWidgetProps {
   projectId: string;
@@ -43,6 +48,36 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
   const [pollError, setPollError] = useState<string | null>(null);
   const [setupOpen, setSetupOpen] = useState(false);
   const [restartNotice, setRestartNotice] = useState<string | null>(null);
+
+  // #518: Auto toggle — start/stop bridge with batch lifecycle
+  const [autoDiscord, setAutoDiscord] = useState(false);
+  const [autoStatus, setAutoStatus] = useState<string | null>(null);
+  const prevBatchRef = useRef<{ complete: boolean; hasItems: boolean } | null>(null);
+  const autoDiscordRef = useRef(autoDiscord);
+  const runningRef = useRef(false);
+  useEffect(() => { autoDiscordRef.current = autoDiscord; }, [autoDiscord]);
+
+  // Load persisted auto setting from config
+  const autoLoadedRef = useRef(false);
+  useEffect(() => {
+    autoLoadedRef.current = false;
+    prevBatchRef.current = null;
+    setAutoDiscord(false);
+    setAutoStatus(null);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (autoLoadedRef.current) return;
+    fetch("/api/config")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (!cfg) return;
+        const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+        if (entry?.discord_auto) setAutoDiscord(true);
+        autoLoadedRef.current = true;
+      })
+      .catch(() => {});
+  }, [projectId]);
 
   const load = useCallback(async () => {
     try {
@@ -112,8 +147,84 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
     await load();
   };
 
+  // #518: toggle handler — persist discord_auto in project config
+  const toggleAutoDiscord = useCallback(async () => {
+    const next = !autoDiscord;
+    setAutoDiscord(next);
+    if (!next) {
+      setAutoStatus(null);
+      prevBatchRef.current = null;
+    }
+    try {
+      const r = await fetch("/api/config");
+      if (!r.ok) return;
+      const cfg = await r.json();
+      const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+      if (entry) {
+        entry.discord_auto = next;
+        await fetch("/api/config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(cfg),
+        });
+      }
+    } catch { /* non-fatal */ }
+  }, [autoDiscord, projectId]);
+
+  // #518: batch lifecycle polling — auto-start/stop bridge with batch
+  const AUTO_POLL_MS = 30_000;
+
+  const checkBatchLifecycle = useCallback(async () => {
+    if (!autoDiscordRef.current) return;
+    try {
+      const r = await fetch(`/api/batch-progress?project=${encodeURIComponent(projectId)}`);
+      if (!r.ok) return;
+      const data: BatchState = await r.json();
+      const hasItems = data.items.length > 0;
+      const prev = prevBatchRef.current;
+      prevBatchRef.current = { complete: data.complete, hasItems };
+
+      if (!prev) {
+        if (hasItems && !data.complete && !runningRef.current) {
+          setAutoStatus("Batch active — auto-starting bridge.");
+          await callDiscord("start", { project_id: projectId }).catch(() => {});
+          await load();
+        }
+        if (hasItems && data.complete && runningRef.current) {
+          setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+          await callDiscord("stop", { project_id: projectId }).catch(() => {});
+          await load();
+        }
+        return;
+      }
+
+      // Batch just completed → auto-stop
+      if (hasItems && data.complete && !prev.complete && runningRef.current) {
+        setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+        await callDiscord("stop", { project_id: projectId }).catch(() => {});
+        await load();
+        return;
+      }
+
+      // New batch started → auto-start
+      if (hasItems && !data.complete && (prev.complete || !prev.hasItems) && !runningRef.current) {
+        setAutoStatus("New batch detected — auto-starting bridge.");
+        await callDiscord("start", { project_id: projectId }).catch(() => {});
+        await load();
+      }
+    } catch { /* non-fatal */ }
+  }, [projectId, load]);
+
+  useEffect(() => {
+    if (!autoDiscord) return;
+    checkBatchLifecycle();
+    const id = window.setInterval(checkBatchLifecycle, AUTO_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [autoDiscord, checkBatchLifecycle]);
+
   const configured = !!status?.configured;
   const running = !!status?.running;
+  useEffect(() => { runningRef.current = running; }, [running]);
   const displayError = actionError || pollError || (!running && status?.last_error) || "";
 
   return (
@@ -126,9 +237,25 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
               <b>Discord Bridge</b> forwards AgentChattr messages to a Discord channel so you can monitor from Discord. Bidirectional — replies from Discord appear in chat.
             </InfoTooltip>
           </div>
-          {displayError && (
-            <span className="text-[10px] text-error">error</span>
-          )}
+          <div className="flex items-center gap-1.5">
+            {configured && (
+              <button
+                type="button"
+                onClick={toggleAutoDiscord}
+                title={autoDiscord ? "Auto ON — bridge follows batch lifecycle" : "Auto OFF — manual start/stop only"}
+                className={`px-1.5 py-0.5 text-[10px] border transition-colors ${
+                  autoDiscord
+                    ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
+                    : "border-border text-text-muted hover:text-text hover:border-accent"
+                }`}
+              >
+                Auto {autoDiscord ? "●" : "○"}
+              </button>
+            )}
+            {displayError && (
+              <span className="text-[10px] text-error">error</span>
+            )}
+          </div>
         </div>
         <div className="p-3 flex flex-col gap-2">
           {!configured ? (
@@ -214,6 +341,11 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
               >
                 dismiss
               </button>
+            </div>
+          )}
+          {autoStatus && (
+            <div className="mt-1 text-[10px] text-accent">
+              {autoStatus}
             </div>
           )}
           {displayError && (

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import InfoTooltip from "./InfoTooltip";
 import TelegramSetupModal from "./TelegramSetupModal";
+
+interface BatchState {
+  complete: boolean;
+  items: { issue_number: number }[];
+}
 
 interface TelegramBridgeWidgetProps {
   projectId: string;
@@ -60,6 +65,36 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
   // 400 registration loop. Surface that prompt here instead of
   // silently returning "Installed".
   const [restartNotice, setRestartNotice] = useState<string | null>(null);
+
+  // #518: Auto toggle — start/stop bridge with batch lifecycle
+  const [autoTelegram, setAutoTelegram] = useState(false);
+  const [autoStatus, setAutoStatus] = useState<string | null>(null);
+  const prevBatchRef = useRef<{ complete: boolean; hasItems: boolean } | null>(null);
+  const autoTelegramRef = useRef(autoTelegram);
+  const runningRef = useRef(false);
+  useEffect(() => { autoTelegramRef.current = autoTelegram; }, [autoTelegram]);
+
+  // Load persisted auto setting from config
+  const autoLoadedRef = useRef(false);
+  useEffect(() => {
+    autoLoadedRef.current = false;
+    prevBatchRef.current = null;
+    setAutoTelegram(false);
+    setAutoStatus(null);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (autoLoadedRef.current) return;
+    fetch("/api/config")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (!cfg) return;
+        const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+        if (entry?.telegram_auto) setAutoTelegram(true);
+        autoLoadedRef.current = true;
+      })
+      .catch(() => {});
+  }, [projectId]);
 
   const load = useCallback(async () => {
     try {
@@ -135,8 +170,84 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
     await load();
   };
 
+  // #518: toggle handler — persist telegram_auto in project config
+  const toggleAutoTelegram = useCallback(async () => {
+    const next = !autoTelegram;
+    setAutoTelegram(next);
+    if (!next) {
+      setAutoStatus(null);
+      prevBatchRef.current = null;
+    }
+    try {
+      const r = await fetch("/api/config");
+      if (!r.ok) return;
+      const cfg = await r.json();
+      const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+      if (entry) {
+        entry.telegram_auto = next;
+        await fetch("/api/config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(cfg),
+        });
+      }
+    } catch { /* non-fatal */ }
+  }, [autoTelegram, projectId]);
+
+  // #518: batch lifecycle polling — auto-start/stop bridge with batch
+  const AUTO_POLL_MS = 30_000;
+
+  const checkBatchLifecycle = useCallback(async () => {
+    if (!autoTelegramRef.current) return;
+    try {
+      const r = await fetch(`/api/batch-progress?project=${encodeURIComponent(projectId)}`);
+      if (!r.ok) return;
+      const data: BatchState = await r.json();
+      const hasItems = data.items.length > 0;
+      const prev = prevBatchRef.current;
+      prevBatchRef.current = { complete: data.complete, hasItems };
+
+      if (!prev) {
+        if (hasItems && !data.complete && !runningRef.current) {
+          setAutoStatus("Batch active — auto-starting bridge.");
+          await callTelegram("start", { project_id: projectId }).catch(() => {});
+          await load();
+        }
+        if (hasItems && data.complete && runningRef.current) {
+          setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+          await callTelegram("stop", { project_id: projectId }).catch(() => {});
+          await load();
+        }
+        return;
+      }
+
+      // Batch just completed → auto-stop
+      if (hasItems && data.complete && !prev.complete && runningRef.current) {
+        setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+        await callTelegram("stop", { project_id: projectId }).catch(() => {});
+        await load();
+        return;
+      }
+
+      // New batch started → auto-start
+      if (hasItems && !data.complete && (prev.complete || !prev.hasItems) && !runningRef.current) {
+        setAutoStatus("New batch detected — auto-starting bridge.");
+        await callTelegram("start", { project_id: projectId }).catch(() => {});
+        await load();
+      }
+    } catch { /* non-fatal */ }
+  }, [projectId, load]);
+
+  useEffect(() => {
+    if (!autoTelegram) return;
+    checkBatchLifecycle();
+    const id = window.setInterval(checkBatchLifecycle, AUTO_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [autoTelegram, checkBatchLifecycle]);
+
   const configured = !!status?.configured;
   const running = !!status?.running;
+  useEffect(() => { runningRef.current = running; }, [running]);
   // #372: show, in preference order, the most recent actionable
   // error: the operator's last Start/Stop failure, then a poll
   // failure, then the server-side log tail from a crashed bridge.
@@ -155,9 +266,25 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
               <b>Telegram Bridge</b> forwards AgentChattr messages to a Telegram bot so you can monitor from your phone. Bidirectional — replies from Telegram appear in chat.
             </InfoTooltip>
           </div>
-          {displayError && (
-            <span className="text-[10px] text-error">error</span>
-          )}
+          <div className="flex items-center gap-1.5">
+            {configured && (
+              <button
+                type="button"
+                onClick={toggleAutoTelegram}
+                title={autoTelegram ? "Auto ON — bridge follows batch lifecycle" : "Auto OFF — manual start/stop only"}
+                className={`px-1.5 py-0.5 text-[10px] border transition-colors ${
+                  autoTelegram
+                    ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
+                    : "border-border text-text-muted hover:text-text hover:border-accent"
+                }`}
+              >
+                Auto {autoTelegram ? "●" : "○"}
+              </button>
+            )}
+            {displayError && (
+              <span className="text-[10px] text-error">error</span>
+            )}
+          </div>
         </div>
         <div className="p-3 flex flex-col gap-2">
           {!configured ? (
@@ -243,6 +370,11 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
               >
                 dismiss
               </button>
+            </div>
+          )}
+          {autoStatus && (
+            <div className="mt-1 text-[10px] text-accent">
+              {autoStatus}
             </div>
           )}
           {displayError && (


### PR DESCRIPTION
## Summary

- Adds **Auto** toggle button to both Telegram and Discord bridge widgets, following the same pattern as Scheduled Trigger (`trigger_auto`, #408) and Keep Mac Awake (`awake_auto`, #441)
- When Auto is ON: bridge auto-starts when a batch becomes active, auto-stops within 30s when all items merge/close, and stays ON waiting for the next batch
- Server-side `autoStopBridges()` helper in `server/index.js` ensures bridges stop even when the operator is viewing a different project page
- Config persisted as `telegram_auto` / `discord_auto` per project entry

## Files changed

- `src/components/TelegramBridgeWidget.tsx` — Auto toggle UI + 30s batch-progress polling
- `src/components/DiscordBridgeWidget.tsx` — same pattern
- `server/index.js` — `autoStopBridges()` helper, extended `sendTriggerMessage` and `autoStopPollingTick`

## Test plan

- [ ] Toggle Auto ON for Telegram bridge — verify toggle persists in config (`/api/config`)
- [ ] Toggle Auto ON for Discord bridge — same
- [ ] Start a batch with Auto ON — verify bridges auto-start within 30s
- [ ] Complete a batch (merge all items) — verify bridges auto-stop within 30s
- [ ] Verify server-side stop works when operator is on a different project page
- [ ] Toggle Auto OFF — verify bridge stays running (manual control)
- [ ] Auto toggle only appears when bridge is configured

Fixes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)