### PR TITLE
[#540] Harden file and directory permissions for local secrets

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -29,6 +29,12 @@ const AGENTCHATTR_PIN = "3e71d4267572579e7ffeb83576645f90932c1849";
 // #444: same pattern for realproject7/agentchattr-telegram.
 const AGENTCHATTR_TELEGRAM_PIN = "4a6b45f1794c612328b9d5ee6d6fcb3f77015abc";
 
+// ─── Permission Helpers ────────────────────────────────────────────────────
+
+function ensureSecureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
 // ─── ANSI Helpers ──────────────────────────────────────────────────────────
 
 const isTTY = process.stdout.isTTY;
@@ -156,7 +162,7 @@ function installAgentChattr(dir) {
   // other when two projects (or two web tabs) launch simultaneously. Lock
   // file lives next to the install dir so it's scoped per-target.
   const lockFile = `${dir}.install.lock`;
-  try { fs.mkdirSync(path.dirname(lockFile), { recursive: true }); }
+  try { ensureSecureDir(path.dirname(lockFile)); }
   catch (e) { return setError(`Cannot create parent of ${dir}: ${e.message}`); }
 
   let acquired = false;
@@ -164,7 +170,7 @@ function installAgentChattr(dir) {
   while (!acquired) {
     try {
       // Atomic create: fails if file already exists, no TOCTOU race.
-      fs.writeFileSync(lockFile, `${process.pid}:${Date.now()}`, { flag: "wx" });
+      fs.writeFileSync(lockFile, `${process.pid}:${Date.now()}`, { mode: 0o600, flag: "wx" });
       acquired = true;
     } catch (e) {
       if (e.code !== "EEXIST") return setError(`Cannot create install lock ${lockFile}: ${e.message}`);
@@ -243,7 +249,7 @@ function _installAgentChattrLocked(dir, setError) {
       }
     }
     // Ensure parent exists before clone (supports arbitrary nested paths).
-    try { fs.mkdirSync(path.dirname(dir), { recursive: true }); }
+    try { ensureSecureDir(path.dirname(dir)); }
     catch (e) { return setError(`Cannot create parent of ${dir}: ${e.message}`); }
     const cloneResult = run("git", ["clone", AGENTCHATTR_REPO, dir], { timeout: 60000 });
     if (cloneResult === null) return setError(`git clone of ${AGENTCHATTR_REPO} into ${dir} failed`);
@@ -410,8 +416,8 @@ function readConfig() {
 }
 
 function writeConfig(config) {
-  if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true });
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+  if (!fs.existsSync(CONFIG_DIR)) ensureSecureDir(CONFIG_DIR);
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 });
 }
 
 // ─── Prerequisites ──────────────────────────────────────────────────────────
@@ -971,7 +977,7 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
 
   // Per-project: isolated data dir and port
   const dataDir = path.join(path.dirname(configTomlPath), "data");
-  if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+  if (!fs.existsSync(dataDir)) ensureSecureDir(dataDir);
   // Read assigned port from config (set by writeQuadWorkConfig)
   const existingConfig = readConfig();
   const existingProject = existingConfig.projects?.find((p) => p.id === setup.projectName);
@@ -992,7 +998,7 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
 
   // Write config.toml
   const configDir = path.dirname(configTomlPath);
-  if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+  if (!fs.existsSync(configDir)) ensureSecureDir(configDir);
   fs.writeFileSync(configTomlPath, tomlContent);
   ok(`Wrote ${configTomlPath}`);
 
@@ -1035,7 +1041,7 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
       acProc.unref();
       if (acProc.pid) {
         ok(`AgentChattr started (PID: ${acProc.pid})`);
-        if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true });
+        if (!fs.existsSync(CONFIG_DIR)) ensureSecureDir(CONFIG_DIR);
         const pidFile = path.join(CONFIG_DIR, `agentchattr-${setup.projectName}.pid`);
         fs.writeFileSync(pidFile, String(acProc.pid));
       } else {
@@ -1196,7 +1202,7 @@ function writeOvernightQueueFile(projectName, repo) {
   const queueDir = path.join(CONFIG_DIR, projectName);
   const queuePath = path.join(queueDir, "OVERNIGHT-QUEUE.md");
   if (fs.existsSync(queuePath)) return false;
-  try { fs.mkdirSync(queueDir, { recursive: true }); }
+  try { ensureSecureDir(queueDir); }
   catch (e) { warn(`Could not create ${queueDir}: ${e.message}`); return false; }
   const templatePath = path.join(TEMPLATES_DIR, "OVERNIGHT-QUEUE.md");
   if (!fs.existsSync(templatePath)) {

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -33,6 +33,7 @@ const AGENTCHATTR_TELEGRAM_PIN = "4a6b45f1794c612328b9d5ee6d6fcb3f77015abc";
 
 function ensureSecureDir(dir) {
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(dir, 0o700); } catch {}
 }
 
 // ─── ANSI Helpers ──────────────────────────────────────────────────────────
@@ -418,6 +419,7 @@ function readConfig() {
 function writeConfig(config) {
   if (!fs.existsSync(CONFIG_DIR)) ensureSecureDir(CONFIG_DIR);
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 });
+  try { fs.chmodSync(CONFIG_PATH, 0o600); } catch {}
 }
 
 // ─── Prerequisites ──────────────────────────────────────────────────────────

--- a/server/config.js
+++ b/server/config.js
@@ -209,14 +209,18 @@ async function syncChattrToken(projectId) {
 // chat exports). Use these helpers instead of raw fs calls to ensure
 // restrictive permissions on multi-user systems.
 
-/** Create a directory with 0o700 (owner-only). */
+/** Create a directory with 0o700 (owner-only). Hardens existing dirs too. */
 function ensureSecureDir(dir) {
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // mkdirSync mode only applies on creation — chmod existing dirs.
+  try { fs.chmodSync(dir, 0o700); } catch {}
 }
 
-/** Write a file with 0o600 (owner-only read/write). */
+/** Write a file with 0o600 (owner-only read/write). Hardens existing files too. */
 function writeSecureFile(filePath, data, extraOpts = {}) {
   fs.writeFileSync(filePath, data, { mode: 0o600, ...extraOpts });
+  // writeFileSync mode only applies on creation — chmod existing files.
+  try { fs.chmodSync(filePath, 0o600); } catch {}
 }
 
 /** Write config.json atomically with 0o600 permissions. */

--- a/server/config.js
+++ b/server/config.js
@@ -74,7 +74,7 @@ function migrateAgentKeys(config) {
   }
   if (changed) {
     try {
-      fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+      writeSecureFile(CONFIG_PATH, JSON.stringify(config, null, 2));
     } catch {}
   }
   return config;
@@ -89,9 +89,9 @@ function readConfig() {
       // Config file doesn't exist — create default
       const dir = path.dirname(CONFIG_PATH);
       if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
+        ensureSecureDir(dir);
       }
-      fs.writeFileSync(CONFIG_PATH, JSON.stringify(DEFAULT_CONFIG, null, 2));
+      writeSecureFile(CONFIG_PATH, JSON.stringify(DEFAULT_CONFIG, null, 2));
       return { ...DEFAULT_CONFIG };
     }
     throw new Error(`Cannot read config at ${CONFIG_PATH}: ${err.message}`);
@@ -198,10 +198,30 @@ async function syncChattrToken(projectId) {
       const realToken = match[1];
       if (project.agentchattr_token !== realToken) {
         project.agentchattr_token = realToken;
-        fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+        writeSecureFile(CONFIG_PATH, JSON.stringify(config, null, 2));
       }
     }
   } catch {}
 }
 
-module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, sanitizeOperatorName, CONFIG_PATH };
+// --- #540: Secure file/directory helpers ---
+// All paths under ~/.quadwork/ may contain secrets (tokens, configs,
+// chat exports). Use these helpers instead of raw fs calls to ensure
+// restrictive permissions on multi-user systems.
+
+/** Create a directory with 0o700 (owner-only). */
+function ensureSecureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+/** Write a file with 0o600 (owner-only read/write). */
+function writeSecureFile(filePath, data, extraOpts = {}) {
+  fs.writeFileSync(filePath, data, { mode: 0o600, ...extraOpts });
+}
+
+/** Write config.json atomically with 0o600 permissions. */
+function writeConfig(cfg) {
+  writeSecureFile(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+}
+
+module.exports = { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, sanitizeOperatorName, CONFIG_PATH, ensureSecureDir, writeSecureFile, writeConfig };

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const os = require("os");
 const { WebSocketServer } = require("ws");
 const pty = require("node-pty");
 const { spawn } = require("child_process");
-const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH } = require("./config");
+const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH, ensureSecureDir, writeSecureFile, writeConfig } = require("./config");
 const routes = require("./routes");
 const {
   patchAgentchattrConfigForDiscordBridge,
@@ -264,8 +264,8 @@ function readPersistedAgentToken(projectId, agentId) {
 function writePersistedAgentToken(projectId, agentId, token) {
   try {
     const configDir = path.join(os.homedir(), ".quadwork", projectId);
-    if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(_agentTokenPath(projectId, agentId), token, { mode: 0o600 });
+    ensureSecureDir(configDir);
+    writeSecureFile(_agentTokenPath(projectId, agentId), token);
   } catch {
     // non-fatal — stale-slot reclaim will degrade but registration still works
   }
@@ -278,7 +278,7 @@ function clearPersistedAgentToken(projectId, agentId) {
 function writeMcpConfigFile(projectId, agentId, mcpHttpPort, token) {
   const os = require("os");
   const configDir = path.join(os.homedir(), ".quadwork", projectId);
-  if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+  ensureSecureDir(configDir);
   const filePath = path.join(configDir, `mcp-${agentId}.json`);
   const url = `http://127.0.0.1:${mcpHttpPort}/mcp`;
   const config = {
@@ -290,7 +290,7 @@ function writeMcpConfigFile(projectId, agentId, mcpHttpPort, token) {
       },
     },
   };
-  fs.writeFileSync(filePath, JSON.stringify(config, null, 2));
+  writeSecureFile(filePath, JSON.stringify(config, null, 2));
   return filePath;
 }
 
@@ -431,7 +431,7 @@ function buildAgentEnv(projectId, agentId) {
   if (cliBase === "gemini" && project.mcp_http_port) {
     const os = require("os");
     const configDir = path.join(os.homedir(), ".quadwork", projectId);
-    if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+    ensureSecureDir(configDir);
     const settingsPath = path.join(configDir, `mcp-${agentId}-settings.json`);
     const url = `http://127.0.0.1:${project.mcp_http_port}/mcp`;
     const settings = {
@@ -443,7 +443,7 @@ function buildAgentEnv(projectId, agentId) {
         },
       },
     };
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    writeSecureFile(settingsPath, JSON.stringify(settings, null, 2));
     env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = settingsPath;
   }
 
@@ -731,7 +731,7 @@ const HISTORY_SNAPSHOT_LIMIT = 5;
 async function snapshotProjectHistory(projectId) {
   try {
     const snapDir = path.join(require("os").homedir(), ".quadwork", projectId, "history-snapshots");
-    if (!fs.existsSync(snapDir)) fs.mkdirSync(snapDir, { recursive: true });
+    ensureSecureDir(snapDir);
     const res = await fetch(`http://127.0.0.1:${PORT}/api/project-history?project=${encodeURIComponent(projectId)}`, {
       signal: AbortSignal.timeout(30000),
     });
@@ -810,7 +810,7 @@ async function handleAgentChattr(req, res) {
     try {
       let content = fs.readFileSync(projectConfigToml, "utf-8");
       content = content.replace(/^port = \d+/m, `port = ${chattrPort}`);
-      fs.writeFileSync(projectConfigToml, content);
+      writeSecureFile(projectConfigToml, content);
     } catch {}
   }
 
@@ -1532,7 +1532,7 @@ app.post("/api/triggers/:project/start", (req, res) => {
       if (typeof message === "string" && message.length > 0) entry.trigger_message = message;
       if (Number.isFinite(interval) && interval > 0) entry.trigger_interval_min = interval;
       if (Number.isFinite(duration) && duration >= 0) entry.trigger_duration_min = duration;
-      fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+      writeConfig(cfg);
     }
   } catch (e) { /* non-fatal — timer still runs with its in-memory values */ }
 
@@ -1623,7 +1623,7 @@ app.put("/api/queue", express.json({ limit: "512kb" }), (req, res) => {
   if (content === null) return res.status(400).json({ error: "Missing content" });
   const p = queuePathFor(projectId);
   try {
-    fs.mkdirSync(path.dirname(p), { recursive: true });
+    ensureSecureDir(path.dirname(p));
     fs.writeFileSync(p, content);
     return res.json({ ok: true });
   } catch (e) { return res.status(500).json({ error: e.message }); }
@@ -1641,7 +1641,7 @@ app.post("/api/queue", (req, res) => {
     let content = fs.readFileSync(tpl, "utf-8");
     content = content.replace(/\{\{project_name\}\}/g, project.name || projectId);
     content = content.replace(/\{\{repo\}\}/g, project.repo || "");
-    fs.mkdirSync(path.dirname(p), { recursive: true });
+    ensureSecureDir(path.dirname(p));
     fs.writeFileSync(p, content);
     return res.json({ ok: true, existed: false });
   } catch (e) { return res.status(500).json({ error: e.message }); }

--- a/server/install-agentchattr.js
+++ b/server/install-agentchattr.js
@@ -102,14 +102,14 @@ function installAgentChattr(dir) {
 
   // --- Per-target lock ---
   const lockFile = `${dir}.install.lock`;
-  try { fs.mkdirSync(path.dirname(lockFile), { recursive: true }); }
+  try { fs.mkdirSync(path.dirname(lockFile), { recursive: true, mode: 0o700 }); }
   catch (e) { return setError(`Cannot create parent of ${dir}: ${e.message}`); }
 
   let acquired = false;
   const deadline = Date.now() + INSTALL_LOCK_WAIT_TOTAL_MS;
   while (!acquired) {
     try {
-      fs.writeFileSync(lockFile, `${process.pid}:${Date.now()}`, { flag: "wx" });
+      fs.writeFileSync(lockFile, `${process.pid}:${Date.now()}`, { mode: 0o600, flag: "wx" });
       acquired = true;
     } catch (e) {
       if (e.code !== "EEXIST") return setError(`Cannot create install lock ${lockFile}: ${e.message}`);
@@ -169,7 +169,7 @@ function _installAgentChattrLocked(dir, setError) {
         return setError(`Refusing to overwrite ${dir}: directory exists with unrelated content`);
       }
     }
-    try { fs.mkdirSync(path.dirname(dir), { recursive: true }); }
+    try { fs.mkdirSync(path.dirname(dir), { recursive: true, mode: 0o700 }); }
     catch (e) { return setError(`Cannot create parent of ${dir}: ${e.message}`); }
     const cloneResult = _run("git", ["clone", AGENTCHATTR_REPO, dir], { timeout: 60000 });
     if (cloneResult === null) return setError(`git clone of ${AGENTCHATTR_REPO} into ${dir} failed`);

--- a/server/install-agentchattr.js
+++ b/server/install-agentchattr.js
@@ -110,6 +110,7 @@ function installAgentChattr(dir) {
   while (!acquired) {
     try {
       fs.writeFileSync(lockFile, `${process.pid}:${Date.now()}`, { mode: 0o600, flag: "wx" });
+      try { fs.chmodSync(lockFile, 0o600); } catch {}
       acquired = true;
     } catch (e) {
       if (e.code !== "EEXIST") return setError(`Cannot create install lock ${lockFile}: ${e.message}`);

--- a/server/routes.js
+++ b/server/routes.js
@@ -36,8 +36,8 @@ function readConfigFile() {
 
 function writeConfigFile(cfg) {
   const dir = path.dirname(CONFIG_PATH);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+  ensureSecureDir(dir);
+  writeConfig(cfg);
 }
 
 // ─── Config ────────────────────────────────────────────────────────────────
@@ -66,8 +66,8 @@ router.put("/api/config", (req, res) => {
   try {
     const body = req.body;
     const dir = path.dirname(CONFIG_PATH);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(CONFIG_PATH, JSON.stringify(body, null, 2));
+    ensureSecureDir(dir);
+    writeConfig(body);
     // Trigger sync is handled internally since we're in the same process now
     if (typeof req.app.get("syncTriggers") === "function") {
       req.app.get("syncTriggers")();
@@ -80,7 +80,7 @@ router.put("/api/config", (req, res) => {
 
 // ─── Chat (AgentChattr proxy) ──────────────────────────────────────────────
 
-const { resolveProjectChattr, sanitizeOperatorName } = require("./config");
+const { resolveProjectChattr, sanitizeOperatorName, ensureSecureDir, writeSecureFile, writeConfig } = require("./config");
 const { installAgentChattr, findAgentChattr } = require("./install-agentchattr");
 
 /**
@@ -96,7 +96,7 @@ function writeOvernightQueueFileSafe(projectId, projectName, repo) {
     if (fs.existsSync(queuePath)) return;
     const tpl = path.join(TEMPLATES_DIR, "OVERNIGHT-QUEUE.md");
     if (!fs.existsSync(tpl)) return;
-    fs.mkdirSync(path.dirname(queuePath), { recursive: true });
+    ensureSecureDir(path.dirname(queuePath));
     let content = fs.readFileSync(tpl, "utf-8");
     content = content.replace(/\{\{project_name\}\}/g, projectName || projectId || "");
     content = content.replace(/\{\{repo\}\}/g, repo || "");
@@ -404,7 +404,7 @@ router.put("/api/loop-guard", async (req, res) => {
       const trailing = content.endsWith("\n") ? "" : "\n";
       content += `${trailing}\n[routing]\ndefault = "none"\nmax_agent_hops = ${value}\n`;
     }
-    fs.writeFileSync(tomlPath, content);
+    writeSecureFile(tomlPath, content);
   } catch (err) {
     return res.status(500).json({ error: "Failed to write config.toml", detail: err.message });
   }
@@ -838,7 +838,7 @@ router.post("/api/activity/log", (req, res) => {
   const row = { agent, start, end: ts, duration_ms: Math.max(0, ts - start) };
   try {
     const p = activityLogPath(project);
-    fs.mkdirSync(path.dirname(p), { recursive: true });
+    ensureSecureDir(path.dirname(p));
     fs.appendFileSync(p, JSON.stringify(row) + "\n");
     // Invalidate the stats cache so the next read sees the new row.
     _activityStatsCache.ts = 0;
@@ -1029,7 +1029,7 @@ const uploadStorage = multer.diskStorage({
     const projectId = req.query.project || "";
     if (!projectId || /[/\\]/.test(projectId)) return cb(new Error("Invalid project"));
     const dir = path.join(CONFIG_DIR, projectId, "uploads");
-    fs.mkdirSync(dir, { recursive: true });
+    ensureSecureDir(dir);
     cb(null, dir);
   },
   filename: (_req, file, cb) => {
@@ -1340,7 +1340,7 @@ function readBatchSnapshot(projectId) {
 function writeBatchSnapshot(projectId, snapshot) {
   try {
     const p = batchSnapshotPath(projectId);
-    fs.mkdirSync(path.dirname(p), { recursive: true });
+    ensureSecureDir(path.dirname(p));
     fs.writeFileSync(p, JSON.stringify(snapshot));
   } catch {
     // Non-fatal — panel still works from the live parse.
@@ -1850,8 +1850,8 @@ router.post("/api/setup/save-token", (req, res) => {
   if (!token) return res.status(400).json({ error: "Missing token" });
   const tokenPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
   const dir = path.dirname(tokenPath);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(tokenPath, token.trim() + "\n", { mode: 0o600 });
+  ensureSecureDir(dir);
+  writeSecureFile(tokenPath, token.trim() + "\n");
   try { fs.chmodSync(tokenPath, 0o600); } catch {}
   res.json({ ok: true, path: tokenPath });
 });
@@ -1890,7 +1890,7 @@ router.post("/api/setup", (req, res) => {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
       if (!fs.existsSync(path.join(workingDir, ".git"))) {
-        if (!fs.existsSync(workingDir)) fs.mkdirSync(workingDir, { recursive: true });
+        if (!fs.existsSync(workingDir)) ensureSecureDir(workingDir);
         if (!REPO_RE.test(body.repo)) return res.json({ ok: false, error: "Invalid repo" });
         const clone = exec("gh", ["repo", "clone", body.repo, workingDir]);
         if (!clone.ok) return res.json({ ok: false, error: `Clone failed: ${clone.output}` });
@@ -2026,7 +2026,7 @@ router.post("/api/setup", (req, res) => {
         }
       }
       const dataDir = path.join(projectConfigDir, "data");
-      fs.mkdirSync(dataDir, { recursive: true });
+      ensureSecureDir(dataDir);
       const tomlPath = path.join(projectConfigDir, "config.toml");
 
       // Resolve per-project ports: prefer explicit body params (from setup wizard),
@@ -2067,7 +2067,7 @@ router.post("/api/setup", (req, res) => {
       // operator to type /continue. AC clamps to [1, 50] internally.
       content += `[routing]\ndefault = "none"\nmax_agent_hops = 30\n\n`;
       content += `[mcp]\nhttp_port = ${mcp_http}\nsse_port = ${mcp_sse}\n`;
-      fs.writeFileSync(tomlPath, content);
+      writeSecureFile(tomlPath, content);
 
       // Restart this project's AgentChattr instance (not global)
       try {
@@ -2158,8 +2158,8 @@ router.post("/api/setup", (req, res) => {
         agentchattr_dir: perProjectDir,
       });
       const dir = path.dirname(CONFIG_PATH);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+      ensureSecureDir(dir);
+      writeConfig(cfg);
 
       // Batch 25 / #204: seed the per-project OVERNIGHT-QUEUE.md at
       // ~/.quadwork/{id}/OVERNIGHT-QUEUE.md.
@@ -2495,8 +2495,7 @@ function writeEnvToken(key, value) {
   const line = `${key}=${value}`;
   if (regex.test(content)) content = content.replace(regex, line);
   else content = content.trimEnd() + (content ? "\n" : "") + line + "\n";
-  fs.writeFileSync(ENV_PATH, content, { mode: 0o600 });
-  fs.chmodSync(ENV_PATH, 0o600);
+  writeSecureFile(ENV_PATH, content);
 }
 
 function resolveToken(value) {
@@ -2558,7 +2557,7 @@ router.get("/api/telegram", async (req, res) => {
         if (data && data.ok && data.result && typeof data.result.username === "string") {
           botUsername = data.result.username;
           project.telegram.bot_username = botUsername;
-          try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2)); } catch {}
+          try { writeConfig(cfg); } catch {}
         }
       }
     } catch { /* non-fatal — widget will just show no username */ }
@@ -2718,8 +2717,7 @@ router.post("/api/telegram", async (req, res) => {
       // #383 Bug 2: write agentchattr_url inside [telegram]; the
       // bridge's load_config only reads from that section.
       const tomlContent = buildTelegramBridgeToml(tg, projectId);
-      fs.writeFileSync(tomlPath, tomlContent, { mode: 0o600 });
-      fs.chmodSync(tomlPath, 0o600);
+      writeSecureFile(tomlPath, tomlContent);
       // #353: pre-flight import check so a fresh install with no
       // `requests` module produces a readable error instead of the
       // Start → Running → Stopped flicker that the v1 code path
@@ -2852,7 +2850,7 @@ router.post("/api/telegram", async (req, res) => {
         const project = cfg.projects?.find((p) => p.id === projectId);
         if (project?.telegram) {
           project.telegram.bot_token = `env:${envKey}`;
-          fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+          writeConfig(cfg);
         }
       } catch {}
       return res.json({ ok: true, env_key: envKey });
@@ -2885,7 +2883,7 @@ router.post("/api/telegram", async (req, res) => {
           // will re-fetch it from Telegram's getMe for the new token.
           bot_username: "",
         };
-        fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+        writeConfig(cfg);
         return res.json({ ok: true, env_key: envKey });
       } catch (err) {
         return res.json({ ok: false, error: err.message || "Config write failed" });
@@ -3030,7 +3028,7 @@ router.get("/api/discord", async (req, res) => {
           if (r.ok && data.username) {
             botUsername = data.username;
             project.discord.bot_username = botUsername;
-            try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2)); } catch {}
+            try { writeConfig(cfg); } catch {}
           }
         }
       } catch { /* non-fatal — widget will just show no username */ }
@@ -3088,7 +3086,7 @@ router.post("/api/discord", async (req, res) => {
         // #506: always copy bundled bridge files (not just on first install)
         // so re-installing after a QuadWork upgrade refreshes the script.
         if (!fs.existsSync(DISCORD_BRIDGE_DIR)) {
-          fs.mkdirSync(DISCORD_BRIDGE_DIR, { recursive: true });
+          ensureSecureDir(DISCORD_BRIDGE_DIR);
         }
         fs.cpSync(
           path.join(DISCORD_BRIDGE_SRC, "discord_bridge.py"),
@@ -3165,8 +3163,7 @@ router.post("/api/discord", async (req, res) => {
       if (!dc || !dc.bot_token || !dc.channel_id) return res.json({ ok: false, error: "Save bot_token and channel_id in project settings first." });
       const tomlPath = discordConfigToml(projectId);
       const tomlContent = buildDiscordBridgeToml(dc, projectId);
-      fs.writeFileSync(tomlPath, tomlContent, { mode: 0o600 });
-      fs.chmodSync(tomlPath, 0o600);
+      writeSecureFile(tomlPath, tomlContent);
       const depCheck = checkDiscordBridgePythonDeps(venvPython);
       if (!depCheck.ok) {
         const msg =
@@ -3273,7 +3270,7 @@ router.post("/api/discord", async (req, res) => {
           channel_id,
           bot_username: "",
         };
-        fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+        writeConfig(cfg);
         return res.json({ ok: true, env_key: envKey });
       } catch (err) {
         return res.json({ ok: false, error: err.message || "Config write failed" });
@@ -3345,7 +3342,7 @@ router.put("/api/project/:projectId/agent-models/:agentId", (req, res) => {
       else a.reasoning_effort = reasoning;
     }
     project.agents[agentId] = a;
-    fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+    writeConfig(cfg);
     return res.json({ ok: true, agent: { agent_id: agentId, model: a.model || "", reasoning_effort: a.reasoning_effort || "" } });
   } catch (err) {
     return res.json({ ok: false, error: err.message || "write failed" });


### PR DESCRIPTION
## Summary

Fixes #540 — security follow-up from audit #531, findings A4/F1/F4.

Adds `ensureSecureDir()` (mode `0o700`) and `writeSecureFile()` (mode `0o600`) helpers to `server/config.js`, then applies them across all secret-bearing write paths under `~/.quadwork/`.

### Changes by file
- **server/config.js** — New helpers + `writeConfig()` convenience function; internal writes converted
- **server/routes.js** — 11 mkdirSync → `ensureSecureDir`, 9 config writes → `writeConfig`, 2 toml writes → `writeSecureFile`, 4 already-secured writes unified
- **server/index.js** — 6 mkdirSync → `ensureSecureDir`, MCP/toml/settings writes → `writeSecureFile`, config write → `writeConfig`
- **bin/quadwork.js** — Inline `ensureSecureDir` helper, 7 mkdirSync converted, config.json and lock file writes secured
- **server/install-agentchattr.js** — 2 mkdirSync + lock file write secured

### Audit findings resolved
| Finding | Description | Resolution |
|---------|-------------|------------|
| A4 (MEDIUM) | MCP config files lack 0o600 | All MCP config writes use `writeSecureFile` |
| F1 (MEDIUM) | config.json written without permissions | All config writes use `writeConfig`/`writeSecureFile` (0o600) |
| F4 (MEDIUM-HIGH) | ~/.quadwork/ dirs created without mode | All dirs use `ensureSecureDir` (0o700) |

## Test plan
- [x] Syntax check passes on all 5 files
- [x] `next build` passes
- [ ] Manual: fresh `npx quadwork init` creates `~/.quadwork/` with 700 permissions
- [ ] Manual: `config.json` created with 600 permissions
- [ ] Manual: MCP config toml files created with 600 permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)