### PR TITLE
[#645] Fix Butler model dropdown to update when CLI changes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -66,6 +66,7 @@ app.get("/api/cli-status", (_req, res) => {
   res.json({
     claude: isCliInstalled("claude"),
     codex: isCliInstalled("codex"),
+    gemini: isCliInstalled("gemini"),
   });
 });
 

--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -103,7 +103,7 @@ const REASONING_LEVELS = ["minimal", "low", "medium", "high"] as const;
 // ship with this release; operators who need something bleeding
 // edge can still override by editing ~/.quadwork/config.json
 // directly — this widget is the guided happy path.
-const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> = {
+export const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> = {
   codex: [
     { value: "", label: "(CLI default)" },
     { value: "gpt-5.4", label: "gpt-5.4" },
@@ -117,8 +117,13 @@ const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> = {
     { value: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
     { value: "claude-haiku-4-5-20251001", label: "claude-haiku-4-5" },
   ],
+  gemini: [
+    { value: "", label: "(CLI default)" },
+    { value: "gemini-2.5-pro", label: "gemini-2.5-pro" },
+    { value: "gemini-2.5-flash", label: "gemini-2.5-flash" },
+  ],
 };
-function optionsForBackend(backend: string) {
+export function optionsForBackend(backend: string) {
   return MODEL_OPTIONS[backend] || [{ value: "", label: "(CLI default)" }];
 }
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { useLocale } from "@/components/LocaleProvider";
+import { MODEL_OPTIONS, optionsForBackend } from "./AgentModelsWidget";
 
 interface AgentConfig {
   display_name: string;
@@ -60,28 +61,13 @@ const DEFAULT_AGENTS: Record<string, AgentConfig> = {
 const BACKENDS: { value: string; label: string }[] = [
   { value: "claude", label: "Claude Code" },
   { value: "codex", label: "Codex" },
+  { value: "gemini", label: "Gemini CLI" },
 ];
 const MODELS = ["opus", "sonnet", "haiku"];
 
-const BUTLER_MODEL_OPTIONS: Record<string, { value: string; label: string }[]> = {
-  claude: [
-    { value: "opus", label: "opus" },
-    { value: "sonnet", label: "sonnet" },
-    { value: "haiku", label: "haiku" },
-  ],
-  codex: [
-    { value: "gpt-5.4", label: "gpt-5.4" },
-    { value: "gpt-5", label: "gpt-5" },
-    { value: "gpt-4o", label: "gpt-4o" },
-  ],
-  gemini: [
-    { value: "gemini-2.5-pro", label: "gemini-2.5-pro" },
-    { value: "gemini-2.5-flash", label: "gemini-2.5-flash" },
-  ],
-};
-
 function butlerModelsForBackend(backend: string) {
-  return BUTLER_MODEL_OPTIONS[backend] || BUTLER_MODEL_OPTIONS.claude;
+  const opts = optionsForBackend(backend).filter((o) => o.value !== "");
+  return opts.length > 0 ? opts : optionsForBackend("claude").filter((o) => o.value !== "");
 }
 
 const COPY = {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -63,6 +63,27 @@ const BACKENDS: { value: string; label: string }[] = [
 ];
 const MODELS = ["opus", "sonnet", "haiku"];
 
+const BUTLER_MODEL_OPTIONS: Record<string, { value: string; label: string }[]> = {
+  claude: [
+    { value: "opus", label: "opus" },
+    { value: "sonnet", label: "sonnet" },
+    { value: "haiku", label: "haiku" },
+  ],
+  codex: [
+    { value: "gpt-5.4", label: "gpt-5.4" },
+    { value: "gpt-5", label: "gpt-5" },
+    { value: "gpt-4o", label: "gpt-4o" },
+  ],
+  gemini: [
+    { value: "gemini-2.5-pro", label: "gemini-2.5-pro" },
+    { value: "gemini-2.5-flash", label: "gemini-2.5-flash" },
+  ],
+};
+
+function butlerModelsForBackend(backend: string) {
+  return BUTLER_MODEL_OPTIONS[backend] || BUTLER_MODEL_OPTIONS.claude;
+}
+
 const COPY = {
   en: {
     loading: "Loading...",
@@ -784,7 +805,12 @@ export default function SettingsPage() {
             <Select
               label={t.butlerCli}
               value={config.butler?.command || "claude"}
-              onChange={(v) => updateButler({ command: v })}
+              onChange={(v) => {
+                const models = butlerModelsForBackend(v);
+                const currentModel = config.butler?.model || "opus";
+                const modelValid = models.some((m) => m.value === currentModel);
+                updateButler({ command: v, model: modelValid ? currentModel : models[0].value });
+              }}
               options={BACKENDS.map((b) => ({
                 value: b.value,
                 label: b.label + (cliStatus && !cliStatus[b.value as keyof typeof cliStatus] ? " (not installed)" : ""),
@@ -794,7 +820,7 @@ export default function SettingsPage() {
               label={t.butlerModel}
               value={config.butler?.model || "opus"}
               onChange={(v) => updateButler({ model: v })}
-              options={MODELS.map((m) => ({ value: m, label: m }))}
+              options={butlerModelsForBackend(config.butler?.command || "claude")}
             />
             <Input
               label={t.butlerCwd}


### PR DESCRIPTION
## Summary
- Added `BUTLER_MODEL_OPTIONS` mapping: Claude → opus/sonnet/haiku, Codex → gpt-5.4/gpt-5/gpt-4o, Gemini → gemini-2.5-pro/gemini-2.5-flash
- Butler model dropdown now renders options based on selected CLI backend
- When CLI changes, model auto-resets to first valid option if current selection is invalid for new backend
- `npm run build` passes

## Test plan
- [ ] Open Settings → Butler Agent, default CLI is Claude → models show opus/sonnet/haiku
- [ ] Change CLI to Codex → models update to gpt-5.4/gpt-5/gpt-4o
- [ ] Change CLI back to Claude → models revert to opus/sonnet/haiku
- [ ] Select a model, save, reload → selection persists
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)