### PR TITLE
[#666] Wrap ResizeObserver fit() in requestAnimationFrame

### DIFF
--- a/src/components/ButlerChat.tsx
+++ b/src/components/ButlerChat.tsx
@@ -118,7 +118,7 @@ export default function ButlerChat() {
 
     requestAnimationFrame(() => fit());
 
-    const observer = new ResizeObserver(() => fit());
+    const observer = new ResizeObserver(() => requestAnimationFrame(() => fit()));
     observer.observe(containerRef.current);
 
     // Forward keystrokes to the WebSocket (same pattern as TerminalPanel)

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -114,7 +114,7 @@ export default function TerminalPanel({
     requestAnimationFrame(() => fit());
 
     // Resize observer
-    const observer = new ResizeObserver(() => fit());
+    const observer = new ResizeObserver(() => requestAnimationFrame(() => fit()));
     observer.observe(containerRef.current);
 
     // #368: register the xterm → client data handler ONCE up-front


### PR DESCRIPTION
## Summary
- Wraps `ResizeObserver` callback's `fit()` call in `requestAnimationFrame()` in both `TerminalPanel.tsx` and `ButlerChat.tsx`
- Eliminates terminal blinking/flicker feedback loop on fractional-pixel layouts
- Terminal resize behavior preserved; `npm run build` passes

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)