### PR TITLE
[#654] Auto-answer Butler trust prompt

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1473,20 +1473,22 @@ function spawnButlerPty() {
       }
     });
 
-    // Auto-answer trust prompt if it appears within the first 10s
-    let trustHandled = false;
-    const trustListener = term.onData((data) => {
-      if (trustHandled) return;
-      if (data.includes("trust") || data.includes("Yes,") || data.includes("1.")) {
-        setTimeout(() => {
-          if (!trustHandled && butlerSession.term === term) {
-            term.write("1\r");
-            trustHandled = true;
-          }
-        }, 500);
-      }
-    });
-    setTimeout(() => { trustListener.dispose(); trustHandled = true; }, 10000);
+    // Auto-answer Claude's trust prompt if it appears within the first 10s
+    if (command === "claude") {
+      let trustHandled = false;
+      const trustListener = term.onData((data) => {
+        if (trustHandled) return;
+        if (data.includes("trust") || data.includes("Yes,") || data.includes("1.")) {
+          setTimeout(() => {
+            if (!trustHandled && butlerSession.term === term) {
+              term.write("1\r");
+              trustHandled = true;
+            }
+          }, 500);
+        }
+      });
+      setTimeout(() => { trustListener.dispose(); trustHandled = true; }, 10000);
+    }
 
     term.onExit(({ exitCode }) => {
       if (butlerSession.term === term) {

--- a/server/index.js
+++ b/server/index.js
@@ -1473,6 +1473,21 @@ function spawnButlerPty() {
       }
     });
 
+    // Auto-answer trust prompt if it appears within the first 10s
+    let trustHandled = false;
+    const trustListener = term.onData((data) => {
+      if (trustHandled) return;
+      if (data.includes("trust") || data.includes("Yes,") || data.includes("1.")) {
+        setTimeout(() => {
+          if (!trustHandled && butlerSession.term === term) {
+            term.write("1\r");
+            trustHandled = true;
+          }
+        }, 500);
+      }
+    });
+    setTimeout(() => { trustListener.dispose(); trustHandled = true; }, 10000);
+
     term.onExit(({ exitCode }) => {
       if (butlerSession.term === term) {
         butlerSession.state = "stopped";


### PR DESCRIPTION
## Summary
- Added trust prompt auto-answer in `spawnButlerPty()`: listens for trust-related output ("trust", "Yes,", "1.") in the first 10s after spawn
- When detected, sends `1\r` after 500ms delay to select "Yes, continue"
- Listener self-cleans after 10s — no side effects if trust was already granted
- Safe if no trust prompt: the listener simply expires without sending anything

## Test plan
- [ ] Fresh Butler start with untrusted directory → trust prompt auto-answered, session starts
- [ ] Butler start with already-trusted directory → no side effects, session starts normally
- [ ] Trust listener cleans up after 10s (no lingering data handlers)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)