### PR TITLE
[#601] Add exact item format to Head AGENTS.md overnight queue seed

### DIFF
--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -67,8 +67,11 @@ When the operator asks you in chat to start a task or batch:
    **Started:** <YYYY-MM-DD HH:MM>
    **Status:** pending kickoff
 
-   (items...)
+   - #598 Fix double AC restart
+   - #600 Display version in sidebar
    ```
+
+   Each item MUST start with `- #<number>` (dash, space, hash, issue number). Do NOT prefix with words like "Issue" — `- Issue #598 ...` will NOT be recognized by the batch progress panel. The `#` must be the first token after the list marker.
 
    When you move a batch to Done, **preserve its `Batch: N` line** so the next batch's number computation stays correct.
 3. Reply in chat to confirm what you wrote to the queue file (issue numbers + which section).


### PR DESCRIPTION
## Summary
- Replaces the vague `(items...)` placeholder in the Head AGENTS.md seed template with concrete examples (`- #598 Fix double AC restart`, `- #600 Display version in sidebar`)
- Adds explicit warning that items must start with `- #<number>` — the `- Issue #598` format is silently ignored by the batch progress parser

## Test plan
- [ ] Seed template shows exact item format with examples
- [ ] Explicitly warns against `- Issue #598` format
- [ ] `npm run build` passes (template-only change, no code impact)

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)