### PR TITLE
[#523] Inline system message filter toggle in chat header

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -126,28 +126,17 @@ function renderMessageWithMentions(text: string): React.ReactNode[] {
  */
 interface ChatPanelProps {
   projectId?: string;
+  /** #523: filter state lifted to parent so toggle renders in PanelHeader */
+  filterSystem?: boolean;
 }
 
-export default function ChatPanel({ projectId }: ChatPanelProps) {
-  return <ChatPanelAPI projectId={projectId} />;
+export default function ChatPanel({ projectId, filterSystem }: ChatPanelProps) {
+  return <ChatPanelAPI projectId={projectId} filterSystem={filterSystem} />;
 }
 
 /** API-driven fallback when iframe is blocked */
-function ChatPanelAPI({ projectId }: { projectId?: string }) {
+function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string; filterSystem?: boolean }) {
   const channel = "general";
-  // #519: filter toggle — hide system/status messages. Persisted in
-  // localStorage (per-browser, not per-project). Default: OFF.
-  const [filterSystem, setFilterSystem] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem("chatFilterSystem") === "1";
-  });
-  const toggleFilter = useCallback(() => {
-    setFilterSystem((prev) => {
-      const next = !prev;
-      localStorage.setItem("chatFilterSystem", next ? "1" : "0");
-      return next;
-    });
-  }, []);
   const [messages, setMessages] = useState<Message[]>([]);
   // #410: track whether the initial fetch has completed so we don't
   // flash the welcome/empty state while messages are still loading.
@@ -417,21 +406,6 @@ function ChatPanelAPI({ projectId }: { projectId?: string }) {
 
   return (
     <div className="flex flex-col h-full bg-bg">
-      {/* #519: filter toggle header */}
-      <div className="flex items-center justify-end h-7 px-3 shrink-0 border-b border-border">
-        <button
-          type="button"
-          onClick={toggleFilter}
-          title={filterSystem ? "Showing agent messages only — click to show all" : "Showing all messages — click to hide system/status noise"}
-          className={`px-1.5 py-0.5 text-[10px] border transition-colors ${
-            filterSystem
-              ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
-              : "border-border text-text-muted hover:text-text hover:border-accent"
-          }`}
-        >
-          {filterSystem ? "Agents only" : "All messages"}
-        </button>
-      </div>
       {/* Auth error banner */}
       {authError && (
         <div className="px-3 py-2 bg-red-900/30 border-b border-red-700/50 text-[11px] text-red-400">

--- a/src/components/PanelHeader.tsx
+++ b/src/components/PanelHeader.tsx
@@ -10,9 +10,11 @@ interface PanelHeaderProps {
   onStatusChange?: (newStatus: string) => void;
   /** #407: optional info tooltip element rendered after the label */
   tooltip?: React.ReactNode;
+  /** #523: optional right-aligned content (e.g. toggle switches) */
+  children?: React.ReactNode;
 }
 
-export default function PanelHeader({ label, status, projectId, agentId, onStatusChange, tooltip }: PanelHeaderProps) {
+export default function PanelHeader({ label, status, projectId, agentId, onStatusChange, tooltip, children }: PanelHeaderProps) {
   const dotColor =
     status === "running"
       ? "bg-accent"
@@ -45,35 +47,38 @@ export default function PanelHeader({ label, status, projectId, agentId, onStatu
         </span>
         {tooltip}
       </div>
-      {showControls && (
-        <div className="flex items-center gap-1">
-          {status !== "running" && (
+      <div className="flex items-center gap-1.5">
+        {children}
+        {showControls && (
+          <>
+            {status !== "running" && (
+              <button
+                onClick={() => lifecycleAction("start")}
+                className="text-[10px] text-text-muted hover:text-accent transition-colors px-1"
+                title="Start"
+              >
+                ▶
+              </button>
+            )}
+            {status === "running" && (
+              <button
+                onClick={() => lifecycleAction("stop")}
+                className="text-[10px] text-text-muted hover:text-error transition-colors px-1"
+                title="Stop"
+              >
+                ■
+              </button>
+            )}
             <button
-              onClick={() => lifecycleAction("start")}
+              onClick={() => lifecycleAction("restart")}
               className="text-[10px] text-text-muted hover:text-accent transition-colors px-1"
-              title="Start"
+              title="Restart"
             >
-              ▶
+              ↻
             </button>
-          )}
-          {status === "running" && (
-            <button
-              onClick={() => lifecycleAction("stop")}
-              className="text-[10px] text-text-muted hover:text-error transition-colors px-1"
-              title="Stop"
-            >
-              ■
-            </button>
-          )}
-          <button
-            onClick={() => lifecycleAction("restart")}
-            className="text-[10px] text-text-muted hover:text-accent transition-colors px-1"
-            title="Restart"
-          >
-            ↻
-          </button>
-        </div>
-      )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import PanelHeader from "./PanelHeader";
 import InfoTooltip from "./InfoTooltip";
 import ChatPanel from "./ChatPanel";
@@ -24,6 +24,34 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
   const [rowRatio, setRowRatio] = useState(0.5);
   const dragging = useRef<"col" | "row" | null>(null);
   const [agentStates, setAgentStates] = useState<Record<string, AgentState>>({});
+
+  // #523: system message filter — lifted here so the toggle renders
+  // inline in PanelHeader while ChatPanel consumes the value.
+  const [filterSystem, setFilterSystem] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem("chatFilterSystem") === "1";
+  });
+  const toggleFilter = useCallback(() => {
+    setFilterSystem((prev) => {
+      const next = !prev;
+      localStorage.setItem("chatFilterSystem", next ? "1" : "0");
+      return next;
+    });
+  }, []);
+  const filterToggle = useMemo(() => (
+    <button
+      type="button"
+      onClick={toggleFilter}
+      title={filterSystem ? "Showing agent messages only — click to show all" : "Showing all messages — click to hide system/status noise"}
+      className={`px-1.5 py-0.5 text-[10px] border transition-colors ${
+        filterSystem
+          ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
+          : "border-border text-text-muted hover:text-text hover:border-accent"
+      }`}
+    >
+      {filterSystem ? "Agents ●" : "All ○"}
+    </button>
+  ), [filterSystem, toggleFilter]);
 
   // Poll agent states
   useEffect(() => {
@@ -117,9 +145,11 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
           <InfoTooltip>
             <b>Primary Chat</b> — live chat between you and the 4 AI agents. Messages you type here trigger agent actions. Use @mentions to address specific agents.
           </InfoTooltip>
-        } />
+        }>
+          {filterToggle}
+        </PanelHeader>
         <div className="flex-1 min-h-0">
-          <ChatPanel projectId={projectId} />
+          <ChatPanel projectId={projectId} filterSystem={filterSystem} />
         </div>
         <ControlBar projectId={projectId} />
       </div>


### PR DESCRIPTION
## Summary

- Lifts filter state from `ChatPanel` to `ProjectDashboard` so the toggle renders inline in the `PanelHeader` row (same line as "AgentChattr — primary chat")
- Removes the separate filter row that previously added an extra line above the chat
- Adds `children` prop to `PanelHeader` for right-aligned content
- Toggle label changed from "All messages" / "Agents only" to compact "All ○" / "Agents ●" matching existing Auto/Sound button patterns

Fixes #523

## Test plan

- [ ] Toggle visible in the chat panel header row, right-aligned
- [ ] No extra row/line above the chat messages
- [ ] Click toggles between "All ○" and "Agents ●"
- [ ] System messages hidden when "Agents ●" is active
- [ ] Filter persists across page reloads (localStorage)
- [ ] Other PanelHeader instances (GitHub, Operator Features) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)