### PR TITLE
[#598] Remove duplicate AC restart during project setup

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2197,12 +2197,6 @@ router.post("/api/setup", (req, res) => {
       content += `[mcp]\nhttp_port = ${mcp_http}\nsse_port = ${mcp_sse}\n`;
       writeSecureFile(tomlPath, content);
 
-      // Restart this project's AgentChattr instance (not global)
-      try {
-        const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
-        const qwPort = cfg.port || 8400;
-        fetch(`http://127.0.0.1:${qwPort}/api/agentchattr/${encodeURIComponent(dirName)}/restart`, { method: "POST" }).catch(() => {});
-      } catch {}
       return res.json({ ok: true, path: tomlPath, agentchattr_token: sessionToken, agentchattr_port: chattrPort, mcp_http_port: mcp_http, mcp_sse_port: mcp_sse });
     }
     case "add-config": {


### PR DESCRIPTION
## Summary
- Removes the duplicate AgentChattr restart call from the `agentchattr-config` setup step (`server/routes.js:2200-2205`)
- The `add-config` step that runs immediately after already triggers a restart — the duplicate caused the first AC instance to be killed, orphaning agent registrations and creating suffixed names (head-2, dev-2) on fresh installs
- Existing installs with persisted agent tokens were unaffected; this only manifested on fresh installs

## Test plan
- [ ] Fresh project setup produces only ONE `restart: port 8300 is free, spawning AC` log line
- [ ] Agents register as `head`, `dev`, `re1`, `re2` (no `-2` suffixes)
- [ ] Config.toml is written before AC starts (agentchattr-config still runs first)
- [ ] `npm run build` passes

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)