### PR TITLE
[#652] Fix scrollback replay binary frame dropping

### DIFF
--- a/server/__tests__/scrub-secrets.test.js
+++ b/server/__tests__/scrub-secrets.test.js
@@ -172,31 +172,32 @@ test("handles multi-line with mixed secrets and normal output", () => {
   assert(!out.includes("eyJhbGci"));
 });
 
-// --- 5. scrubScrollback (Buffer handling) ---
+// --- 5. scrubScrollback (string output for WebSocket text frames) ---
 
-test("scrubScrollback returns Buffer", () => {
+test("scrubScrollback returns string, not Buffer", () => {
   const buf = Buffer.from("SOME_SECRET_KEY=abc123\nnormal line");
   const out = scrubScrollback(buf);
-  assert(Buffer.isBuffer(out), "should return a Buffer");
-  assert(!out.toString().includes("abc123"));
+  assert.strictEqual(typeof out, "string", "should return a string for text WebSocket frames");
+  assert(!out.includes("abc123"));
 });
 
 test("scrubScrollback handles empty buffer", () => {
   const buf = Buffer.alloc(0);
   const out = scrubScrollback(buf);
-  assert(Buffer.isBuffer(out));
-  assert.strictEqual(out.length, 0);
+  assert.strictEqual(typeof out, "string");
+  assert.strictEqual(out, "");
 });
 
 test("scrubScrollback handles null", () => {
-  assert.strictEqual(scrubScrollback(null), null);
+  assert.strictEqual(scrubScrollback(null), "");
 });
 
 test("scrubScrollback preserves non-secret content", () => {
   const content = "Hello world\nBuild succeeded\n42 tests passed";
   const buf = Buffer.from(content);
   const out = scrubScrollback(buf);
-  assert.strictEqual(out.toString(), content);
+  assert.strictEqual(typeof out, "string");
+  assert.strictEqual(out, content);
 });
 
 // --- 6. Integration path verification ---

--- a/server/scrub-secrets.js
+++ b/server/scrub-secrets.js
@@ -45,7 +45,7 @@ function scrubSecrets(text) {
 
 function scrubScrollback(buf) {
   if (!buf || buf.length === 0) return buf;
-  return Buffer.from(scrubSecrets(buf.toString("utf-8")), "utf-8");
+  return scrubSecrets(buf.toString("utf-8"));
 }
 
 module.exports = { scrubSecrets, scrubScrollback, _REDACTED };

--- a/server/scrub-secrets.js
+++ b/server/scrub-secrets.js
@@ -44,7 +44,7 @@ function scrubSecrets(text) {
 }
 
 function scrubScrollback(buf) {
-  if (!buf || buf.length === 0) return buf;
+  if (!buf || buf.length === 0) return "";
   return scrubSecrets(buf.toString("utf-8"));
 }
 


### PR DESCRIPTION
## Summary
- `scrubScrollback()` in `server/scrub-secrets.js` was returning a `Buffer`, causing `ws.send()` to emit a binary WebSocket frame
- Browser receives binary frames as `Blob`, and xterm.js silently drops `Blob` input
- One-line fix: return the string from `scrubSecrets()` directly instead of wrapping in `Buffer.from()`
- Fixes both Butler terminal and agent terminal scrollback replay on reconnect

## Test plan
- [ ] Enable Butler → navigate away → navigate back to Home → scrollback renders (not blank)
- [ ] Agent terminal with active output → refresh page → scrollback replays correctly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)