### PR TITLE
[#522] Clear stale error logs on bridge stop

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2830,6 +2830,9 @@ router.post("/api/telegram", async (req, res) => {
           if (pid) process.kill(pid, "SIGTERM");
           fs.unlinkSync(pf);
         }
+        // #522: clear bridge log so last_error doesn't show stale
+        // connection-refused messages after an intentional stop.
+        try { fs.writeFileSync(telegramBridgeLog(projectId), ""); } catch {}
         return res.json({ ok: true, running: false });
       } catch (err) {
         return res.json({ ok: false, error: err.message || "Stop failed" });
@@ -3238,6 +3241,9 @@ router.post("/api/discord", async (req, res) => {
           if (pid) process.kill(pid, "SIGTERM");
           fs.unlinkSync(pf);
         }
+        // #522: clear bridge log so last_error doesn't show stale
+        // connection-refused messages after an intentional stop.
+        try { fs.writeFileSync(discordBridgeLog(projectId), ""); } catch {}
         return res.json({ ok: true, running: false });
       } catch (err) {
         return res.json({ ok: false, error: err.message || "Stop failed" });

--- a/src/components/DiscordBridgeWidget.tsx
+++ b/src/components/DiscordBridgeWidget.tsx
@@ -227,7 +227,7 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
   const configured = !!status?.configured;
   const running = !!status?.running;
   useEffect(() => { runningRef.current = running; }, [running]);
-  // #522: suppress last_error when bridge was intentionally stopped
+  // #522: suppress last_error when bridge was auto-stopped
   const suppressLastError = !running && !!autoStatus;
   const displayError = actionError || pollError || (!running && !suppressLastError && status?.last_error) || "";
 

--- a/src/components/DiscordBridgeWidget.tsx
+++ b/src/components/DiscordBridgeWidget.tsx
@@ -192,6 +192,7 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
         }
         if (hasItems && data.complete && runningRef.current) {
           setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+          setActionError(null); // #522: clear stale action errors on auto-stop
           await callDiscord("stop", { project_id: projectId }).catch(() => {});
           await load();
         }
@@ -201,6 +202,7 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
       // Batch just completed → auto-stop
       if (hasItems && data.complete && !prev.complete && runningRef.current) {
         setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+        setActionError(null); // #522: clear stale action errors on auto-stop
         await callDiscord("stop", { project_id: projectId }).catch(() => {});
         await load();
         return;
@@ -225,7 +227,9 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
   const configured = !!status?.configured;
   const running = !!status?.running;
   useEffect(() => { runningRef.current = running; }, [running]);
-  const displayError = actionError || pollError || (!running && status?.last_error) || "";
+  // #522: suppress last_error when bridge was intentionally stopped
+  const suppressLastError = !running && !!autoStatus;
+  const displayError = actionError || pollError || (!running && !suppressLastError && status?.last_error) || "";
 
   return (
     <>

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -256,9 +256,9 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
   // Rendered as a dedicated multi-line block below the controls
   // (not a truncated span in the header) so long Python tracebacks
   // from dep-check / spawn failures are actually readable.
-  // #522: suppress last_error when bridge was intentionally stopped
-  // (auto-stop or manual stop) — stale connection-refused logs are not
-  // relevant after the bridge has been deliberately paused.
+  // #522: suppress last_error when bridge was auto-stopped — stale
+  // connection-refused logs are not relevant after the bridge has been
+  // deliberately paused. Manual stop is handled server-side (log truncation).
   const suppressLastError = !running && !!autoStatus;
   const displayError = actionError || pollError || (!running && !suppressLastError && status?.last_error) || "";
 

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -215,6 +215,7 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
         }
         if (hasItems && data.complete && runningRef.current) {
           setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+          setActionError(null); // #522: clear stale action errors on auto-stop
           await callTelegram("stop", { project_id: projectId }).catch(() => {});
           await load();
         }
@@ -224,6 +225,7 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
       // Batch just completed → auto-stop
       if (hasItems && data.complete && !prev.complete && runningRef.current) {
         setAutoStatus("Batch complete — bridge paused. Waiting for next batch.");
+        setActionError(null); // #522: clear stale action errors on auto-stop
         await callTelegram("stop", { project_id: projectId }).catch(() => {});
         await load();
         return;
@@ -254,7 +256,11 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
   // Rendered as a dedicated multi-line block below the controls
   // (not a truncated span in the header) so long Python tracebacks
   // from dep-check / spawn failures are actually readable.
-  const displayError = actionError || pollError || (!running && status?.last_error) || "";
+  // #522: suppress last_error when bridge was intentionally stopped
+  // (auto-stop or manual stop) — stale connection-refused logs are not
+  // relevant after the bridge has been deliberately paused.
+  const suppressLastError = !running && !!autoStatus;
+  const displayError = actionError || pollError || (!running && !suppressLastError && status?.last_error) || "";
 
   return (
     <>


### PR DESCRIPTION
## Summary

- **Server**: Truncate bridge log file (`tg-bridge-*.log` / `dc-bridge-*.log`) on stop action, so `last_error` returns empty on the next status poll instead of showing stale connection-refused messages
- **Client**: Suppress `last_error` display when an `autoStatus` message is active (intentional auto-stop), preventing the red error badge from appearing alongside "Batch complete — bridge paused"
- **Client**: Clear `actionError` state when auto-stop fires, so old operator errors don't linger

Fixes #522

## Test plan

- [ ] Enable Auto toggle on Telegram/Discord bridge, run a batch to completion
- [ ] Verify widget shows "Batch complete — bridge paused" with NO red error badge
- [ ] Verify bridge log file is empty after stop (`cat ~/.quadwork/tg-bridge-*.log`)
- [ ] Manual Stop → verify no stale errors shown
- [ ] Start bridge, kill the process externally → verify real crash error still displays correctly
- [ ] Verify auto-start on new batch still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)