### PR TITLE
[#524] Make sidebar fold/unfold toggle discoverable

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -375,19 +375,6 @@ export default function Sidebar() {
         expanded ? "w-52 items-stretch px-2" : "w-16 items-center"
       }`}
     >
-      {/* Toggle — hidden on mobile */}
-      <button
-        onClick={toggleExpanded}
-        className={`hidden md:flex shrink-0 items-center justify-center w-8 h-8 rounded-sm text-text-muted hover:text-text hover:bg-[#1a1a1a] transition-colors ${
-          expanded ? "self-end mr-0" : "self-center"
-        }`}
-        title={expanded ? "Collapse sidebar" : "Expand sidebar"}
-      >
-        {expanded ? <CollapseIcon /> : <ExpandIcon />}
-      </button>
-
-      <div className="h-1" />
-
       {/* Home */}
       <Link
         href="/"
@@ -607,6 +594,19 @@ export default function Sidebar() {
           )}
         </div>
       )}
+
+      {/* #524: expand/collapse toggle — moved to bottom, larger + bordered */}
+      <button
+        onClick={toggleExpanded}
+        className={`flex shrink-0 items-center justify-center w-10 h-10 rounded-sm border border-border text-text-muted hover:text-accent hover:border-accent/50 transition-colors ${
+          expanded ? "self-end" : "self-center"
+        }`}
+        title={expanded ? "Collapse sidebar" : "Expand sidebar"}
+      >
+        {expanded ? <CollapseIcon /> : <ExpandIcon />}
+      </button>
+
+      <div className="h-1" />
 
       {/* Settings */}
       <Link


### PR DESCRIPTION
## Summary

- Moved expand/collapse toggle from top of sidebar to bottom (above settings gear), matching Option A layout from the issue
- Increased button size from `w-8 h-8` to `w-10 h-10`
- Added `border border-border` for a visible boundary
- Added `hover:text-accent hover:border-accent/50` for clear hover feedback
- Removed `hidden md:flex` — toggle now visible on all viewports

Fixes #524

## Test plan

- [ ] Toggle button clearly visible at bottom of collapsed sidebar (above gear icon)
- [ ] Toggle button visible at bottom of expanded sidebar
- [ ] Click expands/collapses sidebar correctly
- [ ] Hover shows accent color on both icon and border
- [ ] Visible on mobile-width viewports
- [ ] State persists in localStorage across page reloads
- [ ] Keyboard accessible (Tab + Enter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)