### PR TITLE
[#586] Add fallback path checks to isCliInstalled for VPS/headless

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -50,7 +50,15 @@ function isCliInstalled(cmd) {
     execFileSync("which", [cmd], { encoding: "utf-8", stdio: "pipe" });
     return true;
   } catch {
-    return false;
+    // #586: fallback for VPS/headless environments where ~/.local/bin
+    // is not in the inherited PATH (e.g. Claude Code installer adds to
+    // ~/.bashrc but Node's execFileSync doesn't source profile files).
+    const fallbacks = [
+      path.join(os.homedir(), ".local", "bin", cmd),
+      path.join(os.homedir(), ".npm-global", "bin", cmd),
+      `/usr/local/bin/${cmd}`,
+    ];
+    return fallbacks.some((p) => fs.existsSync(p));
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes #586 — `isCliInstalled` now checks common install locations when `which` fails, so CLIs in `~/.local/bin` (Claude Code installer), `~/.npm-global/bin`, or `/usr/local/bin` are detected on VPS/headless environments where profile files aren't sourced by Node's `execFileSync`.

- No change when CLIs are already in PATH (`which` succeeds, fallback never runs)
- Fallback only triggers on `which` failure — zero overhead in the happy path

## Test plan
- [ ] On VPS with claude at `~/.local/bin/claude` (not in PATH): verify `/api/cli-status` returns `claude: true`
- [ ] On local dev with claude in PATH: verify behavior unchanged (`which` succeeds)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)