### PR TITLE
[#588] Fix agent registration: use CLI name as base, role name as label

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -380,14 +380,18 @@ async function buildAgentArgs(projectId, agentId) {
       // token because app.py:2123 requires authenticated agent
       // session for family names — load it from disk (persisted
       // across restarts). Failures are non-fatal.
+      // #588: deregister stale registration — try both the old role-based
+      // name and the CLI-based name for backward compat during transition.
       const stalePersistedToken = readPersistedAgentToken(projectId, agentId);
       if (stalePersistedToken) {
         await deregisterAgent(acServerPort, agentId, stalePersistedToken).catch(() => {});
+        await deregisterAgent(acServerPort, cliBase, stalePersistedToken).catch(() => {});
         clearPersistedAgentToken(projectId, agentId);
       }
       // #478: force-replace so AC expires any ghost slots for this base
       // #565: retry with backoff and degrade gracefully if AC is not ready
-      const registration = await registerAgentWithRetry(acServerPort, agentId, agentCfg.display_name || null, { force: true });
+      // #588: register with CLI name as base, role name as label
+      const registration = await registerAgentWithRetry(acServerPort, cliBase, agentCfg.display_name || agentId, { force: true });
       if (!registration) {
         console.warn(`[#565] Agent ${agentId}: AC registration failed after retries (${registerAgent.lastError}). Spawning without chat integration.`);
       } else {
@@ -413,16 +417,18 @@ async function buildAgentArgs(projectId, agentId) {
         // recovery in spawnAgentPty can retry registration later.
         return { args, acRegistrationName: null, acServerPort, acRegistrationToken: null, acInjectMode: injectMode, acMcpHttpPort: mcpHttpPort || null };
       }
-      // #242: best-effort deregister stale canonical name first using
-      // the persisted bearer token from a previous session.
+      // #588: deregister stale registration — try both old role-based
+      // name and CLI-based name for backward compat during transition.
       const stalePersistedToken = readPersistedAgentToken(projectId, agentId);
       if (stalePersistedToken) {
         await deregisterAgent(acServerPort, agentId, stalePersistedToken).catch(() => {});
+        await deregisterAgent(acServerPort, cliBase, stalePersistedToken).catch(() => {});
         clearPersistedAgentToken(projectId, agentId);
       }
       // #478: force-replace so AC expires any ghost slots for this base
       // #565: retry with backoff and degrade gracefully if AC is not ready
-      const registration = await registerAgentWithRetry(acServerPort, agentId, agentCfg.display_name || null, { force: true });
+      // #588: register with CLI name as base, role name as label
+      const registration = await registerAgentWithRetry(acServerPort, cliBase, agentCfg.display_name || agentId, { force: true });
       if (!registration) {
         console.warn(`[#565] Agent ${agentId}: AC registration failed after retries (${registerAgent.lastError}). Spawning without chat integration.`);
       } else {
@@ -496,19 +502,24 @@ async function recoverFrom409(projectId, agentId, session) {
   const cfg = readConfig();
   const project = cfg.projects?.find((p) => p.id === projectId);
   const agentCfg = project?.agents?.[agentId] || {};
+  const command = agentCfg.command || "claude";
+  const cliBase = command.split("/").pop().split(" ")[0];
   // AC may need a moment to come back up after a restart — wait briefly.
   await waitForAgentChattrReady(session.acServerPort, 10000);
 
   // Best-effort cleanup of the stale registration on disk so the
   // fresh register isn't shoved into a slot 2 by leftover state.
+  // #588: try both old role-based name and CLI-based name.
   const stale = readPersistedAgentToken(projectId, agentId);
   if (stale) {
     await deregisterAgent(session.acServerPort, agentId, stale).catch(() => {});
+    await deregisterAgent(session.acServerPort, cliBase, stale).catch(() => {});
     clearPersistedAgentToken(projectId, agentId);
   }
 
   // #478: force-replace so AC expires any ghost slots for this base
-  const replacement = await registerAgent(session.acServerPort, agentId, agentCfg.display_name || null, { force: true });
+  // #588: register with CLI name as base, role name as label
+  const replacement = await registerAgent(session.acServerPort, cliBase, agentCfg.display_name || agentId, { force: true });
   if (!replacement) return;
 
   const previousName = session.acRegistrationName;
@@ -2424,6 +2435,46 @@ server.listen(PORT, "127.0.0.1", async () => {
           console.warn(`[reseed] ${p.id}/${agentId}: failed to patch ${filename}: ${err.message}`);
         }
       }
+    }
+  }
+  // #588: migrate config.toml from role-based to CLI-based agent sections.
+  // Old configs have [agents.head], [agents.dev], etc. AC's registry needs
+  // CLI-based sections ([agents.claude], [agents.codex]) to accept base
+  // registration. Add CLI sections if missing; leave role sections for compat.
+  for (const p of (startupCfg.projects || [])) {
+    const acPath = projectAgentchattrConfigPath(p.id);
+    if (!fs.existsSync(acPath)) continue;
+    try {
+      let toml = fs.readFileSync(acPath, "utf-8");
+      const cliSections = new Set();
+      // Discover which CLIs are used by this project's agents
+      for (const [, agentCfg] of Object.entries(p.agents || {})) {
+        const cmd = agentCfg.command || "claude";
+        const cli = cmd.split("/").pop().split(" ")[0];
+        cliSections.add(cli);
+      }
+      let changed = false;
+      for (const cli of cliSections) {
+        const sectionPattern = new RegExp(`^\\[agents\\.${cli}\\]`, "m");
+        if (!sectionPattern.test(toml)) {
+          const injectMode = cli === "codex" ? "proxy_flag" : cli === "gemini" ? "env" : "flag";
+          toml += `\n[agents.${cli}]\ncommand = "${cli}"\nlabel = "${cli.charAt(0).toUpperCase() + cli.slice(1)}"\nmcp_inject = "${injectMode}"\n`;
+          changed = true;
+        }
+      }
+      if (changed) {
+        fs.writeFileSync(acPath, toml);
+        console.log(`[#588] ${p.id}: added CLI-based agent sections to config.toml`);
+        // Restart AC so it picks up the new sections
+        setTimeout(async () => {
+          try {
+            const r = await fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(p.id)}/restart`, { method: "POST" });
+            if (r.ok) console.log(`[#588] ${p.id}: restarted AC after config migration`);
+          } catch {}
+        }, 3000);
+      }
+    } catch (err) {
+      console.warn(`[#588] ${p.id}: config.toml migration failed: ${err.message}`);
     }
   }
   // #478 + #502: patch deployed AgentChattr instances to support force-replace

--- a/server/routes.js
+++ b/server/routes.js
@@ -2172,10 +2172,21 @@ router.post("/api/setup", (req, res) => {
       content += `[server]\nport = ${chattrPort}\nhost = "127.0.0.1"\ndata_dir = "${dataDir}"\n`;
       if (sessionToken) content += `session_token = "${sessionToken}"\n`;
       content += `\n`;
+      // #588: write CLI-based agent sections (deduped by CLI name) so AC's
+      // registry accepts the base. Role names are passed as labels at
+      // registration time, not as config.toml section names.
+      const seenClis = new Map(); // cliName → { color, label, mcp_inject }
       agents.forEach((agent, i) => {
-        const wtDir = path.join(parentDir, `${dirName}-${agent}`);
-        content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${labels[i]}"\nmcp_inject = "flag"\n\n`;
+        const cmd = (backends && backends[agent]) || "claude";
+        const cli = cmd.split("/").pop().split(" ")[0];
+        if (!seenClis.has(cli)) {
+          const injectMode = cli === "codex" ? "proxy_flag" : cli === "gemini" ? "env" : "flag";
+          seenClis.set(cli, { command: cmd, color: colors[i], label: cli.charAt(0).toUpperCase() + cli.slice(1), mcp_inject: injectMode });
+        }
       });
+      for (const [cli, cfg] of seenClis) {
+        content += `[agents.${cli}]\ncommand = "${cfg.command}"\ncolor = "${cfg.color}"\nlabel = "${cfg.label}"\nmcp_inject = "${cfg.mcp_inject}"\n\n`;
+      }
       // #403 / quadwork#274: raise the loop guard from AC's default
       // of 4 to 30 so autonomous PR review cycles (head→dev→re1+re2→
       // dev→head, ~5 hops) don't fire mid-batch and force the


### PR DESCRIPTION
## Summary
Fixes #588 — agent registration sent role names (`head`, `dev`, `re1`, `re2`) as the `base` parameter to AC's `/api/register`, but AC validates bases against `[agents.*]` config.toml sections which expect CLI names (`claude`, `codex`, `gemini`). Registration returned 400 "unknown base" and all agents spawned without chat integration.

- **Registration**: sends `cliBase` (`claude`/`codex`/`gemini`) as `base` and `agentId` (`head`/`dev`/`re1`/`re2`) as `label` — AC assigns the label as the display name per `registry.py:149`
- **config.toml generation**: writes CLI-based agent sections (deduped by CLI name) instead of role-based sections, so AC's registry seeds the correct bases
- **Startup migration**: adds CLI-based sections to existing config.toml files that only have role-based sections, and restarts AC to pick them up
- **Stale deregistration**: tries both old role-based name and new CLI-based name for backward compat during the transition
- **recoverFrom409**: also updated to resolve `cliBase` and use it for re-registration

## Test plan
- [ ] Fresh install: create project, verify agents register successfully (no "unknown base" in logs)
- [ ] Existing install: verify startup migration adds CLI sections to config.toml (`[#588]` log line)
- [ ] Verify AC chat shows agents with role-name labels (head, dev, re1, re2) not CLI names
- [ ] Verify `force: true` still lands at slot 1 with CLI-based base
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)