### PR TITLE
[#593] Harden AC pin checkout with retry + hard failure

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -268,16 +268,21 @@ function _installAgentChattrLocked(dir, setError) {
     // On failure (commit unreachable / force-pushed away), fall
     // back to the default branch with a loud warning instead of
     // hard-failing the install.
-    const pinResult = run("git", ["-C", dir, "checkout", "-B", "pinned", AGENTCHATTR_PIN], { timeout: 30000 });
+    // #593: Retry with explicit fetch on failure, abort install on persistent failure.
+    let pinResult = run("git", ["-C", dir, "checkout", "-B", "pinned", AGENTCHATTR_PIN], { timeout: 30000 });
     if (pinResult === null) {
-      const pinWarnMsg = `Could not check out AgentChattr pin ${AGENTCHATTR_PIN} at ${dir}; falling back to default branch. AC's argparse may reject unknown flags. Update AGENTCHATTR_PIN in bin/quadwork.js for reproducible installs.`;
-      warn(pinWarnMsg);
-      // Persist to install log so post-mortem diagnosis is possible
-      // without re-running the install.
-      try {
-        const logDir = path.join(path.dirname(dir));
-        fs.appendFileSync(path.join(logDir, "install.log"), `[${new Date().toISOString()}] PIN-CHECKOUT-FAIL: ${pinWarnMsg}\n`);
-      } catch {}
+      log("Pin checkout failed — fetching commit explicitly...");
+      run("git", ["-C", dir, "fetch", "origin", AGENTCHATTR_PIN], { timeout: 60000 });
+      pinResult = run("git", ["-C", dir, "checkout", "-B", "pinned", AGENTCHATTR_PIN], { timeout: 30000 });
+    }
+    if (pinResult === null) {
+      return setError(
+        `Could not check out AgentChattr pin ${AGENTCHATTR_PIN.slice(0, 12)} at ${dir}. ` +
+        `AC would run an untested HEAD version with known incompatibilities. ` +
+        `Check your network connection and retry, or manually run:\n` +
+        `  git -C ${dir} fetch origin ${AGENTCHATTR_PIN}\n` +
+        `  git -C ${dir} checkout -B pinned ${AGENTCHATTR_PIN}`
+      );
     }
   } else {
     // #366: existing clone from a pre-fix install. If the clone


### PR DESCRIPTION
## Summary
- Pin checkout now retries with explicit `git fetch origin <sha>` when the initial attempt fails
- Install aborts with clear error + manual fix instructions if both attempts fail — no more silent continuation on HEAD AC
- Fetch timeout increased to 60s for slow VPS/network environments

## Changes
- **`bin/quadwork.js`**: Replaced single-attempt pin checkout + silent fallback with retry logic and hard failure

## Safety
- Fast networks: attempt 1 succeeds instantly, no behavior change
- Slow networks: adds one fetch + retry (~30s extra at most)
- Persistent failure: install stops cleanly instead of producing a broken AC installation
- Existing installs unaffected (pin checkout only runs on fresh clone)
- `npm run build` passes

## Test plan
- [ ] Fresh install on fast network succeeds without delay
- [ ] Simulated first-attempt failure recovers via explicit fetch
- [ ] Both attempts failing produces clear error with manual fix commands
- [ ] Existing AC installs are unaffected (code path not reached)

Fixes #593