### PR TITLE
[#641] Replace dual WebSocketServer with single noServer instance

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1953,9 +1953,24 @@ const { scrubSecrets, scrubScrollback } = require("./scrub-secrets");
 // WS connects to an existing PTY session (started via lifecycle API)
 // or spawns a new one if none exists.
 
-const wss = new WebSocketServer({ server, path: "/ws/terminal" });
+const wss = new WebSocketServer({ noServer: true });
 
-wss.on("connection", async (ws, req) => {
+server.on("upgrade", (req, socket, head) => {
+  const pathname = new URL(req.url, "http://localhost").pathname;
+  if (pathname === "/ws/terminal") {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit("connection:terminal", ws, req);
+    });
+  } else if (pathname === "/ws/butler") {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit("connection:butler", ws, req);
+    });
+  } else {
+    socket.destroy();
+  }
+});
+
+wss.on("connection:terminal", async (ws, req) => {
   const params = new URL(req.url, `http://localhost:${PORT}`).searchParams;
   const projectId = params.get("project");
   const agentId = params.get("agent");
@@ -2044,9 +2059,8 @@ wss.on("connection", async (ws, req) => {
 });
 
 // --- Butler WebSocket (#631) ---
-const wssButler = new WebSocketServer({ server, path: "/ws/butler" });
 
-wssButler.on("connection", async (ws) => {
+wss.on("connection:butler", async (ws) => {
   if (!butlerSession.term) {
     const result = spawnButlerPty();
     if (!result.ok) {


### PR DESCRIPTION
## Summary
- Replaces two `WebSocketServer` instances (one for `/ws/terminal`, one for `/ws/butler`) with a single `noServer` WSS and manual `upgrade` routing
- Fixes `Invalid WebSocket frame: RSV1 must be clear` errors that broke all agent terminal rendering since v1.16.0
- Handler logic inside each connection callback is unchanged

## Test plan
- [ ] Agent terminals render PTY output on page load
- [ ] Scrollback replay works (reconnect shows previous output)
- [ ] Butler WebSocket still works when Butler is enabled
- [ ] No `RSV1 must be clear` errors
- [ ] `npm run build` passes (verified locally)

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)