### PR TITLE
[#693] Auto-normalize bare agent names to @mentions

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -297,7 +297,21 @@ const { syncChattrToken } = require("./config");
 // On timeout / early close / 4003, we surface a proper error so the
 // /api/chat handler can return a 5xx (or 401) instead of a silent
 // {ok:true}.
+// #693: Auto-normalize bare agent names to @mentions in outbound messages.
+// Bare "head", "dev", "re1", "re2" become "@head", "@dev", "@re1", "@re2".
+// Already-prefixed mentions are not double-prefixed; suffixed names like
+// "head-2" or "re1-3" are left untouched.
+const MENTION_AGENT_NAMES = ["head", "dev", "re1", "re2"];
+function normalizeMentions(text) {
+  return MENTION_AGENT_NAMES.reduce(
+    (t, name) => t.replace(new RegExp(`(?<![@\\w])\\b${name}\\b(?![\\w-])`, "gi"), `@${name}`),
+    text,
+  );
+}
+
 function sendViaWebSocket(baseUrl, sessionToken, message) {
+  // #693: normalize bare agent names to @mentions before sending
+  message = { ...message, text: normalizeMentions(message.text || "") };
   return new Promise((resolve, reject) => {
     const wsUrl = `${baseUrl.replace(/^http/, "ws")}/ws?token=${encodeURIComponent(sessionToken || "")}`;
     const ws = new NodeWebSocket(wsUrl);
@@ -1065,6 +1079,10 @@ router.post("/api/chat", async (req, res) => {
   if (!message.text && message.attachments.length === 0) {
     return res.status(400).json({ error: "text or attachments required" });
   }
+
+  // #693: normalize bare agent names to @mentions (belt-and-suspenders
+  // with sendViaWebSocket's own normalization)
+  message.text = normalizeMentions(message.text);
 
   const attemptSend = () => sendViaWebSocket(base, sessionToken, message);
 
@@ -3550,3 +3568,5 @@ module.exports.projectAgentchattrConfigPath = projectAgentchattrConfigPath;
 // #236: expose sendViaWebSocket so the chat-ws-send regression test
 // can verify the ack/body/error paths against a fake AC ws server.
 module.exports.sendViaWebSocket = sendViaWebSocket;
+// #693: expose normalizeMentions for unit tests
+module.exports.normalizeMentions = normalizeMentions;

--- a/server/routes.js
+++ b/server/routes.js
@@ -303,6 +303,7 @@ const { syncChattrToken } = require("./config");
 // "head-2" or "re1-3" are left untouched.
 const MENTION_AGENT_NAMES = ["head", "dev", "re1", "re2"];
 function normalizeMentions(text) {
+  if (typeof text !== "string" || !text) return text || "";
   return MENTION_AGENT_NAMES.reduce(
     (t, name) => t.replace(new RegExp(`(?<![@\\w])\\b${name}\\b(?![\\w-])`, "gi"), `@${name}`),
     text,


### PR DESCRIPTION
## Summary
- Adds `normalizeMentions()` that converts bare agent names (`head`, `dev`, `re1`, `re2`) to proper `@mentions` in outbound messages
- Applied in `sendViaWebSocket` (covers all outbound paths) and belt-and-suspenders in `/api/chat` POST handler
- Already-prefixed mentions are not double-prefixed; suffixed names like `head-2` or `re1-3` are left untouched

## Test plan
- [ ] Verify bare "RE1" in agent message becomes "@re1"
- [ ] Verify existing "@head" is not double-prefixed to "@@head"
- [ ] Verify "head-2" and "re1-3" are not affected
- [ ] Verify dashboard user messages still work (existing auto-prefix unchanged)
- [ ] `npm run build` passes

Fixes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)