### PR TITLE
[#572] Auto-restart unregistered agents on AC recovery

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -641,7 +641,12 @@ async function spawnAgentPty(project, agent) {
     if (!session.acRegistrationName && session.acServerPort && session.acInjectMode) {
       const deferredRestart = async () => {
         const ready = await waitForAgentChattrReady(session.acServerPort, 60000);
-        if (!ready) return;
+        if (!ready) {
+          // #572: log timeout so operators know the health monitor will
+          // handle recovery when AC eventually comes up.
+          console.log(`[#565] Agent ${agent}: AC not reachable after 60s — health monitor will restart agent when AC recovers.`);
+          return;
+        }
         // Guard: agent may have been stopped manually while we waited.
         const current = agentSessions.get(key);
         if (!current || !current.term || current.state !== "running") return;
@@ -2088,6 +2093,39 @@ setInterval(runLoopGuardPollingTick, LOOP_GUARD_POLL_INTERVAL_MS);
 // logic). Rate-limited to one restart per 60s per project; gives up after
 // 3 consecutive failures and surfaces a persistent error.
 // ---------------------------------------------------------------------------
+// #572: restart agents that are running without AC registration after AC
+// recovers from a crash. Scans agentSessions for the given project,
+// finds agents missing acRegistrationName, and stop+respawns them so
+// they get MCP CLI flags at launch time.
+async function restartUnregisteredAgents(projectId) {
+  const cfg = readConfig();
+  const project = (cfg.projects || []).find((p) => p.id === projectId);
+  if (!project) return;
+
+  const toRestart = [];
+  for (const [key, session] of agentSessions) {
+    if (session.projectId !== projectId) continue;
+    if (session.acRegistrationName) continue; // already registered
+    if (session.state !== "running") continue;
+    if (!session.acServerPort || !session.acInjectMode) continue;
+    toRestart.push({ key, agentId: session.agentId });
+  }
+
+  if (toRestart.length === 0) return;
+  const samplePort = toRestart.length > 0 ? agentSessions.get(toRestart[0].key)?.acServerPort : "?";
+  console.log(`[health] AC recovered on port ${samplePort} — restarting ${toRestart.length} agent(s) for chat integration`);
+
+  for (const { key, agentId } of toRestart) {
+    try {
+      console.log(`[health] Restarting agent ${agentId} for project ${projectId} to gain chat integration`);
+      await stopAgentSession(key);
+      await spawnAgentPty(project, agentId);
+    } catch (err) {
+      console.error(`[health] Failed to restart agent ${agentId}: ${err.message}`);
+    }
+  }
+}
+
 const _acHealth = {
   // Per-project: { lastRestart: timestamp, consecutiveFailures: number }
   state: new Map(),
@@ -2124,6 +2162,13 @@ async function acHealthCheck() {
       // Healthy — reset failure counter
       if (health.consecutiveFailures > 0) {
         console.log(`[health] AC for ${project.id} recovered (port ${port} alive)`);
+        // #572: restart agents that are running without chat integration.
+        // These are agents where the #565 deferred restart timed out, or
+        // agents spawned while AC was down. MCP flags are set at process
+        // launch, so a full stop+respawn is required.
+        restartUnregisteredAgents(project.id).catch((err) => {
+          console.error(`[health] Failed to restart unregistered agents for ${project.id}:`, err.message);
+        });
       }
       health.consecutiveFailures = 0;
       _acHealth.state.set(project.id, health);

--- a/server/index.js
+++ b/server/index.js
@@ -2098,10 +2098,6 @@ setInterval(runLoopGuardPollingTick, LOOP_GUARD_POLL_INTERVAL_MS);
 // finds agents missing acRegistrationName, and stop+respawns them so
 // they get MCP CLI flags at launch time.
 async function restartUnregisteredAgents(projectId) {
-  const cfg = readConfig();
-  const project = (cfg.projects || []).find((p) => p.id === projectId);
-  if (!project) return;
-
   const toRestart = [];
   for (const [key, session] of agentSessions) {
     if (session.projectId !== projectId) continue;
@@ -2112,14 +2108,14 @@ async function restartUnregisteredAgents(projectId) {
   }
 
   if (toRestart.length === 0) return;
-  const samplePort = toRestart.length > 0 ? agentSessions.get(toRestart[0].key)?.acServerPort : "?";
+  const samplePort = agentSessions.get(toRestart[0].key)?.acServerPort || "?";
   console.log(`[health] AC recovered on port ${samplePort} — restarting ${toRestart.length} agent(s) for chat integration`);
 
   for (const { key, agentId } of toRestart) {
     try {
       console.log(`[health] Restarting agent ${agentId} for project ${projectId} to gain chat integration`);
       await stopAgentSession(key);
-      await spawnAgentPty(project, agentId);
+      await spawnAgentPty(projectId, agentId);
     } catch (err) {
       console.error(`[health] Failed to restart agent ${agentId}: ${err.message}`);
     }


### PR DESCRIPTION
## Summary
- When health monitor detects AC recovered from a crash, scans `agentSessions` for agents running without AC registration (`acRegistrationName === null`) and stop+respawns them
- Connects to #565 deferred restart: if the 60s timeout expires, the health monitor picks up recovery when AC eventually comes up
- Adds timeout log message to #565 deferred restart so operators know the handoff happened

## Changes
- `server/index.js`: Added `restartUnregisteredAgents(projectId)` function — scans sessions, filters unregistered agents, stop+respawns each
- `server/index.js`: Health monitor recovery branch (alive + consecutiveFailures > 0) calls `restartUnregisteredAgents`
- `server/index.js`: #565 deferred restart logs when 60s timeout expires

## Test plan
- [ ] Start agents before AC is ready → agents spawn without chat → AC starts → health monitor triggers agent restart → agents gain chat integration
- [ ] AC crashes mid-session → health monitor restarts AC → unregistered agents are respawned
- [ ] #565 deferred restart timeout → log message appears → AC comes up later → health monitor restarts agents
- [ ] Agents already registered (acRegistrationName set) are NOT restarted on recovery
- [ ] Manually stopped agents are NOT restarted on recovery

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)