### PR TITLE
Add Windows installation guide via WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 Step-by-step guides for setting up QuadWork, designed for both humans and AI coding agents:
 
 - **[Mac Installation](docs/install-mac.md)** — local setup on macOS
+- **[Windows Installation](docs/install-windows.md)** — local setup via WSL2 (Windows Subsystem for Linux)
 - **[VPS Installation](docs/install-vps.md)** — remote server (Hetzner/Ubuntu) with domain + SSL
 - **[Troubleshooting](docs/troubleshooting.md)** — common issues and fixes
 

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -103,4 +103,4 @@ QuadWork runs on `http://127.0.0.1:8400` by default. WSL2 shares localhost with 
 
 ## For AI Agents
 
-After WSL2 is installed by the operator, follow `docs/install-mac.md` exactly. The environment is standard Ubuntu — all commands work identically.
+After WSL2 is installed by the operator: follow Steps 3–4 in this guide for prerequisites, then continue with `docs/install-mac.md` starting from the **"Install AI Coding Agents"** section. Do not run the macOS-specific prerequisite steps (Homebrew, Xcode, SSL certificates) — those are already handled by Step 3 above.

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -1,0 +1,72 @@
+# QuadWork — Windows Installation Guide (WSL2)
+
+QuadWork requires a Unix environment (node-pty, lsof, shell). On Windows, use WSL2 (Windows Subsystem for Linux) to get a full Ubuntu environment. Once inside WSL2, the setup is identical to the Mac guide.
+
+---
+
+## Prerequisites
+
+- **Windows 10** (build 19041 or later) or **Windows 11**
+- Administrator access (for WSL2 installation)
+
+---
+
+## Step 1: Install WSL2
+
+> **Manual step** — this requires PowerShell as Administrator and cannot be done by an agent.
+
+Open **PowerShell as Administrator** and run:
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+Restart your computer when prompted. After restart, Ubuntu will open and ask you to create a username and password.
+
+---
+
+## Step 2: Enter WSL2
+
+Open PowerShell (or Windows Terminal) and run:
+
+```powershell
+wsl
+```
+
+You're now in Ubuntu. All following steps happen inside this shell.
+
+---
+
+## Step 3: Follow the Mac Installation Guide
+
+From here, the setup is identical to macOS. Follow **[docs/install-mac.md](install-mac.md)** starting from Step 1 (nvm + Node.js).
+
+This includes:
+- nvm + Node.js 24
+- GitHub CLI (`gh auth login`)
+- Claude Code + Codex CLI
+- `npm install -g quadwork@latest`
+- `npx quadwork init`
+
+---
+
+## Accessing the Dashboard
+
+QuadWork runs on `http://127.0.0.1:8400` by default. WSL2 shares localhost with Windows automatically — open that URL in your Windows browser (Chrome, Edge, etc.) and it will connect.
+
+---
+
+## Known Differences from Mac/Linux
+
+| Feature | Behavior on WSL2 |
+|---------|-----------------|
+| Keep Mac Awake | Not available (`caffeinate` is macOS-only) |
+| File paths | `/home/<user>/` instead of `/Users/<user>/` |
+| VS Code | Install the "WSL" extension to edit files inside WSL2 |
+| Localhost | Shared with Windows automatically (no port forwarding needed) |
+
+---
+
+## For AI Agents
+
+After WSL2 is installed by the operator, follow `docs/install-mac.md` exactly. The environment is standard Ubuntu — all commands work identically.

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -37,14 +37,48 @@ You're now in Ubuntu. All following steps happen inside this shell.
 
 ---
 
-## Step 3: Follow the Mac Installation Guide
+## Step 3: Install Prerequisites (Ubuntu/WSL2)
 
-From here, the setup is identical to macOS. Follow **[docs/install-mac.md](install-mac.md)** starting from Step 1 (nvm + Node.js).
+These replace the macOS-specific steps (Homebrew, Xcode) in the Mac guide.
+
+**Node.js 24** (via nvm):
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+source ~/.bashrc
+nvm install 24
+nvm use 24
+```
+
+**Python 3 + venv** (required for AgentChattr):
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-venv git
+```
+
+**GitHub CLI:**
+```bash
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list
+sudo apt-get update && sudo apt-get install -y gh
+```
+
+**Authenticate GitHub CLI:**
+```bash
+gh auth login
+```
+
+> **This is interactive** — the operator must complete the browser-based auth flow.
+
+---
+
+## Step 4: Follow the Mac Guide (from "Install AI Coding Agents")
+
+From here, the setup is identical. Follow **[docs/install-mac.md](install-mac.md)** starting from the **"Install AI Coding Agents"** section.
 
 This includes:
-- nvm + Node.js 24
-- GitHub CLI (`gh auth login`)
 - Claude Code + Codex CLI
+- CLI authentication
 - `npm install -g quadwork@latest`
 - `npx quadwork init`
 


### PR DESCRIPTION
## Summary
- Creates `docs/install-windows.md` with WSL2 setup instructions, then links to the Mac guide for the rest
- Updates `README.md` to include Windows in the Installation Guides section
- Clearly marks manual steps (WSL2 install) vs agent-handleable steps
- Documents known differences (caffeinate, paths, VS Code WSL extension) and localhost sharing

Fixes #619

## Test plan
- [ ] `docs/install-windows.md` exists with WSL2 setup + link to Mac guide
- [ ] README.md lists Windows entry in Installation Guides
- [ ] Agent-friendly callout preserved in README
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)