### PR TITLE
[#611] Create agent-friendly installation skill docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@
 
 ---
 
+## Installation Guides
+
+Step-by-step guides for setting up QuadWork, designed for both humans and AI coding agents:
+
+- **[Mac Installation](docs/install-mac.md)** — local setup on macOS
+- **[VPS Installation](docs/install-vps.md)** — remote server (Hetzner/Ubuntu) with domain + SSL
+- **[Troubleshooting](docs/troubleshooting.md)** — common issues and fixes
+
+> **For AI agents:** These guides contain complete step-by-step instructions. When your operator asks you to install or troubleshoot QuadWork, read the relevant guide and follow it.
+
 ## What is QuadWork?
 
 **QuadWork** is a local-first, open-source automation framework that

--- a/docs/install-mac.md
+++ b/docs/install-mac.md
@@ -1,0 +1,212 @@
+# QuadWork — Mac Installation Guide
+
+Step-by-step guide for installing QuadWork on macOS. Designed for both humans and AI coding agents.
+
+---
+
+## Prerequisites
+
+### Check existing tools
+
+```bash
+node --version   # Need 20+ (24 recommended)
+python3 --version # Need 3.x
+git --version
+gh --version
+```
+
+### Install missing prerequisites
+
+**Node.js 20+** (via nvm — recommended):
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+source ~/.zshrc
+nvm install 24
+nvm use 24
+```
+
+**Python 3** (via Homebrew if not already installed):
+```bash
+brew install python3
+```
+
+**Git** (included with Xcode Command Line Tools):
+```bash
+xcode-select --install
+```
+
+**GitHub CLI:**
+```bash
+brew install gh
+```
+
+### Fix macOS Python SSL certificates
+
+macOS Python installations often fail SSL verification. Run this once after installing Python:
+
+```bash
+/Applications/Python\ 3.*/Install\ Certificates.command
+```
+
+> **This requires operator input.** If the path doesn't match, ask the user to check their Python version: `ls /Applications/ | grep Python`
+
+Without this fix, AgentChattr's Python dependencies (fastapi, uvicorn) may fail to install with SSL errors.
+
+### Authenticate GitHub CLI
+
+```bash
+gh auth login
+```
+
+> **This is interactive** — the operator must complete the browser-based auth flow. Ask the user to run this command if not already authenticated.
+
+Verify:
+```bash
+gh auth status
+# You should see: "Logged in to github.com account <username>"
+```
+
+---
+
+## Install AI Coding Agents
+
+Install one or more of the supported agent CLIs:
+
+```bash
+# Claude Code (Anthropic)
+npm install -g @anthropic-ai/claude-code
+
+# Codex CLI (OpenAI)
+npm install -g @openai/codex
+
+# Gemini CLI (Google) — if using Gemini agents
+npm install -g @anthropic-ai/claude-code  # placeholder: check Gemini CLI availability
+```
+
+### Authenticate agent CLIs
+
+Each CLI requires a one-time interactive login:
+
+```bash
+# Claude Code — follow the login prompt
+claude
+
+# Codex — follow the login prompt
+codex
+```
+
+> **These are interactive steps.** Ask the operator to run each command and complete the login flow.
+
+---
+
+## Install QuadWork
+
+```bash
+npm install -g quadwork@latest
+```
+
+Verify:
+```bash
+quadwork --version
+# You should see the version number (e.g., 1.14.5)
+```
+
+---
+
+## Initialize & Start
+
+### Interactive setup
+
+```bash
+quadwork init
+```
+
+> **This is interactive.** The operator will be prompted to configure their first project (name, repo, working directory, agent backends).
+
+### Start the server
+
+```bash
+quadwork start
+```
+
+You should see output like:
+```
+QuadWork dashboard: http://localhost:8400
+AgentChattr:        http://127.0.0.1:8300
+```
+
+Open the dashboard URL in your browser to access the web UI.
+
+---
+
+## Create Your First Project
+
+1. Open the dashboard at `http://localhost:8400`
+2. Click **"+ New Project"** or navigate to `/setup`
+3. Fill in the project details:
+   - **Name:** Your project name
+   - **Repo:** GitHub repo in `owner/repo` format
+   - **Working directory:** Absolute path to the repo clone
+   - **Agent backends:** Choose Claude, Codex, or Gemini for each agent role
+4. Click **Create**
+
+QuadWork will:
+- Create worktree directories for each agent (e.g., `project-head/`, `project-dev/`, `project-re1/`, `project-re2/`)
+- Generate AgentChattr config
+- Seed AGENTS.md files for each role
+
+---
+
+## Trust Prompt (Claude Code)
+
+On first launch, Claude Code agents may get stuck at a "Do you trust this directory?" prompt. QuadWork v1.14.5+ automatically pre-trusts worktree directories for Claude-configured agents during project creation.
+
+**If agents are still stuck** (e.g., upgraded from an older version), manually pre-trust each worktree:
+
+```bash
+# Run in each worktree directory
+cd /path/to/project-head && claude -p "echo ok"
+cd /path/to/project-dev && claude -p "echo ok"
+cd /path/to/project-re1 && claude -p "echo ok"
+cd /path/to/project-re2 && claude -p "echo ok"
+```
+
+---
+
+## Discord / Telegram Bridge (Optional)
+
+### Discord bridge
+
+1. Open the project page in the dashboard
+2. Click the **Discord** widget
+3. Enter your Discord bot token and channel ID
+4. Click **Start**
+
+### Telegram bridge
+
+1. Open the project page in the dashboard
+2. Click the **Telegram** widget
+3. Enter your Telegram bot token and chat ID
+4. Click **Start**
+
+> **Note:** Bridge agent sections (`[agents.dc]`, `[agents.tg]`) are automatically included in config.toml for projects created on v1.14.6+. If upgrading from an older version, restart QuadWork — the startup migration will add them.
+
+---
+
+## Stopping & Restarting
+
+```bash
+# Stop the server (Ctrl+C if running in foreground)
+# Or if running in background:
+quadwork stop
+
+# Restart
+quadwork start
+```
+
+For persistent background operation on Mac, consider using pm2:
+```bash
+npm install -g pm2
+pm2 start "quadwork start" --name quadwork
+pm2 save
+```

--- a/docs/install-mac.md
+++ b/docs/install-mac.md
@@ -80,7 +80,7 @@ npm install -g @anthropic-ai/claude-code
 npm install -g @openai/codex
 
 # Gemini CLI (Google) — if using Gemini agents
-npm install -g @anthropic-ai/claude-code  # placeholder: check Gemini CLI availability
+npm install -g @google/gemini-cli
 ```
 
 ### Authenticate agent CLIs

--- a/docs/install-vps.md
+++ b/docs/install-vps.md
@@ -1,0 +1,317 @@
+# QuadWork — VPS Installation Guide
+
+Step-by-step guide for installing QuadWork on a remote VPS (Hetzner/Ubuntu). Based on real deployment notes. Designed for both humans and AI coding agents.
+
+---
+
+## Recommended VPS Setup
+
+**Provider:** [Hetzner Cloud](https://www.hetzner.com/cloud/) — tested and confirmed working.
+
+| Setting | Value |
+|---|---|
+| Type | Shared Resources > **Regular Performance** (x86 AMD) |
+| Plan | **CPX32** — 4 vCPU, 8 GB RAM, 160 GB disk (~$17/mo) |
+| Image | **Ubuntu 24.04** |
+| Networking | **IPv4 + IPv6** |
+| SSH keys | Add your public key |
+
+**Why CPX32:** QuadWork runs 4 concurrent AI agents, each spawning its own PTY + subprocess. 4 vCPUs map to the 4-agent model, 8 GB RAM provides headroom. Smaller plans may work for testing.
+
+**Why Regular Performance:** Newer AMD hardware with consistent CPU. Cost-Optimized uses older generation hardware — not ideal for sustained agent workloads.
+
+---
+
+## Step 1: Initial SSH Access
+
+After creating the server, add it to your local `~/.ssh/config`:
+
+```
+Host quadwork
+    User root
+    HostName <server-ip>
+    Port 22
+    IdentityFile ~/.ssh/<your-key>
+```
+
+Verify: `ssh quadwork`
+
+---
+
+## Step 2: Create Non-Root User (CRITICAL)
+
+Claude Code blocks `--dangerously-skip-permissions` when running as root. Agents will crash immediately if QuadWork runs under root.
+
+Run these as root:
+
+```bash
+useradd -m -s /bin/bash quadwork
+mkdir -p /projects
+chown quadwork:quadwork /projects
+```
+
+Grant passwordless sudo:
+
+```bash
+echo "quadwork ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/quadwork
+chmod 440 /etc/sudoers.d/quadwork
+```
+
+Copy SSH keys:
+
+```bash
+mkdir -p /home/quadwork/.ssh
+cp /root/.ssh/authorized_keys /home/quadwork/.ssh/authorized_keys
+chown -R quadwork:quadwork /home/quadwork/.ssh
+chmod 700 /home/quadwork/.ssh
+chmod 600 /home/quadwork/.ssh/authorized_keys
+```
+
+Update local `~/.ssh/config` — change `User root` to `User quadwork`. **All subsequent steps run as the `quadwork` user.**
+
+---
+
+## Step 3: System Packages
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3.12-venv git
+```
+
+`python3.12-venv` is required for AgentChattr's Python venv. Without it, the venv is created without pip, and AgentChattr crashes with `ModuleNotFoundError: No module named 'fastapi'`.
+
+---
+
+## Step 4: Node.js via nvm (REQUIRED)
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+source ~/.bashrc
+nvm install 24
+nvm use 24
+```
+
+**Do NOT use system Node (`apt` or `nodesource`).** Only use nvm. System Node alongside nvm creates PATH conflicts — pm2 and QuadWork spawn agents with system PATH (missing nvm binaries), causing agents to fail auth or not be found.
+
+---
+
+## Step 5: GitHub CLI
+
+```bash
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list
+sudo apt-get update && sudo apt-get install -y gh
+```
+
+---
+
+## Step 6: AI Agent CLIs
+
+```bash
+npm install -g @anthropic-ai/claude-code
+npm install -g @openai/codex
+```
+
+All binaries (`claude`, `codex`, `quadwork`, `pm2`) live under `~/.nvm/versions/node/v24.x.x/bin/`.
+
+### Authenticate CLIs
+
+> **These are interactive steps.** The operator must run these via `ssh quadwork`:
+
+```bash
+gh auth login     # Follow browser-based auth flow
+claude            # Follow login prompt
+codex             # Follow login prompt
+```
+
+**If migrating from an existing server**, copy auth configs instead:
+
+```bash
+# From your local machine
+ssh quadwork-old 'tar czf /tmp/auth-backup.tar.gz .claude .codex .config/gh'
+scp quadwork-old:/tmp/auth-backup.tar.gz /tmp/
+scp /tmp/auth-backup.tar.gz quadwork:/tmp/
+ssh quadwork 'cd ~ && tar xzf /tmp/auth-backup.tar.gz && rm /tmp/auth-backup.tar.gz'
+```
+
+---
+
+## Step 7: Install QuadWork
+
+```bash
+npm install -g quadwork@latest
+```
+
+Optional — pre-create config at `~/.quadwork/config.json`:
+
+```json
+{
+  "port": 3000,
+  "agentchattr_url": "http://127.0.0.1:8300",
+  "agentchattr_dir": "",
+  "projects": []
+}
+```
+
+Run interactive setup:
+
+```bash
+quadwork init
+```
+
+---
+
+## Step 8: Process Management with pm2
+
+```bash
+npm install -g pm2
+```
+
+**IMPORTANT:** pm2 strips PATH from child processes. Even if nvm is loaded, the QuadWork process won't have nvm binaries in PATH. **Do not fix with symlinks** — they resolve the binary but not the environment.
+
+Create a wrapper script:
+
+```bash
+cat > ~/start-quadwork.sh << 'EOF'
+#!/bin/bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm use 24
+exec quadwork start
+EOF
+chmod +x ~/start-quadwork.sh
+```
+
+Start with pm2:
+
+```bash
+pm2 start ~/start-quadwork.sh --name quadwork --interpreter /bin/bash
+pm2 save
+```
+
+Auto-start on reboot:
+
+```bash
+pm2 startup systemd
+# This prints a sudo command — copy and run it. Example:
+# sudo env PATH=... pm2 startup systemd -u quadwork --hp /home/quadwork
+```
+
+**Important:** Always run `pm2 save` while the process is **online**. If saved while stopped, it resurrects as stopped on every reboot.
+
+### Common pm2 commands
+
+```bash
+pm2 list                          # View processes
+pm2 logs quadwork                 # Live logs
+pm2 logs quadwork --lines 50 --nostream  # Last 50 lines
+pm2 stop quadwork                 # Stop
+pm2 start quadwork                # Start
+pm2 restart quadwork              # Restart
+pm2 save                          # Save state (always do after start/stop)
+```
+
+---
+
+## Step 9: Domain + Nginx + SSL
+
+### DNS
+
+Create an A record: `app.example.com` -> server IP.
+
+### Nginx reverse proxy
+
+```bash
+sudo apt-get install -y nginx
+```
+
+Create `/etc/nginx/sites-available/app.example.com`:
+
+```nginx
+server {
+    listen 80;
+    server_name app.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+}
+```
+
+`proxy_read_timeout 86400` and WebSocket headers are required for live agent terminal connections.
+
+```bash
+sudo ln -sf /etc/nginx/sites-available/app.example.com /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### SSL with Let's Encrypt
+
+```bash
+sudo apt-get install -y certbot python3-certbot-nginx
+sudo certbot --nginx -d app.example.com --non-interactive --agree-tos -m your@email.com
+```
+
+---
+
+## Step 10: Basic HTTP Auth (Recommended)
+
+The dashboard is publicly accessible once deployed. Add password protection:
+
+```bash
+openssl rand -base64 18
+# Save the output as your password
+
+sudo apt-get install -y apache2-utils
+sudo htpasswd -cb /etc/nginx/.htpasswd admin 'YOUR_GENERATED_PASSWORD'
+```
+
+Add to the nginx `server` block (inside the `listen 443 ssl` block):
+
+```nginx
+auth_basic "QuadWork";
+auth_basic_user_file /etc/nginx/.htpasswd;
+```
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+Save credentials for reference:
+
+```bash
+cat > ~/.quadwork/.env << 'EOF'
+QUADWORK_HTTP_USER=admin
+QUADWORK_HTTP_PASS=YOUR_GENERATED_PASSWORD
+EOF
+chmod 600 ~/.quadwork/.env
+```
+
+---
+
+## Quick Reference: Full Install Order
+
+1. Create Hetzner VPS (CPX32, Ubuntu 24.04, Regular Performance)
+2. SSH in as root, create `quadwork` user with sudo + SSH keys
+3. Update local SSH config to `User quadwork`
+4. Install system packages: `python3.12-venv`, `git`
+5. Install nvm + Node.js 24
+6. Install GitHub CLI
+7. Install Claude Code + Codex CLI
+8. Authenticate CLIs (gh, claude, codex)
+9. Install QuadWork + pm2
+10. Run `quadwork init`
+11. Start with pm2 wrapper, save, configure startup
+12. Set up DNS A record
+13. Configure nginx reverse proxy + SSL
+14. Add HTTP basic auth
+15. Verify reboot survival: `sudo reboot`, then check `pm2 list`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,175 @@
+# QuadWork — Troubleshooting
+
+Common issues and fixes, structured as **Symptom > Cause > Fix**. Searchable by error message.
+
+---
+
+## Claude Code trust prompt blocking agents
+
+**Symptom:** Claude Code agents hang on startup. Terminal shows "Do you trust the files in this folder?" and waits for input indefinitely.
+
+**Cause:** Claude Code requires explicit directory trust before running. The `--dangerously-skip-permissions` flag skips permission prompts but does NOT skip the trust gate.
+
+**Fix:** Pre-trust each worktree directory:
+
+```bash
+cd /path/to/project-dev && claude -p "echo ok"
+cd /path/to/project-head && claude -p "echo ok"
+cd /path/to/project-re1 && claude -p "echo ok"
+cd /path/to/project-re2 && claude -p "echo ok"
+```
+
+QuadWork v1.14.5+ automatically pre-trusts worktree directories for Claude-configured agents during project creation. If upgrading from an older version, run the commands above once.
+
+---
+
+## Agent suffix proliferation (head-2, dev-2)
+
+**Symptom:** Agents register as `head-2`, `dev-2`, `re1-3` instead of their base names. Chat mentions break because agents look for `@head-2` instead of `@head`.
+
+**Cause:** AgentChattr assigns a numeric suffix when another session with the same base name is still registered (e.g., from a crashed process that didn't clean up).
+
+**Fix:**
+1. Stop all agents: stop the QuadWork server
+2. Restart AgentChattr (or restart QuadWork entirely)
+3. Agents will re-register with their base names
+
+QuadWork v1.15.0+ includes suffix-awareness in AGENTS.md seeds — agents will match mentions by base role name regardless of suffix.
+
+---
+
+## AgentChattr not reachable on port 8300
+
+**Symptom:** Agents fail to register. Logs show connection refused to `127.0.0.1:8300`.
+
+**Cause:** AgentChattr may not have started yet, or crashed during startup.
+
+**Fix:**
+1. Check if AgentChattr is running:
+   ```bash
+   curl http://127.0.0.1:8300/healthz
+   ```
+2. If not running, check the AgentChattr logs in the project's data directory
+3. Restart QuadWork — it will restart AgentChattr automatically
+
+---
+
+## Discord/Telegram bridge: 400 "unknown base: dc"
+
+**Symptom:** Bridge shows "Running" but messages don't forward. Bridge log shows: `Initial AC registration failed: 400 Client Error` / `unknown base: dc` (or `tg`).
+
+**Cause:** The project's `config.toml` is missing `[agents.dc]` and/or `[agents.tg]` sections. AgentChattr validates the `base` field against `[agents.*]` keys during registration.
+
+**Fix:**
+1. Restart QuadWork — the startup migration (`bridge-migrate`) will add the missing sections
+2. If the bridge still fails, manually add to the project's `config.toml`:
+   ```toml
+   [agents.dc]
+   label = "Discord Bridge"
+
+   [agents.tg]
+   label = "Telegram Bridge"
+   ```
+3. Restart AgentChattr for the project (use the dashboard SERVER > Restart button)
+
+QuadWork v1.14.6+ includes bridge sections in config.toml for all new projects.
+
+---
+
+## SSL certificate error on macOS Python
+
+**Symptom:** AgentChattr dependency installation fails with `ssl.SSLCertVerificationError` or `[SSL: CERTIFICATE_VERIFY_FAILED]`.
+
+**Cause:** macOS Python installations ship without root certificates configured. The system certificates are not linked to Python's `certifi` package.
+
+**Fix:**
+
+```bash
+/Applications/Python\ 3.*/Install\ Certificates.command
+```
+
+> **This requires operator input.** If the path doesn't match, check: `ls /Applications/ | grep Python`
+
+---
+
+## pm2 PATH stripping (nvm binaries not found)
+
+**Symptom:** Agents fail to launch. Logs show `claude: command not found` or agents get stuck on login prompts even though `claude` works in interactive SSH.
+
+**Cause:** pm2 strips environment variables from child processes. Even if nvm is loaded when you run `pm2 start`, the QuadWork process inherits a minimal PATH without nvm binaries.
+
+**Fix:** Use a wrapper script that sources nvm before starting QuadWork:
+
+```bash
+cat > ~/start-quadwork.sh << 'EOF'
+#!/bin/bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm use 24
+exec quadwork start
+EOF
+chmod +x ~/start-quadwork.sh
+
+pm2 stop quadwork
+pm2 delete quadwork
+pm2 start ~/start-quadwork.sh --name quadwork --interpreter /bin/bash
+pm2 save
+```
+
+**Do NOT fix with symlinks** (e.g., `ln -s ~/.nvm/.../claude /usr/local/bin/claude`). Symlinks resolve the binary but not the environment — agents still won't find auth credentials.
+
+---
+
+## Claude Code blocks --dangerously-skip-permissions as root
+
+**Symptom:** Claude Code refuses to start with `--dangerously-skip-permissions` flag. Error: permission flag is not allowed for root user.
+
+**Cause:** Claude Code explicitly blocks the dangerous permissions bypass when running as root as a safety measure.
+
+**Fix:** Never run QuadWork as root. Create a dedicated non-root user:
+
+```bash
+# As root
+useradd -m -s /bin/bash quadwork
+echo "quadwork ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/quadwork
+chmod 440 /etc/sudoers.d/quadwork
+```
+
+See the [VPS Installation Guide](install-vps.md#step-2-create-non-root-user-critical) for full setup.
+
+---
+
+## python3-venv missing on Ubuntu
+
+**Symptom:** AgentChattr crashes on startup with `ModuleNotFoundError: No module named 'fastapi'`.
+
+**Cause:** Ubuntu 24.04 ships Python 3.12 without the `python3.12-venv` package. AgentChattr creates a venv during setup, but without this package the venv has no pip — dependencies are never installed.
+
+**Fix:**
+
+```bash
+sudo apt-get install -y python3.12-venv
+```
+
+If you already hit this error, recreate the venv:
+
+```bash
+cd ~/.quadwork/<project-id>/agentchattr
+rm -rf .venv
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+Then restart QuadWork: `pm2 restart quadwork`
+
+---
+
+## Duplicate TOML keys crash AgentChattr
+
+**Symptom:** AgentChattr crashes with a TOML parse error on startup.
+
+**Cause:** Manual edits to `config.toml` introduced duplicate keys (e.g., two `max_agent_hops` entries). TOML does not allow duplicate keys.
+
+**Fix:** Open the project's `config.toml` and remove the duplicate entry. Search for the key mentioned in the error message and ensure it appears only once.
+
+**Prevention:** Avoid manually editing `config.toml` fields that QuadWork's startup migrations also manage (e.g., `max_agent_hops`, `[agents.dc]`, `[agents.tg]`).


### PR DESCRIPTION
## Summary
- Creates `docs/install-mac.md` — full Mac installation guide covering prerequisites, CLI auth, QuadWork setup, trust prompt, and bridge configuration
- Creates `docs/install-vps.md` — VPS guide adapted from #587 covering Hetzner setup, non-root user, nvm, pm2 wrapper, nginx + SSL, and basic auth
- Creates `docs/troubleshooting.md` — 8 common issues structured as Symptom > Cause > Fix, searchable by error message
- Updates `README.md` with an Installation Guides section linking all three docs, including an agent-friendly callout

All guides are written for AI agent consumption: explicit commands, copy-pasteable steps, interactive steps clearly marked, and expected output included.

Fixes #611

## Test plan
- [ ] `docs/install-mac.md` covers full Mac installation end-to-end
- [ ] `docs/install-vps.md` covers full VPS installation (adapted from #587)
- [ ] `docs/troubleshooting.md` covers all 8 known issues from the ticket
- [ ] `README.md` links to all three docs with agent-friendly callout
- [ ] Commands are copy-pasteable and unambiguous
- [ ] Interactive steps are clearly marked for agent awareness
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)