### PR TITLE
[#580] Add waitForAgentChattrReady after every AC spawn

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -1564,7 +1564,30 @@ function migrateLoopGuardDefaults(config) {
   }
 }
 
-function cmdStart() {
+/**
+ * #580: Poll AC health endpoint until it responds 200, or timeout.
+ * Simple inline implementation for bin/ (no access to server/ modules).
+ */
+async function waitForAcHealth(baseUrl, timeoutMs = 30000) {
+  const http = require("http");
+  const deadline = Date.now() + timeoutMs;
+  const healthUrl = `${baseUrl}/api/health`;
+  while (Date.now() < deadline) {
+    const ok = await new Promise((resolve) => {
+      const req = http.get(healthUrl, (res) => {
+        res.resume();
+        resolve(res.statusCode >= 200 && res.statusCode < 400);
+      });
+      req.on("error", () => resolve(false));
+      req.setTimeout(2000, () => { req.destroy(); resolve(false); });
+    });
+    if (ok) return true;
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  return false;
+}
+
+async function cmdStart() {
   console.log("\n  QuadWork Start\n");
 
   const config = readConfig();
@@ -1638,7 +1661,14 @@ function cmdStart() {
     acProc.on("error", () => {});
     acProc.unref();
     if (acProc.pid) {
-      ok(`AgentChattr started for ${project.id} from ${projectAcDir} (PID: ${acProc.pid})`);
+      // #580: wait for AC to bind its port before declaring success.
+      const acUrl = project.agentchattr_url || "http://127.0.0.1:8300";
+      const acReady = await waitForAcHealth(acUrl, 30000);
+      if (acReady) {
+        ok(`AgentChattr started for ${project.id} from ${projectAcDir} (PID: ${acProc.pid})`);
+      } else {
+        warn(`AgentChattr spawned for ${project.id} (PID: ${acProc.pid}) but did not become ready within 30s`);
+      }
       log(`  Log: ${acLogPath}`);
       acPids.push(acProc.pid);
     }

--- a/server/index.js
+++ b/server/index.js
@@ -860,7 +860,7 @@ async function handleAgentChattr(req, res) {
     } catch {}
   }
 
-  function spawnChattr() {
+  async function spawnChattr() {
     // Sync config.toml port before starting
     regenerateConfigToml();
 
@@ -913,7 +913,15 @@ async function handleAgentChattr(req, res) {
         setProc({ process: null, state: "stopped", error: code ? `exit:${code}` : null });
       }
     });
-    setProc({ process: child, state: "running", error: null });
+    // #580: wait for AC to actually bind the port before declaring success.
+    // On fast-start installs this resolves in 1-2s; prevents false-down
+    // detection on slow starts that triggered ghost agent cascades.
+    const ready = await waitForAgentChattrReady(chattrPort, 30000);
+    if (ready) {
+      setProc({ process: child, state: "running", error: null });
+    } else {
+      setProc({ process: child, state: "error", error: "AgentChattr did not become ready within 30s" });
+    }
     return child;
   }
 
@@ -989,7 +997,7 @@ async function handleAgentChattr(req, res) {
       console.warn(`[agentchattr] ${projectId} port ${chattrPort} still occupied after 3s — spawning anyway`);
     }
     try {
-      const child = spawnChattr();
+      const child = await spawnChattr();
       if (!child) {
         const errProc = getProc();
         return res.status(500).json({ ok: false, state: "error", error: errProc.error || "Failed to start AgentChattr" });
@@ -1038,7 +1046,7 @@ async function handleAgentChattr(req, res) {
       console.warn(`[agentchattr] ${projectId} port ${chattrPort} still occupied after 3s — spawning anyway`);
     }
     try {
-      const child = spawnChattr();
+      const child = await spawnChattr();
       if (!child) {
         const errProc = getProc();
         return res.status(500).json({ ok: false, state: "error", error: errProc.error || "Failed to start AgentChattr" });
@@ -1137,7 +1145,7 @@ async function handleAgentChattr(req, res) {
       // Restart if it was running before the update
       let restarted = false;
       if (wasRunning) {
-        const child = spawnChattr();
+        const child = await spawnChattr();
         restarted = !!child;
         if (child) {
           setTimeout(() => syncChattrToken(projectId).catch(() => {}), 2000);

--- a/server/index.js
+++ b/server/index.js
@@ -919,10 +919,11 @@ async function handleAgentChattr(req, res) {
     const ready = await waitForAgentChattrReady(chattrPort, 30000);
     if (ready) {
       setProc({ process: child, state: "running", error: null });
+      return child;
     } else {
       setProc({ process: child, state: "error", error: "AgentChattr did not become ready within 30s" });
+      return null;
     }
-    return child;
   }
 
   // #386: Kill any process listening on the AC port. Handles orphaned


### PR DESCRIPTION
## Summary
- `spawnChattr()` in `server/index.js` now `await`s `waitForAgentChattrReady(port, 30000)` before setting state to "running" — if AC doesn't bind within 30s, state is set to "error" instead
- `cmdStart()` in `bin/quadwork.js` polls `/api/health` every 2s (up to 30s) before printing success; warns on timeout
- On fast-start installs the wait resolves in 1-2s with no behavioral change; prevents false-down detection on slow starts that caused ghost agent cascades

## Test plan
- [ ] Fresh install with slow AC startup: verify no auto-restart cascade
- [ ] Existing fast-start install: verify startup completes in ~1-2s with no extra delay
- [ ] `npm run build` passes

Fixes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)