### PR TITLE
Auto-trust worktree directories for Claude Code agents

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2049,12 +2049,16 @@ router.post("/api/setup", (req, res) => {
       // Pre-trust worktree directories for Claude Code agents (#599).
       // Running `claude -p` in a directory auto-trusts it for future sessions,
       // preventing the interactive "Do you trust this directory?" prompt.
-      const claudePath = exec("which", ["claude"]);
-      if (claudePath.ok) {
-        for (const agent of agents) {
-          const wtDir = path.join(parentDir, `${projectName}-${agent}`);
-          if (!fs.existsSync(wtDir)) continue;
-          exec("claude", ["-p", "echo ok"], { cwd: wtDir, timeout: 15000, stdio: "pipe" });
+      const agentBackends = body.backends || {};
+      const claudeAgents = agents.filter((a) => (agentBackends[a] || "claude") === "claude");
+      if (claudeAgents.length > 0) {
+        const claudePath = exec("which", ["claude"]);
+        if (claudePath.ok) {
+          for (const agent of claudeAgents) {
+            const wtDir = path.join(parentDir, `${projectName}-${agent}`);
+            if (!fs.existsSync(wtDir)) continue;
+            exec("claude", ["-p", "echo ok"], { cwd: wtDir, timeout: 15000, stdio: "pipe" });
+          }
         }
       }
       return res.json({ ok: errors.length === 0, created, errors });

--- a/server/routes.js
+++ b/server/routes.js
@@ -2046,6 +2046,17 @@ router.post("/api/setup", (req, res) => {
           else errors.push(`${agent}: ${result.output}`);
         }
       }
+      // Pre-trust worktree directories for Claude Code agents (#599).
+      // Running `claude -p` in a directory auto-trusts it for future sessions,
+      // preventing the interactive "Do you trust this directory?" prompt.
+      const claudePath = exec("which", ["claude"]);
+      if (claudePath.ok) {
+        for (const agent of agents) {
+          const wtDir = path.join(parentDir, `${projectName}-${agent}`);
+          if (!fs.existsSync(wtDir)) continue;
+          exec("claude", ["-p", "echo ok"], { cwd: wtDir, timeout: 15000, stdio: "pipe" });
+        }
+      }
       return res.json({ ok: errors.length === 0, created, errors });
     }
     case "seed-files": {

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -498,7 +498,7 @@ export default function SetupWizard() {
 
     // 1. Create worktrees
     setWorkspaceLog((l) => [...l, "Creating worktrees..."]);
-    const wtResult = await apiCall("create-worktrees", { workingDir, repo });
+    const wtResult = await apiCall("create-worktrees", { workingDir, repo, backends });
     if (!wtResult.ok) {
       setWorkspaceLog((l) => [...l, `Error: ${wtResult.errors?.join(", ") || wtResult.error}`]);
       updateStep(currentStep, { status: "error", error: wtResult.errors?.join(", ") || wtResult.error });


### PR DESCRIPTION
Fixes #599

## Summary
- After creating worktrees in the setup wizard (`create-worktrees` step), runs `claude -p "echo ok"` in each worktree directory to auto-trust it
- Prevents the interactive "Do you trust this directory?" prompt that blocks Claude Code agent PTY sessions on fresh installs
- Only runs when `claude` CLI is installed; non-fatal on failure — existing behavior preserved as fallback

## Safety
- Only executes during project creation (not on every server boot)
- Gated behind `which claude` check — Codex/Gemini agents unaffected
- Append-only change to existing `create-worktrees` handler, no existing logic modified
- `npm run build` passes

## Test plan
- [ ] Fresh install: create a new project via setup wizard, verify Claude agents launch without trust prompt
- [ ] Existing install: verify no behavior change (directories already trusted)
- [ ] Without `claude` CLI: verify setup completes normally (pre-trust step skipped)
- [ ] Codex/Gemini agents: verify unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)