### PR TITLE
[#635] Seed ~/docs/ README.md on Butler first launch

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1414,6 +1414,27 @@ function spawnButlerPty() {
       }
     }
 
+    // #635: seed README.md explaining ~/docs/ folder purpose
+    const readmePath = path.join(docsDir, "README.md");
+    if (!fs.existsSync(readmePath)) {
+      fs.writeFileSync(readmePath, [
+        "# ~/docs/",
+        "",
+        "Butler's working directory — cross-project operator notes and artifacts.",
+        "Not git-tracked; operator-local.",
+        "",
+        "## File types",
+        "",
+        "| Prefix | Purpose |",
+        "|--------|---------|",
+        "| `PROPOSAL-<name>.md` | Feature proposals with phases and operator gates |",
+        "| `REVIEW-<batch>.md` | PR review summaries |",
+        "| `INFO-<topic>.md` | Research notes |",
+        "| `PROGRESS-<project>.md` | Per-project progress (one file per project) |",
+        "",
+      ].join("\n"));
+    }
+
     const term = pty.spawn(command, args, {
       name: "xterm-256color",
       cols: 120,


### PR DESCRIPTION
## Summary
- Seeds `~/docs/README.md` on Butler's first launch explaining folder purpose and file type conventions (PROPOSAL, REVIEW, INFO, PROGRESS)
- Idempotent — skips if README.md already exists
- `~/docs/` directory creation and AGENTS.md seeding were already implemented in #631

## Test plan
- [ ] First Butler start creates `~/docs/README.md` with file type table
- [ ] Subsequent starts don't overwrite existing README.md
- [ ] No error if `~/docs/` already exists
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)