### PR TITLE
[#560] Handle sendFile NotFoundError with error callback

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -1154,8 +1154,11 @@ router.get("/api/uploads/:project/:filename", (req, res) => {
   // existsSync and sendFile, or stricter file resolution in Express 5's
   // send module) is handled gracefully instead of spamming the server log.
   res.sendFile(filePath, (err) => {
-    if (err && !res.headersSent) {
+    if (!err || res.headersSent) return;
+    if (err.status === 404 || err.code === "ENOENT") {
       res.status(404).json({ error: "Not found" });
+    } else {
+      res.status(500).json({ error: "Internal server error" });
     }
   });
 });

--- a/server/routes.js
+++ b/server/routes.js
@@ -1150,7 +1150,14 @@ router.get("/api/uploads/:project/:filename", (req, res) => {
   }
   const filePath = path.join(CONFIG_DIR, project, "uploads", filename);
   if (!fs.existsSync(filePath)) return res.status(404).json({ error: "Not found" });
-  res.sendFile(filePath);
+  // #560: pass error callback so Express/send NotFoundError (race between
+  // existsSync and sendFile, or stricter file resolution in Express 5's
+  // send module) is handled gracefully instead of spamming the server log.
+  res.sendFile(filePath, (err) => {
+    if (err && !res.headersSent) {
+      res.status(404).json({ error: "Not found" });
+    }
+  });
 });
 
 // ─── Projects (dashboard aggregation) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Added error callback to `res.sendFile()` in the `/api/uploads/:project/:filename` route
- Race conditions between `fs.existsSync` and `sendFile` (or Express 5's stricter `send` module) now return a clean 404 JSON instead of spamming the server console with `NotFoundError` stack traces
- Existing `fs.existsSync` pre-check kept as a fast path; the callback handles the edge case

## Test plan

- [ ] Request a valid upload file → served correctly
- [ ] Request a missing upload file → clean 404 JSON response, no stack trace in server console
- [ ] Server console no longer shows `NotFoundError: Not Found` spam

Fixes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)