### PR TITLE
[#592] Add CLI-based agent sections in config.toml for AC HEAD

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2176,6 +2176,19 @@ router.post("/api/setup", (req, res) => {
         const wtDir = path.join(parentDir, `${dirName}-${agent}`);
         content += `[agents.${agent}]\ncommand = "${(backends && backends[agent]) || "claude"}"\ncwd = "${wtDir}"\ncolor = "${colors[i]}"\nlabel = "${labels[i]}"\nmcp_inject = "flag"\n\n`;
       });
+      // #592: CLI-based agent sections for AC HEAD compatibility.
+      // HEAD AC validates `base` against [agents.*] keys. Add CLI-name
+      // sections (deduped) so registration works on both pinned and HEAD AC.
+      const seenClis = new Set();
+      agents.forEach((agent) => {
+        const cmd = (backends && backends[agent]) || "claude";
+        const cli = cmd.split("/").pop().split(" ")[0];
+        seenClis.add(cli);
+      });
+      for (const cli of seenClis) {
+        const injectMode = cli === "codex" ? "proxy_flag" : cli === "gemini" ? "env" : "flag";
+        content += `[agents.${cli}]\ncommand = "${cli}"\nlabel = "${cli}"\nmcp_inject = "${injectMode}"\n\n`;
+      }
       // #403 / quadwork#274: raise the loop guard from AC's default
       // of 4 to 30 so autonomous PR review cycles (head→dev→re1+re2→
       // dev→head, ~5 hops) don't fire mid-batch and force the

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -37,6 +37,20 @@ cwd = "{{dev_cwd}}"
 color = "#da7756"
 label = "Builder"
 
+# #592: CLI-based agent sections for AC HEAD compatibility.
+# HEAD AC validates `base` against [agents.*] keys in config.toml.
+# These sections let registration succeed with CLI names as base,
+# regardless of whether AC is running pinned or at HEAD.
+[agents.claude]
+command = "claude"
+label = "claude"
+mcp_inject = "flag"
+
+[agents.codex]
+command = "codex"
+label = "codex"
+mcp_inject = "proxy_flag"
+
 # #383: AC's registry rejects bases not declared in config.toml.
 # The Telegram bridge registers as `tg` (#439: renamed from
 # `telegram-bridge`), so every per-project AC config must declare


### PR DESCRIPTION
## Summary
- Adds CLI-based `[agents.claude]` and `[agents.codex]` sections to config.toml alongside existing role-based sections (`[agents.head]`, `[agents.dev]`, etc.)
- HEAD AC validates `base` against `[agents.*]` keys — CLI sections ensure registration succeeds whether AC is pinned or running at HEAD
- No registration logic changes — role-based sections still work for pinned AC

## Investigation
Verified AC HEAD's `registry.py`: `register(base)` checks `base in self._bases`, where `_bases` is seeded from `[agents.*]` config.toml keys. Adding CLI-name sections makes both role names and CLI names valid bases.

## Changes
- **`templates/config.toml`**: Added `[agents.claude]` and `[agents.codex]` sections with correct `mcp_inject` modes
- **`server/routes.js`**: Setup wizard appends deduped CLI-based sections after role-based sections

## Safety
- Pinned AC ignores unknown sections → CLI sections are a no-op
- HEAD AC gets the sections it needs → registration succeeds
- Existing projects on pinned AC are unaffected
- `npm run build` passes

## Test plan
- [ ] Verify config.toml generated by setup wizard contains both role and CLI sections
- [ ] Verify `npx quadwork init` template includes CLI sections
- [ ] Confirm registration works on pinned AC (no regression)
- [ ] Confirm registration works on HEAD AC with CLI-based base

Fixes #592