### PR TITLE
[#714] Add JSONL chat engine — single-writer append-only message store

### DIFF
--- a/server/file-chat.js
+++ b/server/file-chat.js
@@ -174,9 +174,7 @@ function appendMessage(projectId, { sender, channel = "general", text, type = "m
         console.error(`[file-chat] Append failure for project ${projectId}: ${err.message}`);
         throw err;
       }
-      // Brief delay before retry
-      const start = Date.now();
-      while (Date.now() - start < 100) { /* busy wait for sync context */ }
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
     }
   }
 

--- a/server/file-chat.js
+++ b/server/file-chat.js
@@ -1,0 +1,252 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { ensureSecureDir, writeSecureFile } = require("./config");
+
+const MENTION_RE = /@(\w[\w-]*)/g;
+
+// Per-project state keyed by projectId
+const projectState = new Map();
+
+function getState(projectId) {
+  if (!projectState.has(projectId)) {
+    projectState.set(projectId, { nextId: null, cache: [] });
+  }
+  return projectState.get(projectId);
+}
+
+function chatDir(projectId) {
+  return path.join(os.homedir(), ".quadwork", projectId, "chat");
+}
+
+function chatFile(projectId) {
+  return path.join(chatDir(projectId), "general.jsonl");
+}
+
+function writerLockPath(projectId) {
+  return path.join(chatDir(projectId), ".writer.pid");
+}
+
+function parseMentions(text) {
+  if (typeof text !== "string") return [];
+  const mentions = [];
+  let m;
+  while ((m = MENTION_RE.exec(text)) !== null) {
+    mentions.push(m[1].toLowerCase());
+  }
+  return [...new Set(mentions)];
+}
+
+// --- Writer lock ---
+
+function acquireWriterLock(projectId) {
+  const lockPath = writerLockPath(projectId);
+  const dir = chatDir(projectId);
+  ensureSecureDir(dir);
+
+  if (fs.existsSync(lockPath)) {
+    let existingPid;
+    try {
+      existingPid = parseInt(fs.readFileSync(lockPath, "utf-8").trim(), 10);
+    } catch {
+      // Corrupt lock file — overwrite
+    }
+    if (existingPid) {
+      try {
+        process.kill(existingPid, 0);
+        throw new Error(`QuadWork already running on this directory (pid ${existingPid})`);
+      } catch (err) {
+        if (err.code === "ESRCH") {
+          console.warn(`[file-chat] Stale writer lock for project ${projectId} (pid ${existingPid}), replacing`);
+        } else if (!err.code) {
+          throw err;
+        }
+      }
+    }
+  }
+
+  writeSecureFile(lockPath, String(process.pid));
+}
+
+function releaseWriterLock(projectId) {
+  try {
+    fs.unlinkSync(writerLockPath(projectId));
+  } catch {}
+}
+
+// --- ID recovery ---
+
+function recoverNextId(projectId) {
+  const filePath = chatFile(projectId);
+  let maxId = 0;
+
+  if (!fs.existsSync(filePath)) return 1;
+
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const record = JSON.parse(line);
+      if (typeof record.id === "number" && record.id > maxId) {
+        maxId = record.id;
+      }
+    } catch {
+      console.warn(`[file-chat] Skipped corrupt JSONL line in project ${projectId}`);
+    }
+  }
+
+  return maxId + 1;
+}
+
+// --- Core functions ---
+
+const CACHE_SIZE = 200;
+
+function initProject(projectId) {
+  const dir = chatDir(projectId);
+  ensureSecureDir(dir);
+
+  acquireWriterLock(projectId);
+
+  const state = getState(projectId);
+  state.nextId = recoverNextId(projectId);
+
+  // Populate cache from existing file
+  const filePath = chatFile(projectId);
+  if (fs.existsSync(filePath)) {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\n");
+    const records = [];
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        records.push(JSON.parse(line));
+      } catch {
+        // already warned during recoverNextId
+      }
+    }
+    state.cache = records.slice(-CACHE_SIZE);
+  }
+
+  console.log(`[file-chat] Initialized project ${projectId}, next ID: ${state.nextId}, cached: ${state.cache.length} messages`);
+}
+
+function shutdownProject(projectId) {
+  releaseWriterLock(projectId);
+  projectState.delete(projectId);
+}
+
+function appendMessage(projectId, { sender, channel = "general", text, type = "message" }) {
+  const state = getState(projectId);
+  if (state.nextId === null) {
+    throw new Error(`Project ${projectId} not initialized — call initProject first`);
+  }
+
+  const id = state.nextId++;
+  const seq = id; // seq mirrors id for single-channel
+  const record = {
+    id,
+    seq,
+    ts: new Date().toISOString(),
+    sender: sender || "system",
+    channel,
+    type,
+    text: text || "",
+    mentions: parseMentions(text),
+  };
+
+  const dir = chatDir(projectId);
+  ensureSecureDir(dir);
+  const filePath = chatFile(projectId);
+
+  const line = JSON.stringify(record) + "\n";
+
+  let retries = 3;
+  while (retries > 0) {
+    try {
+      fs.appendFileSync(filePath, line, { mode: 0o600 });
+      try { fs.chmodSync(filePath, 0o600); } catch {}
+      break;
+    } catch (err) {
+      retries--;
+      if (retries === 0) {
+        console.error(`[file-chat] Append failure for project ${projectId}: ${err.message}`);
+        throw err;
+      }
+      // Brief delay before retry
+      const start = Date.now();
+      while (Date.now() - start < 100) { /* busy wait for sync context */ }
+    }
+  }
+
+  state.cache.push(record);
+  if (state.cache.length > CACHE_SIZE) {
+    state.cache = state.cache.slice(-CACHE_SIZE);
+  }
+
+  return record;
+}
+
+function readMessages(projectId, { since_id = 0, limit = 50 } = {}) {
+  const state = getState(projectId);
+
+  // Try cache first
+  if (state.cache.length > 0) {
+    const cacheMinId = state.cache[0].id;
+    if (since_id >= cacheMinId || since_id === 0) {
+      let results = since_id > 0
+        ? state.cache.filter((m) => m.id > since_id)
+        : state.cache;
+      return results.slice(-limit);
+    }
+  }
+
+  // Fall back to disk
+  const filePath = chatFile(projectId);
+  if (!fs.existsSync(filePath)) {
+    console.warn(`[file-chat] Missing chat file for project ${projectId}, creating empty`);
+    const dir = chatDir(projectId);
+    ensureSecureDir(dir);
+    writeSecureFile(filePath, "");
+    return [];
+  }
+
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const results = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const record = JSON.parse(line);
+      if (since_id > 0 && record.id <= since_id) continue;
+      results.push(record);
+    } catch {
+      console.warn(`[file-chat] Skipped corrupt JSONL line in project ${projectId}`);
+    }
+  }
+
+  return results.slice(-limit);
+}
+
+function getNextId(projectId) {
+  const state = getState(projectId);
+  if (state.nextId === null) {
+    state.nextId = recoverNextId(projectId);
+  }
+  return state.nextId;
+}
+
+module.exports = {
+  initProject,
+  shutdownProject,
+  appendMessage,
+  readMessages,
+  getNextId,
+  parseMentions,
+  MENTION_RE,
+  // exposed for testing
+  _getState: getState,
+  _chatDir: chatDir,
+  _chatFile: chatFile,
+};

--- a/server/file-chat.test.js
+++ b/server/file-chat.test.js
@@ -1,0 +1,157 @@
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const TEST_DIR = path.join(os.tmpdir(), `file-chat-test-${process.pid}-${Date.now()}`);
+const QUADWORK_DIR = path.join(TEST_DIR, ".quadwork");
+
+// Override HOME so file-chat writes to temp dir
+const origHome = os.homedir;
+os.homedir = () => TEST_DIR;
+
+const fileChat = require("./file-chat");
+
+function cleanup() {
+  os.homedir = origHome;
+  try { fs.rmSync(TEST_DIR, { recursive: true, force: true }); } catch {}
+}
+
+process.on("exit", cleanup);
+
+const PROJECT = "test-project";
+
+// --- Test: Monotonic ID property ---
+{
+  fileChat.initProject(PROJECT);
+  const ids = [];
+  for (let i = 0; i < 100; i++) {
+    const msg = fileChat.appendMessage(PROJECT, {
+      sender: "dev",
+      text: `Message ${i}`,
+      channel: "general",
+      type: "message",
+    });
+    ids.push(msg.id);
+  }
+  for (let i = 1; i < ids.length; i++) {
+    assert.ok(ids[i] === ids[i - 1] + 1, `ID ${ids[i]} should be ${ids[i - 1] + 1}`);
+  }
+  console.log("PASS: monotonic ID property (100 messages, sequential IDs)");
+  fileChat.shutdownProject(PROJECT);
+}
+
+// --- Test: readMessages since_id filtering ---
+{
+  const P2 = "test-since-id";
+  fileChat.initProject(P2);
+  for (let i = 0; i < 10; i++) {
+    fileChat.appendMessage(P2, {
+      sender: "head",
+      text: `Batch message ${i}`,
+    });
+  }
+  const allMsgs = fileChat.readMessages(P2, { limit: 50 });
+  assert.equal(allMsgs.length, 10);
+
+  const sinceId = allMsgs[5].id;
+  const filtered = fileChat.readMessages(P2, { since_id: sinceId, limit: 50 });
+  assert.equal(filtered.length, 4);
+  assert.ok(filtered.every((m) => m.id > sinceId), "all returned messages should have id > since_id");
+  console.log("PASS: readMessages since_id filtering");
+  fileChat.shutdownProject(P2);
+}
+
+// --- Test: Malformed-line skip ---
+{
+  const chatDir = fileChat._chatDir(PROJECT);
+  fs.mkdirSync(chatDir, { recursive: true });
+  const chatFile = fileChat._chatFile(PROJECT);
+  // Write some valid lines followed by a corrupt line
+  const validLine = JSON.stringify({ id: 1, seq: 1, ts: new Date().toISOString(), sender: "dev", channel: "general", type: "message", text: "valid", mentions: [] });
+  const corruptLine = "{invalid json here";
+  const validLine2 = JSON.stringify({ id: 2, seq: 2, ts: new Date().toISOString(), sender: "head", channel: "general", type: "message", text: "also valid", mentions: [] });
+  fs.writeFileSync(chatFile, validLine + "\n" + corruptLine + "\n" + validLine2 + "\n");
+
+  fileChat.initProject(PROJECT);
+  const msgs = fileChat.readMessages(PROJECT, { limit: 50 });
+  assert.equal(msgs.length, 2, "should skip corrupt line and return 2 valid messages");
+  assert.equal(msgs[0].text, "valid");
+  assert.equal(msgs[1].text, "also valid");
+  console.log("PASS: malformed-line skip (corrupt trailing line doesn't crash)");
+  fileChat.shutdownProject(PROJECT);
+}
+
+// --- Test: Startup tail-scan recovery ---
+{
+  const chatDir = fileChat._chatDir(PROJECT);
+  fs.mkdirSync(chatDir, { recursive: true });
+  const chatFile = fileChat._chatFile(PROJECT);
+  // Write messages with IDs 50-54
+  const lines = [];
+  for (let i = 50; i <= 54; i++) {
+    lines.push(JSON.stringify({ id: i, seq: i, ts: new Date().toISOString(), sender: "dev", channel: "general", type: "message", text: `msg ${i}`, mentions: [] }));
+  }
+  fs.writeFileSync(chatFile, lines.join("\n") + "\n");
+
+  fileChat.initProject(PROJECT);
+  const nextId = fileChat.getNextId(PROJECT);
+  assert.equal(nextId, 55, "next ID should be 55 after recovering from file with max ID 54");
+
+  const newMsg = fileChat.appendMessage(PROJECT, { sender: "dev", text: "after restart" });
+  assert.equal(newMsg.id, 55, "first message after restart should have ID 55");
+  console.log("PASS: startup tail-scan recovery (restart recovers correct next ID)");
+  fileChat.shutdownProject(PROJECT);
+}
+
+// --- Test: parseMentions ---
+{
+  const mentions = fileChat.parseMentions("@dev Please review @re1 and @re2");
+  assert.deepEqual(mentions, ["dev", "re1", "re2"]);
+
+  const noMentions = fileChat.parseMentions("No mentions here");
+  assert.deepEqual(noMentions, []);
+
+  const dupes = fileChat.parseMentions("@dev @dev @dev");
+  assert.deepEqual(dupes, ["dev"], "duplicate mentions should be deduplicated");
+  console.log("PASS: parseMentions");
+}
+
+// --- Test: Cache serves recent messages without disk reads ---
+{
+  const chatDir = fileChat._chatDir(PROJECT);
+  fs.mkdirSync(chatDir, { recursive: true });
+  const chatFile = fileChat._chatFile(PROJECT);
+  fs.writeFileSync(chatFile, "");
+
+  fileChat.initProject(PROJECT);
+  for (let i = 0; i < 5; i++) {
+    fileChat.appendMessage(PROJECT, { sender: "dev", text: `cache test ${i}` });
+  }
+
+  // Remove file to prove cache is serving
+  fs.unlinkSync(chatFile);
+  const cached = fileChat.readMessages(PROJECT, { limit: 50 });
+  assert.equal(cached.length, 5, "cache should serve 5 messages even with file deleted");
+  console.log("PASS: in-memory cache serves recent messages without disk reads");
+  fileChat.shutdownProject(PROJECT);
+}
+
+// --- Test: File permissions ---
+{
+  fileChat.initProject(PROJECT);
+  fileChat.appendMessage(PROJECT, { sender: "dev", text: "permissions test" });
+  const chatDir = fileChat._chatDir(PROJECT);
+  const chatFile = fileChat._chatFile(PROJECT);
+
+  const dirStat = fs.statSync(chatDir);
+  assert.equal(dirStat.mode & 0o777, 0o700, "chat dir should have 0700 permissions");
+
+  const fileStat = fs.statSync(chatFile);
+  assert.equal(fileStat.mode & 0o777, 0o600, "chat file should have 0600 permissions");
+  console.log("PASS: file permissions (0700 dir, 0600 file)");
+  fileChat.shutdownProject(PROJECT);
+}
+
+console.log("\nAll file-chat tests passed.");
+cleanup();

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ const pty = require("node-pty");
 const { spawn } = require("child_process");
 const { readConfig, resolveAgentCwd, resolveAgentCommand, resolveProjectChattr, resolveChattrSpawn, syncChattrToken, CONFIG_PATH, ensureSecureDir, writeSecureFile, writeConfig } = require("./config");
 const routes = require("./routes");
+const fileChat = require("./file-chat");
 const {
   patchAgentchattrConfigForDiscordBridge,
   patchAgentchattrConfigForTelegramBridge,
@@ -2933,6 +2934,18 @@ server.listen(PORT, "127.0.0.1", async () => {
       console.log(`[startup] ${p.id}: AC already alive on port ${acPort} — tracking`);
     }
   }
+  // #714: Initialize file-chat engine for projects with chat_mode: "file"
+  for (const p of (startupCfg.projects || [])) {
+    if (p.chat_mode === "file") {
+      try {
+        fileChat.initProject(p.id);
+        console.log(`[startup] ${p.id}: file-chat engine initialized`);
+      } catch (err) {
+        console.error(`[startup] ${p.id}: file-chat init failed: ${err.message}`);
+      }
+    }
+  }
+
   // Sync AgentChattr tokens for all projects on startup and backfill
   // the sender-overflow CSS/JS patch (#402) so already-running AC
   // instances receive the fix without requiring a restart.
@@ -3002,6 +3015,13 @@ function shutdownChattrProcesses() {
   chattrProcesses.clear();
   // #631: stop Butler PTY on shutdown
   stopButlerPty();
+  // #714: release file-chat writer locks
+  const cfg = readConfig();
+  for (const p of (cfg.projects || [])) {
+    if (p.chat_mode === "file") {
+      try { fileChat.shutdownProject(p.id); } catch {}
+    }
+  }
 }
 
 module.exports = { shutdownChattrProcesses };

--- a/server/index.js
+++ b/server/index.js
@@ -2935,17 +2935,16 @@ server.listen(PORT, "127.0.0.1", async () => {
     }
   }
   // #714: Initialize file-chat engine for projects with chat_mode: "file".
-  // If the writer lock is held by another process, downgrade to "ac" mode
-  // so the single-writer invariant is never violated.
+  // If the writer lock is held by another live process, refuse to start —
+  // enforces the single-writer invariant against the "two terminals" scenario.
   for (const p of (startupCfg.projects || [])) {
     if (p.chat_mode === "file") {
       try {
         fileChat.initProject(p.id);
         console.log(`[startup] ${p.id}: file-chat engine initialized`);
       } catch (err) {
-        console.error(`[startup] ${p.id}: file-chat init failed, falling back to AC mode: ${err.message}`);
-        p.chat_mode = "ac";
-        writeConfig(startupCfg);
+        console.error(`[startup] FATAL: ${p.id}: ${err.message}`);
+        process.exit(1);
       }
     }
   }

--- a/server/index.js
+++ b/server/index.js
@@ -2934,14 +2934,18 @@ server.listen(PORT, "127.0.0.1", async () => {
       console.log(`[startup] ${p.id}: AC already alive on port ${acPort} — tracking`);
     }
   }
-  // #714: Initialize file-chat engine for projects with chat_mode: "file"
+  // #714: Initialize file-chat engine for projects with chat_mode: "file".
+  // If the writer lock is held by another process, downgrade to "ac" mode
+  // so the single-writer invariant is never violated.
   for (const p of (startupCfg.projects || [])) {
     if (p.chat_mode === "file") {
       try {
         fileChat.initProject(p.id);
         console.log(`[startup] ${p.id}: file-chat engine initialized`);
       } catch (err) {
-        console.error(`[startup] ${p.id}: file-chat init failed: ${err.message}`);
+        console.error(`[startup] ${p.id}: file-chat init failed, falling back to AC mode: ${err.message}`);
+        p.chat_mode = "ac";
+        writeConfig(startupCfg);
       }
     }
   }

--- a/server/routes.js
+++ b/server/routes.js
@@ -10,6 +10,7 @@ const path = require("path");
 const os = require("os");
 
 const multer = require("multer");
+const fileChat = require("./file-chat");
 
 const router = express.Router();
 
@@ -236,6 +237,13 @@ function getChattrConfig(projectId) {
   return { url: resolved.url, token: resolved.token };
 }
 
+function getProjectChatMode(projectId) {
+  if (!projectId) return "ac";
+  const cfg = readConfigFile();
+  const project = (cfg.projects || []).find((p) => p.id === projectId);
+  return project?.chat_mode === "file" ? "file" : "ac";
+}
+
 function chatAuthHeaders(token) {
   if (!token) return {};
   return { "x-session-token": token };
@@ -243,6 +251,15 @@ function chatAuthHeaders(token) {
 
 router.get("/api/chat", async (req, res) => {
   const projectId = req.query.project;
+
+  if (getProjectChatMode(projectId) === "file") {
+    const messages = fileChat.readMessages(projectId, {
+      since_id: Number(req.query.since_id) || 0,
+      limit: Number(req.query.limit) || 50,
+    });
+    return res.json(messages);
+  }
+
   const apiPath = req.query.path || "/api/messages";
   const { url: base, token } = getChattrConfig(projectId);
 
@@ -1075,6 +1092,24 @@ router.get("/api/activity/stats", (_req, res) => {
 
 router.post("/api/chat", async (req, res) => {
   const projectId = req.query.project || req.body.project;
+
+  if (getProjectChatMode(projectId) === "file") {
+    let operatorSender = "user";
+    try {
+      const cfg = readConfigFile();
+      operatorSender = sanitizeOperatorName(cfg.operator_name);
+    } catch {}
+    const text = typeof req.body?.text === "string" ? req.body.text : "";
+    if (!text) return res.status(400).json({ error: "text required" });
+    const msg = fileChat.appendMessage(projectId, {
+      sender: operatorSender,
+      text: normalizeMentions(text),
+      channel: req.body?.channel || "general",
+      type: "message",
+    });
+    return res.json({ ok: true, message: msg });
+  }
+
   const { url: base, token: sessionToken } = getChattrConfig(projectId);
   if (!base) return res.status(400).json({ error: "Missing project" });
 
@@ -1254,6 +1289,12 @@ router.get("/api/projects", async (req, res) => {
   // Fetch chat messages from all projects (per-project AgentChattr instances)
   const chatMsgsByProject = {};
   const chatFetches = (cfg.projects || []).map(async (p) => {
+    if (getProjectChatMode(p.id) === "file") {
+      try {
+        chatMsgsByProject[p.id] = fileChat.readMessages(p.id, { limit: 30 });
+      } catch {}
+      return;
+    }
     const { url: chattrUrl, token: chattrToken } = getChattrConfig(p.id);
     try {
       const headers = chattrToken ? { "x-session-token": chattrToken } : {};
@@ -3998,3 +4039,5 @@ module.exports.projectAgentchattrConfigPath = projectAgentchattrConfigPath;
 module.exports.sendViaWebSocket = sendViaWebSocket;
 // #693: expose normalizeMentions for unit tests
 module.exports.normalizeMentions = normalizeMentions;
+// #714: expose for file-chat integration
+module.exports.getProjectChatMode = getProjectChatMode;

--- a/server/routes.js
+++ b/server/routes.js
@@ -1094,15 +1094,10 @@ router.post("/api/chat", async (req, res) => {
   const projectId = req.query.project || req.body.project;
 
   if (getProjectChatMode(projectId) === "file") {
-    let operatorSender = "user";
-    try {
-      const cfg = readConfigFile();
-      operatorSender = sanitizeOperatorName(cfg.operator_name);
-    } catch {}
     const text = typeof req.body?.text === "string" ? req.body.text : "";
     if (!text) return res.status(400).json({ error: "text required" });
     const msg = fileChat.appendMessage(projectId, {
-      sender: operatorSender,
+      sender: "user",
       text: normalizeMentions(text),
       channel: req.body?.channel || "general",
       type: "message",


### PR DESCRIPTION
## Summary
- Adds `server/file-chat.js`: JSONL-based chat engine with monotonic IDs, append-only writes, in-memory ring buffer cache (200 msgs), and writer lock file for single-writer enforcement
- Integrates with existing `GET /POST /api/chat` routes via `chat_mode: "file"` project config flag — AC proxy remains default (`"ac"`)
- Initializes file-chat engine on server startup for `chat_mode: "file"` projects, releases writer locks on shutdown
- Full test suite: monotonic IDs, since_id filtering, malformed-line skip, startup tail-scan recovery, mention parsing, cache-only reads, file permissions

## Test plan
- [x] `node server/file-chat.test.js` — all 7 tests pass
- [x] `npm run build` passes
- [ ] Manual: set `chat_mode: "file"` on a test project, verify messages round-trip via GET/POST `/api/chat`

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)