### PR TITLE
[#664] Sidebar batch indicator: read queue file instead of GitHub API

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -1798,6 +1798,19 @@ function summarizeItems(items) {
   return parts.join(" · ");
 }
 
+router.get("/api/batch-active", (req, res) => {
+  const projectId = req.query.project;
+  if (!projectId) return res.status(400).json({ error: "Missing project" });
+  const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
+  let active = false;
+  try {
+    const text = fs.readFileSync(queuePath, "utf-8");
+    const { issueNumbers } = parseActiveBatch(text);
+    active = issueNumbers.length > 0;
+  } catch {}
+  return res.json({ active });
+});
+
 router.get("/api/batch-progress", async (req, res) => {
   const projectId = req.query.project;
   if (!projectId) return res.status(400).json({ error: "Missing project" });

--- a/server/routes.js
+++ b/server/routes.js
@@ -1801,6 +1801,7 @@ function summarizeItems(items) {
 router.get("/api/batch-active", (req, res) => {
   const projectId = req.query.project;
   if (!projectId) return res.status(400).json({ error: "Missing project" });
+  if (!getRepo(projectId)) return res.status(400).json({ error: "No repo configured for project" });
   const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
   let active = false;
   try {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -276,9 +276,9 @@ export default function Sidebar() {
     const poll = () => {
       Promise.all(
         projects.map((p) =>
-          fetch(`/api/batch-progress?project=${encodeURIComponent(p.id)}`)
+          fetch(`/api/batch-active?project=${encodeURIComponent(p.id)}`)
             .then((r) => (r.ok ? r.json() : null))
-            .then((d) => ({ id: p.id, active: d && Array.isArray(d.items) && d.items.length > 0 && !d.complete }))
+            .then((d) => ({ id: p.id, active: !!d?.active }))
             .catch(() => ({ id: p.id, active: false }))
         )
       ).then((results) => {


### PR DESCRIPTION
## Summary
- Added `GET /api/batch-active?project=<id>` that reads `~/.quadwork/<project>/OVERNIGHT-QUEUE.md` locally and returns `{ active: boolean }` — no GitHub API calls.
- Updated `Sidebar.tsx` batch pulse polling to call `/api/batch-active` instead of `/api/batch-progress`.
- 30s polling interval preserved.

## Acceptance
- Sidebar batch polling makes zero GitHub API calls
- Pulse animation still reflects projects with active batch items
- `npm run build` passes

## Test plan
- [ ] Verify sidebar orbit dot appears for projects with an active batch in their OVERNIGHT-QUEUE.md
- [ ] Verify sidebar orbit dot disappears when the Active Batch section has no items
- [ ] Confirm no `gh` CLI calls are made from the batch-active endpoint
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)