### PR TITLE
[#680] Add design guide pointers to Dev and Butler seeds

### DIFF
--- a/templates/seeds/butler.CLAUDE.md
+++ b/templates/seeds/butler.CLAUDE.md
@@ -357,7 +357,16 @@ Read `docs/troubleshooting.md` first for known issues. Then use the architecture
 
 Ask for repo/CLIs/creds, guide through dashboard wizard, verify worktrees/AC/registration, help with bridges and first batch.
 
-## 12. Batch Creation & Overnight Queue Management
+## 12. Design Awareness
+
+When reviewing PRs with UI changes or creating frontend proposals:
+1. Reference `DESIGN-GUIDE.md` for universal craft rules (spacing, typography, color, animation)
+2. Check if the project has a `DESIGN.md` for project-specific design tokens
+3. Include design specifications in frontend proposals (colors, spacing, typography, component patterns)
+4. Flag design quality issues in PR reviews using the RE1/RE2 design checklist criteria (spacing grid, state coverage, anti-AI-slop)
+5. When creating tickets for UI work, specify the expected design standard — don't leave it to Dev's default
+
+## 13. Batch Creation & Overnight Queue Management
 
 Butler can create batches on any project directly by editing that project's OVERNIGHT-QUEUE.md file.
 
@@ -415,7 +424,7 @@ Butler can create batches on any project directly by editing that project's OVER
 - Maximum batch safety: group tickets that touch different files/components together
 - When uncertain about safety, ask: "These 3 tickets touch server/index.js — batch together or separate?"
 
-## 13. Operator Workflow Rules
+## 14. Operator Workflow Rules
 
 - Create tickets, don't fix directly (unless trivially simple)
 - Edit issue body for scope changes, never comments

--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -57,6 +57,14 @@ Head owns this file — do not edit it. Read it when you need context on the bat
 - **NO issue creation** — Head creates issues. If a follow-up is needed, ask @head to create it.
 - **NO PR review** — Reviewers review only
 
+## Design Quality
+When implementing UI/frontend changes:
+1. Read `DESIGN-GUIDE.md` in your workspace for universal craft rules (spacing, typography, color, animation, anti-AI-slop patterns)
+2. Read `DESIGN.md` if present for project-specific design tokens and brand guidelines
+3. Follow the spacing grid, type scale, and color discipline — reviewers will check against these
+4. Handle all 5 states: loading, empty, error, populated, edge — not just the happy path
+5. Self-check against the anti-AI-slop list before requesting review
+
 ## Workflow
 1. Receive assignment from Head with issue number — **do NOT reply, just start working**
 2. Read the issue: `gh issue view <number>`


### PR DESCRIPTION
## Summary
Adds design guide pointers to Dev and Butler agent seeds:

- **Dev** (dev.AGENTS.md): 5-line 'Design Quality' section — read DESIGN-GUIDE.md for UI work, self-check against anti-AI-slop, handle all 5 states
- **Butler** (butler.CLAUDE.md): 5-line 'Design Awareness' section — reference design guide in PR reviews and proposals, flag design issues

Zero token cost on non-UI work — actual guides are separate files read on demand.

## Test plan
- [ ] Dev seed has Design Quality section
- [ ] Butler seed has Design Awareness section
- [ ] npm run build passes

Fixes #680