### PR TITLE
[#600] Display QuadWork version number at bottom of sidebar

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2197,12 +2197,6 @@ router.post("/api/setup", (req, res) => {
       content += `[mcp]\nhttp_port = ${mcp_http}\nsse_port = ${mcp_sse}\n`;
       writeSecureFile(tomlPath, content);
 
-      // Restart this project's AgentChattr instance (not global)
-      try {
-        const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
-        const qwPort = cfg.port || 8400;
-        fetch(`http://127.0.0.1:${qwPort}/api/agentchattr/${encodeURIComponent(dirName)}/restart`, { method: "POST" }).catch(() => {});
-      } catch {}
       return res.json({ ok: true, path: tomlPath, agentchattr_token: sessionToken, agentchattr_port: chattrPort, mcp_http_port: mcp_http, mcp_sse_port: mcp_sse });
     }
     case "add-config": {

--- a/server/routes.js
+++ b/server/routes.js
@@ -124,6 +124,13 @@ function writeConfigFile(cfg) {
   writeConfig(cfg);
 }
 
+// ─── Version ──────────────────────────────────────────────────────────────
+
+router.get("/api/version", (_req, res) => {
+  const pkg = require("../package.json");
+  res.json({ version: pkg.version });
+});
+
 // ─── Config ────────────────────────────────────────────────────────────────
 
 router.get("/api/config", (_req, res) => {
@@ -2197,6 +2204,12 @@ router.post("/api/setup", (req, res) => {
       content += `[mcp]\nhttp_port = ${mcp_http}\nsse_port = ${mcp_sse}\n`;
       writeSecureFile(tomlPath, content);
 
+      // Restart this project's AgentChattr instance (not global)
+      try {
+        const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+        const qwPort = cfg.port || 8400;
+        fetch(`http://127.0.0.1:${qwPort}/api/agentchattr/${encodeURIComponent(dirName)}/restart`, { method: "POST" }).catch(() => {});
+      } catch {}
       return res.json({ ok: true, path: tomlPath, agentchattr_token: sessionToken, agentchattr_port: chattrPort, mcp_http_port: mcp_http, mcp_sse_port: mcp_sse });
     }
     case "add-config": {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -191,6 +191,7 @@ export default function Sidebar() {
   const [backendStatus, setBackendStatus] = useState<"online" | "offline" | "recovering">("online");
   const [expanded, setExpanded] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
+  const [version, setVersion] = useState<string>("");
   const configRef = useRef<Record<string, unknown> | null>(null);
 
   // Restore persisted state on mount — only on desktop-width screens
@@ -220,6 +221,13 @@ export default function Sidebar() {
       return next;
     });
   };
+
+  useEffect(() => {
+    fetch("/api/version")
+      .then((r) => r.json())
+      .then((d) => setVersion(d.version || ""))
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     fetch("/api/config")
@@ -623,6 +631,12 @@ export default function Sidebar() {
         <GearIcon />
         {expanded && <span className="text-xs">Settings</span>}
       </Link>
+
+      {version && (
+        <div className={`text-[10px] text-text-muted/40 ${expanded ? "px-3" : "text-center"} pt-2`}>
+          v{version}
+        </div>
+      )}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `GET /api/version` endpoint that reads version from `package.json`
- Fetches and displays the version as muted text (`v1.14.3`) at the very bottom of the sidebar, below the Settings link
- Works in both collapsed (centered) and expanded (left-aligned) sidebar states

## Test plan
- [ ] Version number visible at bottom of left sidebar in both collapsed and expanded states
- [ ] Version matches `package.json` version
- [ ] `npm run build` passes

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)