### PR TITLE
[#569] Redirect AC spawn logs to file for diagnostics

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1989,8 +1989,17 @@ function cmdDoctor() {
         console.log(`  ${p.id}: (no log file)`);
         continue;
       }
-      const content = fs.readFileSync(logPath, "utf-8");
-      const lines = content.trimEnd().split("\n");
+      // Bounded tail: read last 8KB instead of the whole file to stay
+      // fast on large append-only logs.
+      const stat = fs.statSync(logPath);
+      const readSize = Math.min(stat.size, 8192);
+      const buf = Buffer.alloc(readSize);
+      const fd = fs.openSync(logPath, "r");
+      fs.readSync(fd, buf, 0, readSize, stat.size - readSize);
+      fs.closeSync(fd);
+      const lines = buf.toString("utf-8").trimEnd().split("\n");
+      // If we read from mid-file, the first line is likely partial — drop it.
+      if (readSize < stat.size) lines.shift();
       const tail = lines.slice(-20);
       console.log(`  ${p.id}: ${logPath} (last ${tail.length} lines)`);
       for (const line of tail) {

--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1617,15 +1617,22 @@ function cmdStart() {
     if (!configToml) continue;
     const acSpawn = chattrSpawnArgs(projectAcDir, ["--config", configToml]);
     if (!acSpawn) continue;
+    // #569: redirect AC stdout/stderr to a log file for diagnostics.
+    const acLogDir = path.join(CONFIG_DIR, project.id);
+    try { fs.mkdirSync(acLogDir, { recursive: true, mode: 0o700 }); } catch {}
+    const acLogPath = path.join(acLogDir, "agentchattr.log");
+    const acLogFd = fs.openSync(acLogPath, "a");
     const acProc = spawn(acSpawn.command, acSpawn.spawnArgs, {
       cwd: acSpawn.cwd,
-      stdio: "ignore",
+      stdio: ["ignore", acLogFd, acLogFd],
       detached: true,
     });
+    fs.closeSync(acLogFd);
     acProc.on("error", () => {});
     acProc.unref();
     if (acProc.pid) {
       ok(`AgentChattr started for ${project.id} from ${projectAcDir} (PID: ${acProc.pid})`);
+      log(`  Log: ${acLogPath}`);
       acPids.push(acProc.pid);
     }
   }
@@ -1967,6 +1974,35 @@ function cmdDoctor() {
 
   console.log("");
   console.log("Legend: [OK  ] on pin + on `pinned` branch; [BR  ] on pin but on a non-`pinned` named branch; [DETACH] on pin but in detached HEAD (re-run quadwork start to auto-migrate); [DIFF] off-pin (re-clone manually to re-sync)");
+
+  // #569: show last 20 lines of AC log for each project to help
+  // operators diagnose startup failures.
+  console.log("");
+  console.log("AgentChattr logs");
+  console.log("────────────────");
+  try {
+    const cfg = readConfig();
+    const projects = Array.isArray(cfg.projects) ? cfg.projects : [];
+    for (const p of projects) {
+      const logPath = path.join(CONFIG_DIR, p.id || "", "agentchattr.log");
+      if (!fs.existsSync(logPath)) {
+        console.log(`  ${p.id}: (no log file)`);
+        continue;
+      }
+      const content = fs.readFileSync(logPath, "utf-8");
+      const lines = content.trimEnd().split("\n");
+      const tail = lines.slice(-20);
+      console.log(`  ${p.id}: ${logPath} (last ${tail.length} lines)`);
+      for (const line of tail) {
+        console.log(`    ${line}`);
+      }
+    }
+    if (projects.length === 0) {
+      console.log("  (no projects)");
+    }
+  } catch (err) {
+    console.log(`  (could not read logs: ${err.message})`);
+  }
   console.log("");
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -875,16 +875,25 @@ async function handleAgentChattr(req, res) {
       return null;
     }
 
+    // #569: redirect AC stdout/stderr to a log file so operators can
+    // diagnose startup failures. Append mode preserves restart history.
+    const acLogDir = path.join(os.homedir(), ".quadwork", projectId);
+    try { fs.mkdirSync(acLogDir, { recursive: true, mode: 0o700 }); } catch {}
+    const acLogPath = path.join(acLogDir, "agentchattr.log");
+    const acLogFd = fs.openSync(acLogPath, "a");
     const child = spawn(acSpawn.command, [...acSpawn.args, ...extraArgs], {
       cwd: acSpawn.cwd,
       env: process.env,
-      stdio: "ignore",
+      stdio: ["ignore", acLogFd, acLogFd],
       detached: true,
     });
 
+    // Close our copy of the log fd — child inherits its own copy.
+    fs.closeSync(acLogFd);
+
     // If pid is undefined, spawn failed
     if (!child.pid) {
-      setProc({ process: null, state: "error", error: "Failed to start AgentChattr — check that Python venv is set up in " + acDir });
+      setProc({ process: null, state: "error", error: "Failed to start AgentChattr — check that Python venv is set up in " + acDir + ". Log: " + acLogPath });
       child.on("error", () => {});
       return null;
     }


### PR DESCRIPTION
## Summary
- Both AC spawn paths (`server/index.js:spawnChattr` and `bin/quadwork.js:cmdStart`) now redirect stdout/stderr to `~/.quadwork/{projectId}/agentchattr.log` in append mode
- Parent fd is closed after spawn to avoid leaking file descriptors
- `quadwork doctor` now tails the last 20 lines of each project's AC log for quick diagnosis
- Error messages include log path when spawn fails

## Changes
- `server/index.js`: `spawnChattr()` opens log fd, passes as stdio, closes after spawn
- `bin/quadwork.js`: `cmdStart()` AC spawn loop does the same; prints log path on success
- `bin/quadwork.js`: `cmdDoctor()` adds "AgentChattr logs" section with per-project tail

## Test plan
- [ ] Start AC via dashboard → verify `~/.quadwork/{projectId}/agentchattr.log` is created and contains AC output
- [ ] Start via `npx quadwork start` → same log file created
- [ ] Restart AC → log appends (not overwritten)
- [ ] `npx quadwork doctor` → shows last 20 lines of AC log per project
- [ ] Kill AC with bad config → log captures Python traceback for diagnosis

Fixes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)