### PR TITLE
[#579] Harden AC startup race: detect running AC, grace period, reset dedup

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -556,11 +556,18 @@ async function checkPrereqs(rl) {
   }
 
   // ── 3. AgentChattr (clone + venv — needs Python and git) ──
+  // #579: skip global install on fresh installs with no projects. Each
+  // project gets its own per-project clone via the web setup wizard, so
+  // a global ~/.quadwork/agentchattr/ clone is redundant cruft.
+  // Only check for an existing install to report status.
   const acDir = findAgentChattr();
+  const config = readConfig();
   if (acDir) {
     ok(`AgentChattr (${acDir})`);
     agentChattrFound = true;
-  } else if (hasPython) {
+  } else if (hasPython && config.projects && config.projects.length > 0) {
+    // Existing projects but no global install — install globally as
+    // fallback for legacy projects that don't have per-project clones.
     console.log("");
     warn("AgentChattr lets your AI agents communicate with each other.");
     log("It will be cloned and set up in a virtualenv.");
@@ -583,6 +590,11 @@ async function checkPrereqs(rl) {
       log(`  → Install later: git clone ${AGENTCHATTR_REPO} ${DEFAULT_AGENTCHATTR_DIR}`);
       allOk = false;
     }
+  } else if (hasPython) {
+    // Fresh install with no projects — AC will be installed per-project
+    // when the user creates their first project via the dashboard.
+    ok("AgentChattr will be installed per-project when you create a project.");
+    agentChattrFound = true;
   } else {
     warn("AgentChattr requires Python — install Python first, then re-run init.");
     allOk = false;
@@ -1671,6 +1683,17 @@ async function cmdStart() {
       }
       log(`  Log: ${acLogPath}`);
       acPids.push(acProc.pid);
+    }
+    // #579: verify pin checkout after spawn — surface loudly if AC clone
+    // drifted from the pinned commit, so operators know they're not on
+    // the tested version. The install-time warn() is often buried mid-
+    // spinner; this post-spawn check is always visible.
+    const headSha = (run("git", ["-C", projectAcDir, "rev-parse", "HEAD"]) || "").trim();
+    if (headSha && headSha !== AGENTCHATTR_PIN) {
+      warn(`AgentChattr for ${project.id} is NOT on the pinned commit.`);
+      log(`  Current: ${headSha.slice(0, 12)}`);
+      log(`  Pinned:  ${AGENTCHATTR_PIN.slice(0, 12)}`);
+      log(`  Run: git -C ${projectAcDir} checkout -B pinned ${AGENTCHATTR_PIN}`);
     }
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -1094,8 +1094,19 @@ async function handleAgentChattr(req, res) {
       // #447: auto-reset all agents after AC restart so they get
       // fresh MCP tokens. #581: mark reset as scheduled immediately
       // so the health monitor skips its own reset while ours is in-flight.
+      // #579: also skip if a reset already succeeded within the last 30s.
+      // Multiple restart sources (bridge-migrate, health monitor, dashboard)
+      // can fire in rapid succession — only the first should trigger a reset.
+      const existingReset = _acHealth.resetState.get(projectId);
+      const resetRecentlyDone = existingReset &&
+        (existingReset.status === "succeeded" || existingReset.status === "scheduled") &&
+        Date.now() - existingReset.timestamp < 30_000;
+      if (resetRecentlyDone) {
+        console.log(`[agentchattr] ${projectId} skipping auto-reset — one already ${existingReset.status} ${Math.round((Date.now() - existingReset.timestamp) / 1000)}s ago`);
+      } else {
       _acHealth.resetState.set(projectId, { status: "scheduled", timestamp: Date.now() });
-      setTimeout(async () => {
+      }
+      if (!resetRecentlyDone) setTimeout(async () => {
         try {
           const resetResp = await fetch(`http://127.0.0.1:${PORT}/api/agents/${encodeURIComponent(projectId)}/reset`, {
             method: "POST",
@@ -2152,6 +2163,10 @@ const _acHealth = {
   // #581: per-project reset state — prevents duplicate resets per restart event.
   // Values: { status: "scheduled"|"succeeded"|"failed", timestamp: number }
   resetState: new Map(),
+  // #579: timestamp when the health monitor started. The first 60s are a
+  // grace period: skip checks so cmdStart spawns and startup migrations
+  // (bridge-migrate, ghost-fix) can settle before the monitor acts.
+  startedAt: 0,
 };
 
 function isPortAlive(port) {
@@ -2166,6 +2181,10 @@ function isPortAlive(port) {
 }
 
 async function acHealthCheck() {
+  // #579: skip checks during the startup grace period so cmdStart spawns
+  // and startup migrations (bridge-migrate, ghost-fix) can settle.
+  if (_acHealth.startedAt && Date.now() - _acHealth.startedAt < 60_000) return;
+
   const cfg = readConfig();
   for (const project of (cfg.projects || [])) {
     const proc = chattrProcesses.get(project.id);
@@ -2263,18 +2282,36 @@ async function acHealthCheck() {
 
 function startAcHealthMonitor() {
   if (_acHealth.intervalHandle) return;
+  _acHealth.startedAt = Date.now();
   _acHealth.intervalHandle = setInterval(acHealthCheck, 30_000);
-  console.log("[health] AC health monitor started (30s interval)");
+  console.log("[health] AC health monitor started (30s interval, 60s startup grace)");
 }
 
-server.listen(PORT, "127.0.0.1", () => {
+server.listen(PORT, "127.0.0.1", async () => {
   console.log(`QuadWork server listening on http://127.0.0.1:${PORT}`);
   syncTriggersFromConfig();
+  // #579: detect AC processes already running (spawned by cmdStart before
+  // the server module loaded). Without this, chattrProcesses is empty on
+  // boot and the health monitor can't track cmdStart-spawned ACs, while
+  // the dashboard's Start button would redundantly kill+respawn them.
+  const startupCfg = readConfig();
+  for (const p of (startupCfg.projects || [])) {
+    const { url: acUrl } = resolveProjectChattr(p.id);
+    const acPortMatch = acUrl.match(/:(\d+)/);
+    const acPort = acPortMatch ? parseInt(acPortMatch[1], 10) : 8300;
+    const alive = await isPortAlive(acPort);
+    if (alive && !chattrProcesses.has(p.id)) {
+      // AC is already running (e.g. spawned by cmdStart). Record it so
+      // the health monitor can track it and the dashboard shows the
+      // correct state. process is null because we don't own the child.
+      chattrProcesses.set(p.id, { process: null, state: "running", error: null });
+      console.log(`[startup] ${p.id}: AC already alive on port ${acPort} — tracking`);
+    }
+  }
   // Sync AgentChattr tokens for all projects on startup and backfill
   // the sender-overflow CSS/JS patch (#402) so already-running AC
   // instances receive the fix without requiring a restart.
   // #448: retry after 5s for projects where AC isn't up yet at boot.
-  const startupCfg = readConfig();
   for (const p of (startupCfg.projects || [])) {
     syncChattrToken(p.id).catch(() => {
       setTimeout(() => syncChattrToken(p.id).catch(() => {}), 5000);

--- a/server/index.js
+++ b/server/index.js
@@ -918,7 +918,7 @@ async function handleAgentChattr(req, res) {
     // detection on slow starts that triggered ghost agent cascades.
     const ready = await waitForAgentChattrReady(chattrPort, 30000);
     if (ready) {
-      setProc({ process: child, state: "running", error: null });
+      setProc({ process: child, state: "running", error: null, runningSince: Date.now() });
       return child;
     } else {
       setProc({ process: child, state: "error", error: "AgentChattr did not become ready within 30s" });
@@ -2163,10 +2163,10 @@ const _acHealth = {
   // #581: per-project reset state — prevents duplicate resets per restart event.
   // Values: { status: "scheduled"|"succeeded"|"failed", timestamp: number }
   resetState: new Map(),
-  // #579: timestamp when the health monitor started. The first 60s are a
-  // grace period: skip checks so cmdStart spawns and startup migrations
-  // (bridge-migrate, ghost-fix) can settle before the monitor acts.
-  startedAt: 0,
+  // #579: per-project grace period. Projects whose AC entered "running"
+  // within the last 60s are skipped by the health monitor so startup
+  // migrations (bridge-migrate, ghost-fix) and fresh spawns can settle.
+  // Tracked via `runningSince` in chattrProcesses entries.
 };
 
 function isPortAlive(port) {
@@ -2181,16 +2181,17 @@ function isPortAlive(port) {
 }
 
 async function acHealthCheck() {
-  // #579: skip checks during the startup grace period so cmdStart spawns
-  // and startup migrations (bridge-migrate, ghost-fix) can settle.
-  if (_acHealth.startedAt && Date.now() - _acHealth.startedAt < 60_000) return;
-
   const cfg = readConfig();
   for (const project of (cfg.projects || [])) {
     const proc = chattrProcesses.get(project.id);
     // Only monitor projects that were explicitly started (state === "running"
     // or had a process). Skip intentionally stopped projects.
     if (!proc || proc.state === "stopped") continue;
+    // #579: per-project grace period — skip projects whose AC entered
+    // "running" within the last 60s. This lets cmdStart spawns and
+    // startup migrations (bridge-migrate, ghost-fix) settle before the
+    // monitor acts, regardless of when the project was created.
+    if (proc.runningSince && Date.now() - proc.runningSince < 60_000) continue;
 
     const { url } = resolveProjectChattr(project.id);
     const portMatch = url.match(/:(\d+)/);
@@ -2282,9 +2283,8 @@ async function acHealthCheck() {
 
 function startAcHealthMonitor() {
   if (_acHealth.intervalHandle) return;
-  _acHealth.startedAt = Date.now();
   _acHealth.intervalHandle = setInterval(acHealthCheck, 30_000);
-  console.log("[health] AC health monitor started (30s interval, 60s startup grace)");
+  console.log("[health] AC health monitor started (30s interval, per-project 60s grace)");
 }
 
 server.listen(PORT, "127.0.0.1", async () => {
@@ -2304,7 +2304,7 @@ server.listen(PORT, "127.0.0.1", async () => {
       // AC is already running (e.g. spawned by cmdStart). Record it so
       // the health monitor can track it and the dashboard shows the
       // correct state. process is null because we don't own the child.
-      chattrProcesses.set(p.id, { process: null, state: "running", error: null });
+      chattrProcesses.set(p.id, { process: null, state: "running", error: null, runningSince: Date.now() });
       console.log(`[startup] ${p.id}: AC already alive on port ${acPort} — tracking`);
     }
   }


### PR DESCRIPTION
## Summary
Fixes #579 — comprehensive startup hardening for the AC race condition that caused triple auto-reset cascades, ghost agent identities, and restart failures on fresh installs.

Builds on the acute fixes in #580 (waitForReady), #581 (reset dedup), and #582 (restart port-free) with five additional guards:

- **Detect already-running AC on server boot** — probes each project's AC port and populates `chattrProcesses`, so the health monitor tracks cmdStart-spawned ACs and the dashboard doesn't redundantly restart them
- **60s health monitor startup grace period** — skips health checks during the initial startup window so cmdStart spawns and startup migrations (bridge-migrate, ghost-fix) can settle
- **Dedupe auto-reset across rapid restart calls** — skips the reset if one was already scheduled or succeeded within the last 30s, preventing triple auto-reset when multiple restart sources fire in succession
- **Surface pin checkout warning after spawn** — clearly warns in cmdStart if AC clone drifted from the pinned commit, instead of burying the message mid-spinner during install
- **Skip legacy global clone on fresh installs** — no longer creates `~/.quadwork/agentchattr/` on fresh installs with no projects; AC is installed per-project by the web setup wizard

## Test plan
- [ ] Fresh install: verify no `~/.quadwork/agentchattr/` global clone created during `npx quadwork init`
- [ ] Fresh install: verify AC is installed per-project when creating first project via dashboard
- [ ] Existing install: verify server boot detects already-running AC (`[startup]` log line)
- [ ] Verify health monitor skips checks during first 60s (`60s startup grace` in log)
- [ ] Trigger multiple rapid AC restarts (bridge-migrate + dashboard) and verify only one auto-reset fires
- [ ] Verify pin drift warning appears in cmdStart output when AC clone is not on pinned commit
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)