### PR TITLE
Replace orbit animation with pulse ring on project icon

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -90,21 +90,13 @@ h1, h2, h3, h4, h5, h6 {
   animation: qw-name-shimmer 1.6s ease-in-out infinite;
 }
 
-@keyframes qw-orbit {
-  from { transform: rotate(0deg) translateX(22px) rotate(0deg); }
-  to { transform: rotate(360deg) translateX(22px) rotate(-360deg); }
+@keyframes qw-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(0, 255, 136, 0.4); }
+  50% { box-shadow: 0 0 0 4px rgba(0, 255, 136, 0); }
 }
-.animate-orbit {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 4px;
-  height: 4px;
-  margin: -2px 0 0 -2px;
-  border-radius: 50%;
-  background: var(--accent, #00ff88);
-  animation: qw-orbit 3s linear infinite;
-  pointer-events: none;
+.animate-pulse-ring {
+  animation: qw-pulse 2s ease-in-out infinite;
+  will-change: box-shadow;
 }
 
 /* Korean help text should wrap by word, not by individual syllable.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -160,7 +160,7 @@ function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onCo
               isActive
                 ? "border-2 border-accent text-accent"
                 : "border border-border text-text-muted hover:text-text"
-            }`}
+            } ${hasActiveBatch ? "animate-pulse-ring" : ""}`}
           >
             {project.name.slice(0, 2) || "?"}
           </div>
@@ -169,7 +169,6 @@ function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onCo
               <PinIcon size={8} />
             </div>
           )}
-          {hasActiveBatch && <div className="animate-orbit" />}
         </div>
         {expanded && (
           <span className={`text-xs truncate flex items-center gap-1 ${isActive ? "text-accent" : "text-text-muted"}`}>


### PR DESCRIPTION
## Summary
- Remove `@keyframes qw-orbit` and `.animate-orbit` (translateX(22px) caused terminal flickering on Intel GPUs by painting outside sidebar bounds)
- Add `@keyframes qw-pulse` with box-shadow pulse on the icon circle itself — GPU composited via `will-change: box-shadow`, no layout reflows
- Apply `.animate-pulse-ring` class directly to the project icon `<div>` when `hasActiveBatch` is true, removing the separate orbiting dot element

Fixes #662

## Test plan
- [ ] No terminal flickering on any device
- [ ] Active batch projects show a visible subtle green pulse on the icon
- [ ] Animation is CSS-only, GPU composited (no layout reflows)
- [ ] No elements paint outside sidebar bounds
- [ ] Collapsed and expanded sidebar both look correct
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)