### PR TITLE
[#577] Drop rejected --config flag from AC spawn sites

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -270,7 +270,14 @@ function _installAgentChattrLocked(dir, setError) {
     // hard-failing the install.
     const pinResult = run("git", ["-C", dir, "checkout", "-B", "pinned", AGENTCHATTR_PIN], { timeout: 30000 });
     if (pinResult === null) {
-      try { console.warn(`[quadwork] WARNING: could not check out AgentChattr pin ${AGENTCHATTR_PIN} at ${dir}; falling back to default branch. The upstream commit may have been force-pushed away — update AGENTCHATTR_PIN in bin/quadwork.js for reproducible installs.`); } catch {}
+      const pinWarnMsg = `Could not check out AgentChattr pin ${AGENTCHATTR_PIN} at ${dir}; falling back to default branch. AC's argparse may reject unknown flags. Update AGENTCHATTR_PIN in bin/quadwork.js for reproducible installs.`;
+      warn(pinWarnMsg);
+      // Persist to install log so post-mortem diagnosis is possible
+      // without re-running the install.
+      try {
+        const logDir = path.join(path.dirname(dir));
+        fs.appendFileSync(path.join(logDir, "install.log"), `[${new Date().toISOString()}] PIN-CHECKOUT-FAIL: ${pinWarnMsg}\n`);
+      } catch {}
     }
   } else {
     // #366: existing clone from a pre-fix install. If the clone
@@ -1032,7 +1039,7 @@ function writeAgentChattrConfig(setup, configTomlPath, { skipInstall = false } =
   // Start AgentChattr server (only if installed)
   if (acAvailable) {
     log("Starting AgentChattr server...");
-    const acSpawn = chattrSpawnArgs(acDir, ["--config", configTomlPath]);
+    const acSpawn = chattrSpawnArgs(acDir, []);
     if (acSpawn) {
       const acProc = spawn(acSpawn.command, acSpawn.spawnArgs, {
         cwd: acSpawn.cwd,
@@ -1615,7 +1622,7 @@ function cmdStart() {
       ? perProjectToml
       : (fs.existsSync(legacyToml) ? legacyToml : null);
     if (!configToml) continue;
-    const acSpawn = chattrSpawnArgs(projectAcDir, ["--config", configToml]);
+    const acSpawn = chattrSpawnArgs(projectAcDir, []);
     if (!acSpawn) continue;
     // #569: redirect AC stdout/stderr to a log file for diagnostics.
     const acLogDir = path.join(CONFIG_DIR, project.id);

--- a/scripts/e2e-per-project.js
+++ b/scripts/e2e-per-project.js
@@ -346,9 +346,9 @@ function killPidsOnPorts(ports) {
   }
 
   // Re-spawn project-b from its own clone via the same code path
-  // cmdStart uses (chattrSpawnArgs with cwd=clone, --config <tomlAtRoot>).
+  // cmdStart uses (chattrSpawnArgs with cwd=clone, config.toml at ROOT).
   const bVenvPy = path.join(bDir, ".venv", "bin", "python");
-  const bRespawn = spawn(bVenvPy, ["run.py", "--config", bToml], {
+  const bRespawn = spawn(bVenvPy, ["run.py"], {
     cwd: bDir,
     stdio: "ignore",
     detached: true,

--- a/server/index.js
+++ b/server/index.js
@@ -866,7 +866,7 @@ async function handleAgentChattr(req, res) {
 
     // Use project config.toml if available (isolated data dir + ports), otherwise fall back to --port
     const extraArgs = (projectConfigToml && fs.existsSync(projectConfigToml))
-      ? ["--config", projectConfigToml]
+      ? []
       : ["--port", chattrPort];
 
     // Resolve AgentChattr from its cloned directory


### PR DESCRIPTION
## Summary
- Remove `--config <path>` from all three AC `run.py` spawn sites (`bin/quadwork.js` ×2, `server/index.js` ×1) — AC's argparse rejects this flag, causing it to exit before binding port 8300 (the root cause of every `[#565] AC not reachable` error)
- Fix the same `--config` usage in the e2e test (`scripts/e2e-per-project.js`)
- Replace the buried `console.warn` on pin-checkout failure with the project's `warn()` helper + persist to `install.log` for post-mortem diagnosis

AC reads `config.toml` from its `cwd` automatically — the `--config` flag was always redundant. It was silently ignored on the pinned commit (pre-argparse) but fatal on any post-`59965ce` checkout.

Fixes #577

## Test plan
- [ ] `npx quadwork start` with AC clone at HEAD (post-argparse) — AC should bind 8300 without argparse rejection
- [ ] Verify `agentchattr.log` shows clean uvicorn startup, no `unrecognized arguments` error
- [ ] Confirm all four agents come online with chat integration (no `[#565]` messages)
- [ ] Force a pin-checkout failure and verify warning appears via `warn()` and is persisted to `install.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)