### PR TITLE
[#629] Move crash timeout patch to clone time and restart AC for existing installs

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -320,9 +320,31 @@ function _installAgentChattrLocked(dir, setError) {
       if (pipResult === null) return setError(`pip install -r ${reqFile} failed`);
     }
   }
+  // #629: patch crash timeout before AC's first import
+  _patchCrashTimeout(dir);
   return dir;
 }
 installAgentChattr.lastError = null;
+
+function _patchCrashTimeout(dir) {
+  if (!dir) return;
+  const appPath = path.join(dir, "app.py");
+  if (!fs.existsSync(appPath)) return;
+  try {
+    let app = fs.readFileSync(appPath, "utf-8");
+    if (app.includes("_CRASH_TIMEOUT = 15")) {
+      app = app.replace("_CRASH_TIMEOUT = 15", "_CRASH_TIMEOUT = 120");
+      app = app.replace(
+        "# Crash timeout: if a wrapper hasn't heartbeated for 60s,\n",
+        "# Crash timeout: if a wrapper hasn't heartbeated for 120s,\n",
+      );
+      fs.writeFileSync(appPath, app);
+      log("[idle-fix] patched crash timeout to 120s at clone time (#629)");
+    }
+  } catch (err) {
+    try { console.warn(`[idle-fix] failed to patch crash timeout: ${err.message}`); } catch {}
+  }
+}
 
 /**
  * Get spawn args for launching AgentChattr from its cloned directory.

--- a/server/index.js
+++ b/server/index.js
@@ -1169,6 +1169,8 @@ async function handleAgentChattr(req, res) {
       const pullResult = execFileSync("git", ["pull"], { cwd: acDir, encoding: "utf-8", timeout: 30000, stdio: "pipe" }).trim();
       // #388: re-apply sender-overflow CSS patch after git pull
       patchAgentchattrCss(acDir);
+      // #629: re-apply crash timeout patch after git pull (pull may revert app.py)
+      patchCrashTimeout(acDir);
       const venvPython = path.join(acDir, ".venv", "bin", "python");
       let pipResult = "";
       const reqFile = path.join(acDir, "requirements.txt");
@@ -2561,18 +2563,24 @@ server.listen(PORT, "127.0.0.1", async () => {
   }
   // #629: restart AC for projects where idle-fix patched the on-disk file
   // so the running Python process picks up _CRASH_TIMEOUT = 120.
+  // Use port-alive check instead of chattrProcesses — AC may be running
+  // from a previous QuadWork instance (tracked with process: null).
   if (startupCfg._acRestartNeeded) {
     for (const projectId of startupCfg._acRestartNeeded) {
-      const proc = chattrProcesses.get(projectId);
-      if (!proc || !proc.process) continue;
-      console.log(`[idle-fix] ${projectId}: restarting AC so running process observes _CRASH_TIMEOUT = 120 (#629)`);
-      fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(projectId)}/restart`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "restart" }),
+      const { url } = resolveProjectChattr(projectId);
+      const portMatch = url.match(/:(\d+)/);
+      const port = portMatch ? parseInt(portMatch[1], 10) : 8300;
+      isPortAlive(port).then((alive) => {
+        if (!alive) return;
+        console.log(`[idle-fix] ${projectId}: restarting AC (port ${port}) so running process observes _CRASH_TIMEOUT = 120 (#629)`);
+        return fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(projectId)}/restart`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "restart" }),
+        });
       }).then((r) => {
-        if (r.ok) console.log(`[idle-fix] ${projectId}: AC restarted successfully`);
-        else console.warn(`[idle-fix] ${projectId}: AC restart returned ${r.status}`);
+        if (r && r.ok) console.log(`[idle-fix] ${projectId}: AC restarted successfully`);
+        else if (r) console.warn(`[idle-fix] ${projectId}: AC restart returned ${r.status}`);
       }).catch((err) => {
         console.warn(`[idle-fix] ${projectId}: AC restart failed: ${err.message}`);
       });

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,7 @@ const {
   projectAgentchattrConfigPath,
 } = routes;
 const { waitForAgentChattrReady, registerAgent, registerAgentWithRetry, deregisterAgent, startHeartbeat, stopHeartbeat } = require("./agentchattr-registry");
-const { patchAgentchattrCss } = require("./install-agentchattr");
+const { patchAgentchattrCss, patchCrashTimeout } = require("./install-agentchattr");
 const { startQueueWatcher, stopQueueWatcher } = require("./queue-watcher");
 
 const net = require("net");
@@ -2506,22 +2506,19 @@ server.listen(PORT, "127.0.0.1", async () => {
         console.warn(`[ghost-fix] ${p.id}: failed to patch app.py: ${err.message}`);
       }
     }
-    // #502: increase crash timeout from 15s to 120s for idle agent tolerance
+    // #502 + #629: increase crash timeout from 15s to 120s.
+    // Uses the shared patchCrashTimeout() from install-agentchattr.js.
+    // For existing installs where AC is already running, the on-disk
+    // patch alone is useless (Python caches module-level values at import).
+    // Flag the project for AC restart so the running process picks it up.
     if (fs.existsSync(appPath)) {
       try {
-        let app = fs.readFileSync(appPath, "utf-8");
+        const app = fs.readFileSync(appPath, "utf-8");
         if (app.includes("_CRASH_TIMEOUT = 15")) {
-          app = app.replace(
-            "_CRASH_TIMEOUT = 15",
-            "_CRASH_TIMEOUT = 120",
-          );
-          // Fix the misleading comment too
-          app = app.replace(
-            "# Crash timeout: if a wrapper hasn't heartbeated for 60s,\n",
-            "# Crash timeout: if a wrapper hasn't heartbeated for 120s,\n",
-          );
-          fs.writeFileSync(appPath, app);
-          console.log(`[idle-fix] ${p.id}: increased crash timeout to 120s (#502)`);
+          patchCrashTimeout(acDir);
+          console.log(`[idle-fix] ${p.id}: crash timeout patched on disk — AC restart required for running process to observe it (#629)`);
+          if (!startupCfg._acRestartNeeded) startupCfg._acRestartNeeded = [];
+          startupCfg._acRestartNeeded.push(p.id);
         }
       } catch (err) {
         console.warn(`[idle-fix] ${p.id}: failed to patch app.py crash timeout: ${err.message}`);
@@ -2560,6 +2557,25 @@ server.listen(PORT, "127.0.0.1", async () => {
       }
     } catch (err) {
       console.warn(`[#596] ${p.id}: config.toml migration failed: ${err.message}`);
+    }
+  }
+  // #629: restart AC for projects where idle-fix patched the on-disk file
+  // so the running Python process picks up _CRASH_TIMEOUT = 120.
+  if (startupCfg._acRestartNeeded) {
+    for (const projectId of startupCfg._acRestartNeeded) {
+      const proc = chattrProcesses.get(projectId);
+      if (!proc || !proc.process) continue;
+      console.log(`[idle-fix] ${projectId}: restarting AC so running process observes _CRASH_TIMEOUT = 120 (#629)`);
+      fetch(`http://127.0.0.1:${PORT}/api/agentchattr/${encodeURIComponent(projectId)}/restart`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "restart" }),
+      }).then((r) => {
+        if (r.ok) console.log(`[idle-fix] ${projectId}: AC restarted successfully`);
+        else console.warn(`[idle-fix] ${projectId}: AC restart returned ${r.status}`);
+      }).catch((err) => {
+        console.warn(`[idle-fix] ${projectId}: AC restart failed: ${err.message}`);
+      });
     }
   }
   // #416: start the AC health monitor

--- a/server/install-agentchattr.js
+++ b/server/install-agentchattr.js
@@ -195,6 +195,8 @@ function _installAgentChattrLocked(dir, setError) {
   }
   // #388: patch sender-column overflow CSS after clone/install
   patchAgentchattrCss(dir);
+  // #629: patch crash timeout before AC's first import
+  patchCrashTimeout(dir);
   return dir;
 }
 
@@ -260,10 +262,36 @@ function patchAgentchattrCss(dir) {
   }
 }
 
+/**
+ * #629: Patch AC's crash timeout from 15s to 120s.
+ * Must run at clone time (before any `python run.py`) so the first
+ * AC process imports the patched value. Idempotent.
+ */
+function patchCrashTimeout(dir) {
+  if (!dir) return;
+  const appPath = path.join(dir, "app.py");
+  if (!fs.existsSync(appPath)) return;
+  try {
+    let app = fs.readFileSync(appPath, "utf-8");
+    if (app.includes("_CRASH_TIMEOUT = 15")) {
+      app = app.replace("_CRASH_TIMEOUT = 15", "_CRASH_TIMEOUT = 120");
+      app = app.replace(
+        "# Crash timeout: if a wrapper hasn't heartbeated for 60s,\n",
+        "# Crash timeout: if a wrapper hasn't heartbeated for 120s,\n",
+      );
+      fs.writeFileSync(appPath, app);
+      console.log(`[idle-fix] ${path.basename(path.dirname(dir)) || dir}: patched crash timeout to 120s at clone time (#629)`);
+    }
+  } catch (err) {
+    console.warn(`[idle-fix] failed to patch crash timeout in ${appPath}: ${err.message}`);
+  }
+}
+
 module.exports = {
   AGENTCHATTR_REPO,
   findAgentChattr,
   installAgentChattr,
   chattrSpawnArgs,
   patchAgentchattrCss,
+  patchCrashTimeout,
 };

--- a/server/install-agentchattr.js
+++ b/server/install-agentchattr.js
@@ -280,7 +280,7 @@ function patchCrashTimeout(dir) {
         "# Crash timeout: if a wrapper hasn't heartbeated for 120s,\n",
       );
       fs.writeFileSync(appPath, app);
-      console.log(`[idle-fix] ${path.basename(path.dirname(dir)) || dir}: patched crash timeout to 120s at clone time (#629)`);
+      console.log(`[idle-fix] patched crash timeout to 120s at clone time (#629): ${dir}`);
     }
   } catch (err) {
     console.warn(`[idle-fix] failed to patch crash timeout in ${appPath}: ${err.message}`);

--- a/server/install-agentchattr.patchCrashTimeout.test.js
+++ b/server/install-agentchattr.patchCrashTimeout.test.js
@@ -1,0 +1,71 @@
+// #629: patchCrashTimeout tests. Plain node:assert — run with
+// `node server/install-agentchattr.patchCrashTimeout.test.js`.
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { patchCrashTimeout } = require("./install-agentchattr");
+
+const UNPATCHED_APP_PY = [
+  "import time",
+  "",
+  "# Crash timeout: if a wrapper hasn't heartbeated for 60s,",
+  "# consider it dead and deregister.",
+  "_CRASH_TIMEOUT = 15",
+  "",
+  "def check_heartbeats():",
+  "    now = time.time()",
+  "    for name, last_seen in list(_heartbeats.items()):",
+  "        if last_seen > 0 and now - last_seen > _CRASH_TIMEOUT:",
+  '            log.info(f"Crash timeout: deregistering {name} (no heartbeat for {_CRASH_TIMEOUT}s)")',
+].join("\n");
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "qw-test-629-"));
+
+function setup(content) {
+  const dir = fs.mkdtempSync(path.join(tmpDir, "ac-"));
+  if (content !== undefined) {
+    fs.writeFileSync(path.join(dir, "app.py"), content);
+  }
+  return dir;
+}
+
+// 1) Patches _CRASH_TIMEOUT from 15 to 120
+{
+  const dir = setup(UNPATCHED_APP_PY);
+  patchCrashTimeout(dir);
+  const result = fs.readFileSync(path.join(dir, "app.py"), "utf-8");
+  assert.ok(result.includes("_CRASH_TIMEOUT = 120"), "timeout patched to 120");
+  assert.ok(!result.includes("_CRASH_TIMEOUT = 15"), "old value removed");
+  assert.ok(result.includes("heartbeated for 120s"), "comment updated");
+  assert.ok(!result.includes("heartbeated for 60s"), "old comment removed");
+}
+
+// 2) Idempotent — already-patched file is untouched
+{
+  const dir = setup(UNPATCHED_APP_PY.replace("_CRASH_TIMEOUT = 15", "_CRASH_TIMEOUT = 120")
+    .replace("heartbeated for 60s", "heartbeated for 120s"));
+  const before = fs.readFileSync(path.join(dir, "app.py"), "utf-8");
+  patchCrashTimeout(dir);
+  const after = fs.readFileSync(path.join(dir, "app.py"), "utf-8");
+  assert.equal(before, after, "already-patched file unchanged");
+}
+
+// 3) No app.py — no crash
+{
+  const dir = setup();
+  patchCrashTimeout(dir);
+  assert.ok(!fs.existsSync(path.join(dir, "app.py")), "no file created");
+}
+
+// 4) Null/undefined dir — no crash
+{
+  patchCrashTimeout(null);
+  patchCrashTimeout(undefined);
+}
+
+// Cleanup
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+console.log("patchCrashTimeout: all tests passed");


### PR DESCRIPTION
## Summary
- Moved `_CRASH_TIMEOUT` patch from `server/index.js` startup migration into `server/install-agentchattr.js` (`patchCrashTimeout()`) so it runs at clone time — before AC's first `python run.py` import. Fresh installs now get `_CRASH_TIMEOUT = 120` in memory from the start.
- For existing installs where the startup migration patches `app.py` on a running AC instance, the migration now flags the project and triggers an AC restart so the running Python process picks up the new value.
- Added focused tests for `patchCrashTimeout()` covering: patch application, idempotency, missing `app.py`, and null/undefined dir.

## Test plan
- [ ] Fresh install: verify `_CRASH_TIMEOUT = 120` in `app.py` before AC starts, confirm AC log shows `120s` (not `15s`) in any crash-timeout entries
- [ ] Existing install with `_CRASH_TIMEOUT = 15` still on disk: verify startup migration patches and restarts AC, confirm log shows restart message
- [ ] Existing install already patched (`_CRASH_TIMEOUT = 120`): verify no restart triggered, no-op behavior
- [ ] Run `node server/install-agentchattr.patchCrashTimeout.test.js` — all assertions pass
- [ ] Leave machine idle overnight, check `agentchattr.log` for crash-timeout entries showing `120s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)