### PR TITLE
[#690] Seed DESIGN-GUIDE.md into agent worktrees

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2839,7 +2839,7 @@ function runStartupMigrations(cfg) {
     }
   }
 
-  // #677: seed DESIGN-GUIDE.md into existing agent worktrees
+  // #690: seed DESIGN-GUIDE.md into existing agent worktrees
   const designGuideSrc = path.join(__dirname, "..", "templates", "seeds", "DESIGN-GUIDE.md");
   if (fs.existsSync(designGuideSrc)) {
     for (const p of projects) {
@@ -2852,7 +2852,7 @@ function runStartupMigrations(cfg) {
         if (fs.existsSync(wtDir) && !fs.existsSync(dst)) {
           try {
             fs.copyFileSync(designGuideSrc, dst);
-            console.log(`[#677] ${p.id}: seeded DESIGN-GUIDE.md into ${agent} worktree`);
+            console.log(`[#690] ${p.id}: seeded DESIGN-GUIDE.md into ${agent} worktree`);
           } catch {}
         }
       }

--- a/server/index.js
+++ b/server/index.js
@@ -2839,6 +2839,26 @@ function runStartupMigrations(cfg) {
     }
   }
 
+  // #677: seed DESIGN-GUIDE.md into existing agent worktrees
+  const designGuideSrc = path.join(__dirname, "..", "templates", "seeds", "DESIGN-GUIDE.md");
+  if (fs.existsSync(designGuideSrc)) {
+    for (const p of projects) {
+      if (!p.working_dir) continue;
+      const dirName = path.basename(p.working_dir);
+      const parentDir = path.dirname(p.working_dir);
+      for (const agent of ["head", "dev", "re1", "re2"]) {
+        const wtDir = path.join(parentDir, `${dirName}-${agent}`);
+        const dst = path.join(wtDir, "DESIGN-GUIDE.md");
+        if (fs.existsSync(wtDir) && !fs.existsSync(dst)) {
+          try {
+            fs.copyFileSync(designGuideSrc, dst);
+            console.log(`[#677] ${p.id}: seeded DESIGN-GUIDE.md into ${agent} worktree`);
+          } catch {}
+        }
+      }
+    }
+  }
+
   return acRestartNeeded;
 }
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -2130,6 +2130,14 @@ router.post("/api/setup", (req, res) => {
           seeded.push(`${agent}/CLAUDE.md`);
         }
 
+        // DESIGN-GUIDE.md — universal design craft rules (#677)
+        const designGuideSrc = path.join(TEMPLATES_DIR, "seeds", "DESIGN-GUIDE.md");
+        const designGuideDst = path.join(wtDir, "DESIGN-GUIDE.md");
+        if (fs.existsSync(designGuideSrc) && !fs.existsSync(designGuideDst)) {
+          fs.copyFileSync(designGuideSrc, designGuideDst);
+          seeded.push(`${agent}/DESIGN-GUIDE.md`);
+        }
+
         // .gitignore — ensure token files are never committed
         const gitignorePath = path.join(wtDir, ".gitignore");
         const tokenIgnorePatterns = "reviewer-token\n*-token\n";

--- a/server/routes.js
+++ b/server/routes.js
@@ -2130,7 +2130,7 @@ router.post("/api/setup", (req, res) => {
           seeded.push(`${agent}/CLAUDE.md`);
         }
 
-        // DESIGN-GUIDE.md — universal design craft rules (#677)
+        // DESIGN-GUIDE.md — universal design craft rules (#690)
         const designGuideSrc = path.join(TEMPLATES_DIR, "seeds", "DESIGN-GUIDE.md");
         const designGuideDst = path.join(wtDir, "DESIGN-GUIDE.md");
         if (fs.existsSync(designGuideSrc) && !fs.existsSync(designGuideDst)) {


### PR DESCRIPTION
## Summary
- Adds DESIGN-GUIDE.md seeding to the `seed-files` step in `server/routes.js` so new projects get the file in all 4 agent worktrees
- Adds idempotent startup migration in `server/index.js` (`runStartupMigrations`) to seed DESIGN-GUIDE.md into existing project worktrees on next server boot
- Both paths guard with `!fs.existsSync(dst)` to preserve user edits

## Test plan
- [ ] Create a new project and verify DESIGN-GUIDE.md appears in all 4 agent worktrees
- [ ] Restart server with existing projects and verify DESIGN-GUIDE.md is seeded into worktrees that don't have it
- [ ] Verify existing DESIGN-GUIDE.md files are not overwritten
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)