### PR TITLE
[#530] Rename chat filter toggle to 'Filter system log: on/off'

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -78,7 +78,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
           : "border-border text-text-muted hover:text-text hover:border-accent"
       }`}
     >
-      {filterSystem ? "Agents ●" : "All ○"}
+      {filterSystem ? "Filter system log: on" : "Filter system log: off"}
     </button>
   ), [filterSystem, toggleFilter]);
 


### PR DESCRIPTION
## Summary
- Replaces `Agents ●` / `All ○` toggle labels with `Filter system log: on` / `Filter system log: off`
- Removes colored dot indicators, uses plain text instead
- Toggle functionality and styling unchanged

Fixes #530

## Test plan
- [x] Build passes (`npx next build`)
- [ ] Toggle reads "Filter system log: on" when system messages are hidden
- [ ] Toggle reads "Filter system log: off" when all messages are shown
- [ ] No colored dot visible
- [ ] Click behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)