### PR TITLE
[#644] Show Butler enable CTA on home screen

### DIFF
--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -30,6 +30,10 @@ const COPY = {
     joinLink: "Join Hunt Town",
     joinSuffix: "and find @project7.",
     recentActivity: "Recent Activity",
+    butlerCtaTitle: "Butler Agent",
+    butlerCtaNew: "NEW",
+    butlerCtaDesc: "Your cross-project AI assistant.",
+    butlerCtaLink: "Enable in Settings →",
   },
   ko: {
     loading: "대시보드 로딩 중...",
@@ -54,6 +58,10 @@ const COPY = {
     joinLink: "Hunt Town 참여",
     joinSuffix: "에서 @project7을 찾아보세요.",
     recentActivity: "최근 활동",
+    butlerCtaTitle: "Butler Agent",
+    butlerCtaNew: "NEW",
+    butlerCtaDesc: "크로스 프로젝트 AI 어시스턴트.",
+    butlerCtaLink: "설정에서 활성화 →",
   },
 } as const;
 
@@ -99,6 +107,10 @@ export default function HomeDashboard() {
   const [activity, setActivity] = useState<ActivityEvent[]>([]);
   const [projectsState, setProjectsState] = useState<"loading" | "loaded" | "error">("loading");
   const [butlerEnabled, setButlerEnabled] = useState(false);
+  const [butlerCtaDismissed, setButlerCtaDismissed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem("qw-butler-cta-dismissed") === "1";
+  });
 
   useEffect(() => {
     fetch("/api/projects")
@@ -142,9 +154,37 @@ export default function HomeDashboard() {
           {butlerEnabled ? (
             <ButlerChat />
           ) : projectsState === "loaded" ? (
-            <div className="mb-6">
-              <HomeEmptyState hasProjects={projects.length > 0} />
-            </div>
+            <>
+              {!butlerCtaDismissed && (
+                <div className="mb-3 border border-border bg-bg-surface px-4 py-3 flex items-center justify-between">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="text-[11px] font-semibold text-text">{t.butlerCtaTitle}</span>
+                    <span className="text-[9px] font-semibold text-accent border border-accent/30 px-1.5 py-0.5 leading-none">{t.butlerCtaNew}</span>
+                    <span className="text-[11px] text-text-muted hidden sm:inline">{t.butlerCtaDesc}</span>
+                    <Link
+                      href="/settings#butler"
+                      className="text-[11px] text-accent hover:text-accent-dim transition-colors shrink-0"
+                    >
+                      {t.butlerCtaLink}
+                    </Link>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      localStorage.setItem("qw-butler-cta-dismissed", "1");
+                      setButlerCtaDismissed(true);
+                    }}
+                    className="text-text-muted hover:text-text text-[11px] ml-3 shrink-0 transition-colors"
+                    aria-label="Dismiss"
+                  >
+                    ×
+                  </button>
+                </div>
+              )}
+              <div className="mb-6">
+                <HomeEmptyState hasProjects={projects.length > 0} />
+              </div>
+            </>
           ) : null}
           {projectsState === "error" && (
             <div className="mb-6 border border-error/30 bg-error/5 text-error text-[11px] px-3 py-2">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -450,6 +450,15 @@ export default function SettingsPage() {
     }
   }, [config, searchParams, autoAdded]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    if (!config) return;
+    const hash = window.location.hash.replace("#", "");
+    if (hash) {
+      const el = document.getElementById(hash);
+      if (el) el.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [config]);
+
   const save = async () => {
     if (!config) return;
     setSaving(true);
@@ -757,7 +766,7 @@ export default function SettingsPage() {
       </section>
 
       {/* Butler Agent (#632) */}
-      <section className="mb-8">
+      <section id="butler" className="mb-8">
         <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">{t.butlerAgent}</h2>
         <div className="border border-border p-3 space-y-3">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Adds a subtle CTA banner above the hero section on the home screen when Butler is not enabled
- Banner shows "Butler Agent — NEW" label with description and "Enable in Settings →" link
- Dismissible via × button, persisted in localStorage (`qw-butler-cta-dismissed`)
- Hidden automatically when Butler is enabled (replaced by ButlerChat)
- Settings page Butler section gets `id="butler"` anchor + scroll-into-view for `#butler` hash
- i18n: English and Korean copy included
- Responsive: description text hidden on small screens

## Test plan
- [ ] Open home screen with Butler disabled → CTA banner visible above hero
- [ ] Click "Enable in Settings →" → navigates to `/settings#butler`, scrolls to Butler section
- [ ] Click × dismiss → banner disappears, persists across page reloads
- [ ] Enable Butler → CTA never shows (ButlerChat renders instead)
- [ ] Clear `qw-butler-cta-dismissed` from localStorage → CTA reappears
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)