### PR TITLE
[#682] Replace 4x500ms fit cycle on WS open with single rAF fit

### DIFF
--- a/src/components/ButlerChat.tsx
+++ b/src/components/ButlerChat.tsx
@@ -156,6 +156,8 @@ export default function ButlerChat() {
       return baseUrl;
     };
 
+    let fitPending = false;
+
     const connect = async () => {
       const base = await resolveBase();
       if (cancelled) return;
@@ -174,7 +176,10 @@ export default function ButlerChat() {
 
       ws.onmessage = (e) => {
         term.write(e.data);
-        requestAnimationFrame(() => fit());
+        if (!fitPending) {
+          fitPending = true;
+          requestAnimationFrame(() => { fit(); fitPending = false; });
+        }
       };
 
       ws.onclose = (e) => {

--- a/src/components/ButlerChat.tsx
+++ b/src/components/ButlerChat.tsx
@@ -163,19 +163,7 @@ export default function ButlerChat() {
       const ws = new WebSocket(`${base}/ws/butler`);
       wsRef.current = ws;
 
-      let postReplayFitTimer: ReturnType<typeof setInterval> | null = null;
-
       ws.onopen = () => {
-        if (postReplayFitTimer) clearInterval(postReplayFitTimer);
-        let fitAttempts = 0;
-        postReplayFitTimer = setInterval(() => {
-          fit();
-          fitAttempts++;
-          if (fitAttempts >= 4) {
-            clearInterval(postReplayFitTimer!);
-            postReplayFitTimer = null;
-          }
-        }, 500);
         ws.send(JSON.stringify({
           type: "resize",
           cols: term.cols,
@@ -186,13 +174,10 @@ export default function ButlerChat() {
 
       ws.onmessage = (e) => {
         term.write(e.data);
+        requestAnimationFrame(() => fit());
       };
 
       ws.onclose = (e) => {
-        if (postReplayFitTimer) {
-          clearInterval(postReplayFitTimer);
-          postReplayFitTimer = null;
-        }
         if (cancelled) return;
         term.write(`\r\n\x1b[38;2;115;115;115m[session closed: ${e.reason || e.code}]\x1b[0m\r\n`);
         setRunning(false);

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -181,6 +181,8 @@ export default function TerminalPanel({
     let reattachAttempts = 0;
     const MAX_REATTACH = 5;
 
+    let fitPending = false;
+
     const connect = async () => {
       const base = await resolveBase();
       if (cancelled) return;
@@ -203,7 +205,10 @@ export default function TerminalPanel({
 
       ws.onmessage = (e) => {
         term.write(e.data);
-        requestAnimationFrame(() => fit());
+        if (!fitPending) {
+          fitPending = true;
+          requestAnimationFrame(() => { fit(); fitPending = false; });
+        }
         const cb = onActivityRef.current;
         if (cb) cb();
       };

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -181,13 +181,6 @@ export default function TerminalPanel({
     let reattachAttempts = 0;
     const MAX_REATTACH = 5;
 
-    // #511: aggressive post-replay fit strategy. A single rAF fit
-    // isn't enough — the container may not have final CSS dimensions
-    // when the first WS message arrives. Retry fit() on an interval
-    // for the first 2s after connect to cover slow layout, SSR
-    // hydration delays, and lazy container sizing.
-    let postReplayFitTimer: ReturnType<typeof setInterval> | null = null;
-
     const connect = async () => {
       const base = await resolveBase();
       if (cancelled) return;
@@ -198,19 +191,6 @@ export default function TerminalPanel({
 
       ws.onopen = () => {
         reattachAttempts = 0;
-        // #511: start the aggressive fit interval on connect. Fires
-        // fit() every 500ms for 2s (4 attempts) to catch containers
-        // that aren't layout-resolved yet when scrollback arrives.
-        if (postReplayFitTimer) clearInterval(postReplayFitTimer);
-        let fitAttempts = 0;
-        postReplayFitTimer = setInterval(() => {
-          fit();
-          fitAttempts++;
-          if (fitAttempts >= 4) {
-            clearInterval(postReplayFitTimer!);
-            postReplayFitTimer = null;
-          }
-        }, 500);
         ws.send(
           JSON.stringify({
             type: "resize",
@@ -218,25 +198,17 @@ export default function TerminalPanel({
             rows: term.rows,
           })
         );
-        // #461: request scrollback replay after xterm + onmessage are
-        // ready. This eliminates the timing race where server-sent
-        // scrollback arrived before the client could process it.
         ws.send(JSON.stringify({ type: "replay" }));
       };
 
       ws.onmessage = (e) => {
         term.write(e.data);
+        requestAnimationFrame(() => fit());
         const cb = onActivityRef.current;
         if (cb) cb();
       };
 
       ws.onclose = async (e) => {
-        // #511: clear any running fit interval so it doesn't overlap
-        // with a new session's fit loop on reattach.
-        if (postReplayFitTimer) {
-          clearInterval(postReplayFitTimer);
-          postReplayFitTimer = null;
-        }
         if (cancelled) return;
         // #368: bounded polling probe of /api/sessions. A single
         // fixed-delay probe is timing-fragile — if the server-side
@@ -280,7 +252,6 @@ export default function TerminalPanel({
 
     return () => {
       cancelled = true;
-      if (postReplayFitTimer) clearInterval(postReplayFitTimer);
       observer.disconnect();
       wsRef.current?.close();
       term.dispose();


### PR DESCRIPTION
## Summary
- Removed the 4×500ms `setInterval` fit cycle from `ws.onopen` in both `TerminalPanel.tsx` and `ButlerChat.tsx`
- Replaced with a single `requestAnimationFrame(() => fit())` call in `ws.onmessage`, so fit runs once per frame as data arrives
- Eliminates the 2-second fit storm per WS connection that compounded with multi-viewer ping-pong (#681) and ResizeObserver loop (#666) to cause severe flicker

## Test plan
- [ ] Open a project with multiple agent terminals — verify terminals fit correctly on connect with no visible flicker
- [ ] Resize the browser window — terminals still refit properly
- [ ] Open Butler chat — terminal fits correctly after connecting
- [ ] `npm run build` passes

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)