### PR TITLE
[#607] Add bridge agent sections to dashboard config.toml

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2217,6 +2217,9 @@ router.post("/api/setup", (req, res) => {
       // operator to type /continue. AC clamps to [1, 50] internally.
       content += `[routing]\ndefault = "none"\nmax_agent_hops = 30\n\n`;
       content += `[mcp]\nhttp_port = ${mcp_http}\nsse_port = ${mcp_sse}\n`;
+      // #607: Bridge agent declarations so AC accepts dc/tg base registration
+      content += `\n[agents.tg]\nlabel = "Telegram Bridge"\n\n`;
+      content += `[agents.dc]\nlabel = "Discord Bridge"\n`;
       writeSecureFile(tomlPath, content);
 
       return res.json({ ok: true, path: tomlPath, agentchattr_token: sessionToken, agentchattr_port: chattrPort, mcp_http_port: mcp_http, mcp_sse_port: mcp_sse });


### PR DESCRIPTION
## Summary
- Adds `[agents.dc]` and `[agents.tg]` sections to the inline config.toml generation in `server/routes.js` for dashboard-created projects
- Fixes Discord/Telegram bridge registration failing with `400 Bad Request: unknown base: dc/tg` on projects created via the dashboard setup wizard
- Matches the format already used in `templates/config.toml` and the startup migration

Fixes #607

## Test plan
- [ ] Create a new project via the dashboard setup wizard
- [ ] Verify generated config.toml includes `[agents.dc]` and `[agents.tg]` sections
- [ ] Start Discord bridge — confirm it registers successfully (no 400 error)
- [ ] Start Telegram bridge — confirm it registers successfully
- [ ] Verify existing projects are unaffected
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)