### PR TITLE
[#564] Remove old agent names from UI, document legacy compat mappings

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -384,7 +384,9 @@ function askYN(rl, question, defaultYes = false) {
   });
 }
 
-// Migration: rename old agent keys to new ones
+// Migration: rename old agent keys to new ones.
+// Keep this map — it migrates pre-v1.8 configs on startup so existing
+// installs transition to the canonical head/dev/re1/re2 slugs.
 const AGENT_KEY_MAP = { t1: "head", t2a: "re1", t2b: "re2", t3: "dev", reviewer1: "re1", reviewer2: "re2" };
 
 function migrateAgentKeys(config) {

--- a/server/config.js
+++ b/server/config.js
@@ -55,7 +55,9 @@ function sanitizeOperatorName(value) {
   return truncated;
 }
 
-// Migration: rename old agent keys to new ones
+// Migration: rename old agent keys to new ones.
+// Keep this map — it migrates pre-v1.8 configs on startup so existing
+// installs transition to the canonical head/dev/re1/re2 slugs.
 const AGENT_KEY_MAP = { t1: "head", t2a: "re1", t2b: "re2", t3: "dev", reviewer1: "re1", reviewer2: "re2" };
 
 function migrateAgentKeys(config) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -623,6 +623,8 @@ const RESERVED_HISTORY_SENDERS = new Set([
   "dev",
   "re1",
   "re2",
+  // Legacy agent slugs — kept for backward compat so old config
+  // imports are still blocked. New projects use head/dev/re1/re2.
   "reviewer1",
   "reviewer2",
   "t1",

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -266,6 +266,8 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
               const agentStatus: Record<string, string> = {};
               for (const r of reviews) {
                 const body = (r.body || "").trim();
+                // Current names checked first; legacy Reviewer1/2 and T2a/b
+                // kept as fallback for reviews posted before the slug rename.
                 if (/^(?:RE2|Reviewer2|T2b)\b/i.test(body)) {
                   agentStatus["re2"] = r.state;
                 } else if (/^(?:RE1|Reviewer1|T2a)\b/i.test(body) || /^##\s*Verdict/i.test(body)) {

--- a/src/components/ProjectHistoryWidget.tsx
+++ b/src/components/ProjectHistoryWidget.tsx
@@ -192,6 +192,9 @@ export default function ProjectHistoryWidget({ projectId }: ProjectHistoryWidget
     // #414 / quadwork#297: pre-scan for reserved agent senders so
     // we can prompt once instead of after a server 400. The same
     // RESERVED set lives in server/routes.js — keep them in sync.
+    // Current + legacy agent slugs — legacy names kept so imported
+    // histories with old senders are still flagged. Mirrors
+    // RESERVED_HISTORY_SENDERS in server/routes.js.
     const RESERVED_SENDERS = new Set(["head", "dev", "reviewer1", "reviewer2", "re1", "re2", "t1", "t2a", "t2b", "t3", "system"]);
     let allowAgentSenders = false;
     const offenders = new Set<string>();

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -133,7 +133,7 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const sendToT1 = async () => {
+  const sendToHead = async () => {
     try {
       const cfgRes = await fetch("/api/config");
       if (!cfgRes.ok) throw new Error("config");
@@ -280,7 +280,7 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
 
         <div className="flex items-center gap-2 px-3 py-3">
           <button
-            onClick={sendToT1}
+            onClick={sendToHead}
             className="px-4 py-1.5 bg-accent text-bg text-[12px] font-semibold hover:bg-accent-dim transition-colors"
           >
             {sent ? "Sent to Head" : "Send to Head Terminal"}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -38,10 +38,10 @@ const BACKENDS: { value: string; label: string }[] = [
 ];
 
 const AGENTS = [
-  { key: "head", label: "T1 — Head", role: "Owner / Final Guard", desc: "Merges PRs, makes final calls" },
-  { key: "re1", label: "RE1 — Reviewer 1", role: "Design Reviewer", desc: "Reviews architecture & design" },
-  { key: "re2", label: "RE2 — Reviewer 2", role: "Code Reviewer", desc: "Reviews implementation quality" },
-  { key: "dev", label: "T3 — Developer", role: "Full-Stack Builder", desc: "Implements features & fixes" },
+  { key: "head", label: "Head", role: "Owner / Final Guard", desc: "Merges PRs, makes final calls" },
+  { key: "re1", label: "RE1", role: "Design Reviewer", desc: "Reviews architecture & design" },
+  { key: "re2", label: "RE2", role: "Code Reviewer", desc: "Reviews implementation quality" },
+  { key: "dev", label: "Dev", role: "Full-Stack Builder", desc: "Implements features & fixes" },
 ];
 
 /* ── Component ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Setup wizard labels updated: `T1 — Head` → `Head`, `RE1 — Reviewer 1` → `RE1`, `RE2 — Reviewer 2` → `RE2`, `T3 — Developer` → `Dev`
- Renamed `sendToT1` → `sendToHead` in QueueManager
- Added explanatory comments to all legacy slug lists (server/routes.js, bin/quadwork.js, GitHubPanel.tsx, ProjectHistoryWidget.tsx) — these are kept for backward compat / migration

## Test plan

- [ ] Fresh setup wizard shows only `Head`, `RE1`, `RE2`, `Dev` — no T1/T3/Reviewer prefixes
- [ ] Queue manager "Send to Head" button works (renamed from sendToT1)
- [ ] Existing projects with old-slug configs still migrate correctly on startup
- [ ] Build passes cleanly

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)