### PR TITLE
[#715] MCP shim for agent CLI communication

### DIFF
--- a/server/file-chat.js
+++ b/server/file-chat.js
@@ -235,6 +235,18 @@ function getNextId(projectId) {
   return state.nextId;
 }
 
+// #715: per-agent shim tokens for authenticated sends.
+// Map<"projectId:agentId", token>
+const _shimTokens = new Map();
+
+function registerShimToken(projectId, agentId, token) {
+  _shimTokens.set(`${projectId}:${agentId}`, token);
+}
+
+function validateShimToken(projectId, agentId, token) {
+  return _shimTokens.get(`${projectId}:${agentId}`) === token;
+}
+
 module.exports = {
   initProject,
   shutdownProject,
@@ -243,6 +255,8 @@ module.exports = {
   getNextId,
   parseMentions,
   MENTION_RE,
+  registerShimToken,
+  validateShimToken,
   // exposed for testing
   _getState: getState,
   _chatDir: chatDir,

--- a/server/index.js
+++ b/server/index.js
@@ -318,6 +318,24 @@ function writeMcpConfigFile(projectId, agentId, mcpHttpPort, token) {
   return filePath;
 }
 
+function writeFileChatMcpConfig(projectId, agentId, serverPort) {
+  const os = require("os");
+  const configDir = path.join(os.homedir(), ".quadwork", projectId);
+  ensureSecureDir(configDir);
+  const filePath = path.join(configDir, `mcp-${agentId}.json`);
+  const shimPath = path.join(__dirname, "mcp-chat-shim.js");
+  const config = {
+    mcpServers: {
+      chat: {
+        command: "node",
+        args: [shimPath, "--project", projectId, "--agent", agentId, "--port", String(serverPort)],
+      },
+    },
+  };
+  writeSecureFile(filePath, JSON.stringify(config, null, 2));
+  return filePath;
+}
+
 /**
  * Build extra launch args for an agent (permission flags + MCP injection).
  * Async because Codex proxy_flag mode needs to await proxy startup.
@@ -371,6 +389,24 @@ async function buildAgentArgs(projectId, agentId) {
   // MCP config injection
   const mcpHttpPort = project.mcp_http_port;
   const token = project.agentchattr_token;
+
+  // #715: file-chat mode — use the MCP shim instead of AgentChattr
+  if (project.chat_mode === "file") {
+    const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag");
+    acInjectMode = injectMode;
+    if (injectMode === "flag") {
+      const mcpConfigPath = writeFileChatMcpConfig(projectId, agentId, PORT);
+      const mcpFlag = agentCfg.mcp_flag || "--mcp-config";
+      args.push(mcpFlag, mcpConfigPath);
+    } else if (injectMode === "proxy_flag") {
+      const shimPath = path.join(__dirname, "mcp-chat-shim.js");
+      const shimUrl = `stdio://${shimPath}?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}&port=${PORT}`;
+      args.push("-c", `mcp_servers.chat.url="${shimUrl}"`);
+    }
+    // env mode (Gemini) handled in buildAgentEnv
+    return { args, acRegistrationName: agentId, acServerPort: null, acRegistrationToken: null, acInjectMode: injectMode, acMcpHttpPort: null };
+  }
+
   if (mcpHttpPort) {
     const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag");
     acInjectMode = injectMode;
@@ -471,23 +507,39 @@ function buildAgentEnv(projectId, agentId) {
   const env = {};
 
   // Gemini: inject MCP via env var
-  if (cliBase === "gemini" && project.mcp_http_port) {
+  if (cliBase === "gemini") {
     const os = require("os");
     const configDir = path.join(os.homedir(), ".quadwork", projectId);
     ensureSecureDir(configDir);
     const settingsPath = path.join(configDir, `mcp-${agentId}-settings.json`);
-    const url = `http://127.0.0.1:${project.mcp_http_port}/mcp`;
-    const settings = {
-      mcpServers: {
-        agentchattr: {
-          type: "http",
-          url,
-          ...(project.agentchattr_token ? { headers: { Authorization: `Bearer ${project.agentchattr_token}` } } : {}),
+
+    if (project.chat_mode === "file") {
+      // #715: file-chat shim for Gemini
+      const shimPath = path.join(__dirname, "mcp-chat-shim.js");
+      const settings = {
+        mcpServers: {
+          chat: {
+            command: "node",
+            args: [shimPath, "--project", projectId, "--agent", agentId, "--port", String(PORT)],
+          },
         },
-      },
-    };
-    writeSecureFile(settingsPath, JSON.stringify(settings, null, 2));
-    env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = settingsPath;
+      };
+      writeSecureFile(settingsPath, JSON.stringify(settings, null, 2));
+      env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = settingsPath;
+    } else if (project.mcp_http_port) {
+      const url = `http://127.0.0.1:${project.mcp_http_port}/mcp`;
+      const settings = {
+        mcpServers: {
+          agentchattr: {
+            type: "http",
+            url,
+            ...(project.agentchattr_token ? { headers: { Authorization: `Bearer ${project.agentchattr_token}` } } : {}),
+          },
+        },
+      };
+      writeSecureFile(settingsPath, JSON.stringify(settings, null, 2));
+      env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = settingsPath;
+    }
   }
 
   return env;

--- a/server/index.js
+++ b/server/index.js
@@ -320,20 +320,23 @@ function writeMcpConfigFile(projectId, agentId, mcpHttpPort, token) {
 
 function writeFileChatMcpConfig(projectId, agentId, serverPort) {
   const os = require("os");
+  const crypto = require("crypto");
   const configDir = path.join(os.homedir(), ".quadwork", projectId);
   ensureSecureDir(configDir);
   const filePath = path.join(configDir, `mcp-${agentId}.json`);
   const shimPath = path.join(__dirname, "mcp-chat-shim.js");
+  const token = crypto.randomBytes(16).toString("hex");
+  fileChat.registerShimToken(projectId, agentId, token);
   const config = {
     mcpServers: {
       chat: {
         command: "node",
-        args: [shimPath, "--project", projectId, "--agent", agentId, "--port", String(serverPort)],
+        args: [shimPath, "--project", projectId, "--agent", agentId, "--port", String(serverPort), "--token", token],
       },
     },
   };
   writeSecureFile(filePath, JSON.stringify(config, null, 2));
-  return filePath;
+  return { filePath, token };
 }
 
 /**
@@ -395,13 +398,16 @@ async function buildAgentArgs(projectId, agentId) {
     const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag");
     acInjectMode = injectMode;
     if (injectMode === "flag") {
-      const mcpConfigPath = writeFileChatMcpConfig(projectId, agentId, PORT);
+      const { filePath: mcpConfigPath } = writeFileChatMcpConfig(projectId, agentId, PORT);
       const mcpFlag = agentCfg.mcp_flag || "--mcp-config";
       args.push(mcpFlag, mcpConfigPath);
     } else if (injectMode === "proxy_flag") {
+      const { token: shimToken } = writeFileChatMcpConfig(projectId, agentId, PORT);
       const shimPath = path.join(__dirname, "mcp-chat-shim.js");
-      const shimUrl = `stdio://${shimPath}?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}&port=${PORT}`;
-      args.push("-c", `mcp_servers.chat.url="${shimUrl}"`);
+      args.push(
+        "-c", `mcp_servers.chat.command="node"`,
+        "-c", `mcp_servers.chat.args=["${shimPath}","--project","${projectId}","--agent","${agentId}","--port","${PORT}","--token","${shimToken}"]`,
+      );
     }
     // env mode (Gemini) handled in buildAgentEnv
     return { args, acRegistrationName: agentId, acServerPort: null, acRegistrationToken: null, acInjectMode: injectMode, acMcpHttpPort: null };
@@ -514,13 +520,14 @@ function buildAgentEnv(projectId, agentId) {
     const settingsPath = path.join(configDir, `mcp-${agentId}-settings.json`);
 
     if (project.chat_mode === "file") {
-      // #715: file-chat shim for Gemini
+      // #715: file-chat shim for Gemini — reuse writeFileChatMcpConfig for token generation
+      const { token: shimToken } = writeFileChatMcpConfig(projectId, agentId, PORT);
       const shimPath = path.join(__dirname, "mcp-chat-shim.js");
       const settings = {
         mcpServers: {
           chat: {
             command: "node",
-            args: [shimPath, "--project", projectId, "--agent", agentId, "--port", String(PORT)],
+            args: [shimPath, "--project", projectId, "--agent", agentId, "--port", String(PORT), "--token", shimToken],
           },
         },
       };

--- a/server/mcp-chat-shim.js
+++ b/server/mcp-chat-shim.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+"use strict";
+
+const http = require("http");
+const readline = require("readline");
+
+const args = process.argv.slice(2);
+function flag(name) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : null;
+}
+
+const PROJECT = flag("project");
+const AGENT = flag("agent");
+const PORT = flag("port");
+
+if (!PROJECT || !AGENT || !PORT) {
+  process.stderr.write("Usage: node mcp-chat-shim.js --project <id> --agent <id> --port <port>\n");
+  process.exit(1);
+}
+
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const TOOLS = [
+  {
+    name: "chat_send",
+    description: "Send a message to the project chat",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel: { type: "string", default: "general" },
+        message: { type: "string" },
+      },
+      required: ["message"],
+    },
+  },
+  {
+    name: "chat_read",
+    description: "Read recent messages from project chat",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel: { type: "string", default: "general" },
+        limit: { type: "number", default: 50 },
+        since_id: { type: "number" },
+      },
+    },
+  },
+];
+
+function jsonRpc(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function httpRequest(method, urlPath, body, extraHeaders) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const opts = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      method,
+      headers: { "Content-Type": "application/json", ...extraHeaders },
+    };
+    const req = http.request(opts, (res) => {
+      let data = "";
+      res.on("data", (c) => (data += c));
+      res.on("end", () => {
+        try {
+          resolve({ status: res.statusCode, body: JSON.parse(data) });
+        } catch {
+          resolve({ status: res.statusCode, body: data });
+        }
+      });
+    });
+    req.on("error", reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+async function handleToolCall(id, name, params) {
+  try {
+    if (name === "chat_send") {
+      const res = await httpRequest("POST", `/api/chat?project=${encodeURIComponent(PROJECT)}`, {
+        text: params.message || "",
+        channel: params.channel || "general",
+      }, { "X-Chat-Sender": AGENT });
+      if (res.status >= 400) {
+        return jsonRpcError(id, -32000, `API error ${res.status}: ${JSON.stringify(res.body)}`);
+      }
+      return jsonRpc(id, { content: [{ type: "text", text: JSON.stringify(res.body) }] });
+    }
+
+    if (name === "chat_read") {
+      const qs = new URLSearchParams({ project: PROJECT });
+      if (params.limit) qs.set("limit", String(params.limit));
+      if (params.since_id) qs.set("since_id", String(params.since_id));
+      const res = await httpRequest("GET", `/api/chat?${qs.toString()}`);
+      if (res.status >= 400) {
+        return jsonRpcError(id, -32000, `API error ${res.status}: ${JSON.stringify(res.body)}`);
+      }
+      return jsonRpc(id, { content: [{ type: "text", text: JSON.stringify(res.body) }] });
+    }
+
+    return jsonRpcError(id, -32601, `Unknown tool: ${name}`);
+  } catch (err) {
+    return jsonRpcError(id, -32000, err.message);
+  }
+}
+
+// --- Notification callback server ---
+
+let notifyServer = null;
+let notifyPort = null;
+
+function startNotifyServer() {
+  return new Promise((resolve) => {
+    notifyServer = http.createServer((req, res) => {
+      if (req.method === "POST") {
+        let body = "";
+        req.on("data", (c) => (body += c));
+        req.on("end", () => {
+          try {
+            const payload = JSON.parse(body);
+            const notification = JSON.stringify({
+              jsonrpc: "2.0",
+              method: "notifications/message",
+              params: payload,
+            });
+            process.stdout.write(notification + "\n");
+          } catch {}
+          res.writeHead(200);
+          res.end("ok");
+        });
+      } else {
+        res.writeHead(405);
+        res.end();
+      }
+    });
+    notifyServer.listen(0, "127.0.0.1", () => {
+      notifyPort = notifyServer.address().port;
+      resolve(notifyPort);
+    });
+  });
+}
+
+// --- MCP stdio protocol ---
+
+async function handleMessage(msg) {
+  const { id, method, params } = msg;
+
+  if (method === "initialize") {
+    await startNotifyServer();
+    return jsonRpc(id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: { name: "quadwork-chat", version: "1.0.0" },
+    });
+  }
+
+  if (method === "initialized") {
+    // Register notification callback with QuadWork
+    if (notifyPort) {
+      httpRequest("POST", `/api/chat/notify-register?project=${encodeURIComponent(PROJECT)}`, {
+        agent: AGENT,
+        callback_url: `http://127.0.0.1:${notifyPort}`,
+      }).catch(() => {});
+    }
+    return null;
+  }
+
+  if (method === "tools/list") {
+    return jsonRpc(id, { tools: TOOLS });
+  }
+
+  if (method === "tools/call") {
+    return handleToolCall(id, params?.name, params?.arguments || {});
+  }
+
+  if (method === "ping") {
+    return jsonRpc(id, {});
+  }
+
+  if (id != null) {
+    return jsonRpcError(id, -32601, `Method not found: ${method}`);
+  }
+  return null;
+}
+
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+rl.on("line", async (line) => {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    process.stdout.write(jsonRpcError(null, -32700, "Parse error") + "\n");
+    return;
+  }
+  const response = await handleMessage(msg);
+  if (response) {
+    process.stdout.write(response + "\n");
+  }
+});
+
+rl.on("close", () => {
+  if (notifyServer) notifyServer.close();
+  process.exit(0);
+});

--- a/server/mcp-chat-shim.js
+++ b/server/mcp-chat-shim.js
@@ -98,6 +98,7 @@ async function handleToolCall(id, name, params) {
 
     if (name === "chat_read") {
       const qs = new URLSearchParams({ project: PROJECT });
+      if (params.channel) qs.set("channel", params.channel);
       if (params.limit) qs.set("limit", String(params.limit));
       if (params.since_id) qs.set("since_id", String(params.since_id));
       const res = await httpRequest("GET", `/api/chat?${qs.toString()}`);

--- a/server/mcp-chat-shim.js
+++ b/server/mcp-chat-shim.js
@@ -13,9 +13,10 @@ function flag(name) {
 const PROJECT = flag("project");
 const AGENT = flag("agent");
 const PORT = flag("port");
+const TOKEN = flag("token");
 
 if (!PROJECT || !AGENT || !PORT) {
-  process.stderr.write("Usage: node mcp-chat-shim.js --project <id> --agent <id> --port <port>\n");
+  process.stderr.write("Usage: node mcp-chat-shim.js --project <id> --agent <id> --port <port> [--token <token>]\n");
   process.exit(1);
 }
 
@@ -89,7 +90,7 @@ async function handleToolCall(id, name, params) {
       const res = await httpRequest("POST", `/api/chat?project=${encodeURIComponent(PROJECT)}`, {
         text: params.message || "",
         channel: params.channel || "general",
-      }, { "X-Chat-Sender": AGENT });
+      }, { "X-Chat-Sender": AGENT, ...(TOKEN ? { "X-Chat-Token": TOKEN } : {}) });
       if (res.status >= 400) {
         return jsonRpcError(id, -32000, `API error ${res.status}: ${JSON.stringify(res.body)}`);
       }

--- a/server/mcp-chat-shim.test.js
+++ b/server/mcp-chat-shim.test.js
@@ -1,0 +1,187 @@
+"use strict";
+
+const { spawn } = require("child_process");
+const http = require("http");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const { ensureSecureDir } = require("./config");
+const fileChat = require("./file-chat");
+
+const PROJECT = "__mcp_shim_test__";
+const AGENT = "test-agent";
+const SHIM = path.join(__dirname, "mcp-chat-shim.js");
+
+let server;
+let serverPort;
+
+function sendJsonRpc(proc, msg) {
+  proc.stdin.write(JSON.stringify(msg) + "\n");
+}
+
+function readResponse(proc) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timeout waiting for response")), 5000);
+    const handler = (data) => {
+      clearTimeout(timeout);
+      proc.stdout.removeListener("data", handler);
+      try {
+        resolve(JSON.parse(data.toString().trim().split("\n").pop()));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    proc.stdout.on("data", handler);
+  });
+}
+
+function startTestServer() {
+  return new Promise((resolve) => {
+    const express = require("express");
+    const app = express();
+    app.use(express.json());
+
+    app.get("/api/chat", (req, res) => {
+      const msgs = fileChat.readMessages(PROJECT, {
+        since_id: Number(req.query.since_id) || 0,
+        limit: Number(req.query.limit) || 50,
+      });
+      res.json(msgs);
+    });
+
+    app.post("/api/chat", (req, res) => {
+      const sender = req.headers["x-chat-sender"] || "user";
+      const msg = fileChat.appendMessage(PROJECT, {
+        sender,
+        text: req.body.text || "",
+        channel: req.body.channel || "general",
+        type: "message",
+      });
+      res.json({ ok: true, message: msg });
+    });
+
+    app.post("/api/chat/notify-register", (req, res) => {
+      res.json({ ok: true });
+    });
+
+    server = app.listen(0, "127.0.0.1", () => {
+      serverPort = server.address().port;
+      resolve();
+    });
+  });
+}
+
+async function runTests() {
+  let passed = 0;
+  let failed = 0;
+
+  function assert(condition, msg) {
+    if (condition) {
+      passed++;
+      console.log(`  PASS: ${msg}`);
+    } else {
+      failed++;
+      console.error(`  FAIL: ${msg}`);
+    }
+  }
+
+  // Setup
+  fileChat.initProject(PROJECT);
+  await startTestServer();
+
+  const shim = spawn("node", [SHIM, "--project", PROJECT, "--agent", AGENT, "--port", String(serverPort)], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  shim.stderr.on("data", (d) => process.stderr.write(`[shim stderr] ${d}`));
+
+  // Test 1: initialize
+  console.log("\n--- MCP Shim Conformance Tests ---\n");
+  sendJsonRpc(shim, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  const initResp = await readResponse(shim);
+  assert(initResp.result?.protocolVersion === "2024-11-05", "initialize returns protocol version");
+  assert(initResp.result?.capabilities?.tools != null, "initialize returns tools capability");
+
+  // Send initialized notification
+  sendJsonRpc(shim, { jsonrpc: "2.0", method: "initialized" });
+  await new Promise((r) => setTimeout(r, 100));
+
+  // Test 2: tools/list
+  sendJsonRpc(shim, { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+  const listResp = await readResponse(shim);
+  const toolNames = (listResp.result?.tools || []).map((t) => t.name);
+  assert(toolNames.includes("chat_send"), "tools/list includes chat_send");
+  assert(toolNames.includes("chat_read"), "tools/list includes chat_read");
+
+  // Test 3: chat_send
+  sendJsonRpc(shim, {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "chat_send", arguments: { message: "hello from shim @user" } },
+  });
+  const sendResp = await readResponse(shim);
+  assert(sendResp.result?.content?.[0]?.type === "text", "chat_send returns text content");
+  const sendBody = JSON.parse(sendResp.result.content[0].text);
+  assert(sendBody.ok === true, "chat_send returns ok: true");
+  assert(sendBody.message?.sender === AGENT, "chat_send uses agent sender from X-Chat-Sender header");
+
+  // Test 4: chat_read
+  sendJsonRpc(shim, {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: { name: "chat_read", arguments: {} },
+  });
+  const readResp = await readResponse(shim);
+  assert(readResp.result?.content?.[0]?.type === "text", "chat_read returns text content");
+  const messages = JSON.parse(readResp.result.content[0].text);
+  assert(Array.isArray(messages), "chat_read returns array");
+  assert(messages.length >= 1, "chat_read contains the sent message");
+  assert(messages[messages.length - 1]?.text === "hello from shim @user", "chat_read message text matches");
+
+  // Test 5: chat_read with since_id
+  const lastId = messages[messages.length - 1].id;
+  sendJsonRpc(shim, {
+    jsonrpc: "2.0",
+    id: 5,
+    method: "tools/call",
+    params: { name: "chat_send", arguments: { message: "second message" } },
+  });
+  await readResponse(shim);
+
+  sendJsonRpc(shim, {
+    jsonrpc: "2.0",
+    id: 6,
+    method: "tools/call",
+    params: { name: "chat_read", arguments: { since_id: lastId } },
+  });
+  const sinceResp = await readResponse(shim);
+  const sinceMessages = JSON.parse(sinceResp.result.content[0].text);
+  assert(sinceMessages.length === 1, "chat_read with since_id returns only new messages");
+  assert(sinceMessages[0]?.text === "second message", "since_id filtered message matches");
+
+  // Test 6: ping
+  sendJsonRpc(shim, { jsonrpc: "2.0", id: 7, method: "ping" });
+  const pingResp = await readResponse(shim);
+  assert(pingResp.id === 7 && pingResp.result != null, "ping responds");
+
+  // Cleanup
+  shim.stdin.end();
+  await new Promise((r) => shim.on("close", r));
+  server.close();
+  fileChat.shutdownProject(PROJECT);
+
+  // Clean up test files
+  const testDir = path.join(os.homedir(), ".quadwork", PROJECT);
+  try { fs.rmSync(testDir, { recursive: true }); } catch {}
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  console.error(err);
+  if (server) server.close();
+  process.exit(1);
+});

--- a/server/mcp-chat-shim.test.js
+++ b/server/mcp-chat-shim.test.js
@@ -8,8 +8,11 @@ const os = require("os");
 const { ensureSecureDir } = require("./config");
 const fileChat = require("./file-chat");
 
+const crypto = require("crypto");
+
 const PROJECT = "__mcp_shim_test__";
 const AGENT = "test-agent";
+const TEST_TOKEN = crypto.randomBytes(16).toString("hex");
 const SHIM = path.join(__dirname, "mcp-chat-shim.js");
 
 let server;
@@ -50,7 +53,15 @@ function startTestServer() {
     });
 
     app.post("/api/chat", (req, res) => {
-      const sender = req.headers["x-chat-sender"] || "user";
+      const shimSender = req.headers["x-chat-sender"];
+      const shimToken = req.headers["x-chat-token"];
+      let sender = "user";
+      if (shimSender && shimToken) {
+        if (!fileChat.validateShimToken(PROJECT, shimSender, shimToken)) {
+          return res.status(403).json({ error: "Invalid shim token" });
+        }
+        sender = shimSender;
+      }
       const msg = fileChat.appendMessage(PROJECT, {
         sender,
         text: req.body.text || "",
@@ -87,9 +98,10 @@ async function runTests() {
 
   // Setup
   fileChat.initProject(PROJECT);
+  fileChat.registerShimToken(PROJECT, AGENT, TEST_TOKEN);
   await startTestServer();
 
-  const shim = spawn("node", [SHIM, "--project", PROJECT, "--agent", AGENT, "--port", String(serverPort)], {
+  const shim = spawn("node", [SHIM, "--project", PROJECT, "--agent", AGENT, "--port", String(serverPort), "--token", TEST_TOKEN], {
     stdio: ["pipe", "pipe", "pipe"],
   });
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -1114,11 +1114,18 @@ router.post("/api/chat", async (req, res) => {
   if (getProjectChatMode(projectId) === "file") {
     const text = typeof req.body?.text === "string" ? req.body.text : "";
     if (!text) return res.status(400).json({ error: "text required" });
-    // #715: MCP shim identifies itself via X-Chat-Sender header with the
-    // agent ID injected at spawn time. Dashboard POSTs never set this
-    // header, so they always get sender: "user".
+    // #715: MCP shim identifies itself via X-Chat-Sender + X-Chat-Token
+    // headers. The token is generated at spawn time and validated against
+    // the in-memory registry to prevent impersonation.
     const shimSender = req.headers["x-chat-sender"];
-    const sender = shimSender || "user";
+    const shimToken = req.headers["x-chat-token"];
+    let sender = "user";
+    if (shimSender && shimToken) {
+      if (!fileChat.validateShimToken(projectId, shimSender, shimToken)) {
+        return res.status(403).json({ error: "Invalid shim token" });
+      }
+      sender = shimSender;
+    }
     const msg = fileChat.appendMessage(projectId, {
       sender,
       text: normalizeMentions(text),

--- a/server/routes.js
+++ b/server/routes.js
@@ -1223,11 +1223,16 @@ router.post("/api/chat", async (req, res) => {
 });
 
 // #715: MCP shim notification callback registration
+const LOCALHOST_CB_RE = /^http:\/\/127\.0\.0\.1:\d+\/?$/;
+
 router.post("/api/chat/notify-register", (req, res) => {
   const projectId = req.query.project;
   const { agent, callback_url } = req.body || {};
   if (!projectId || !agent || !callback_url) {
     return res.status(400).json({ error: "project, agent, and callback_url required" });
+  }
+  if (!LOCALHOST_CB_RE.test(callback_url)) {
+    return res.status(400).json({ error: "callback_url must be http://127.0.0.1:<port>" });
   }
   if (!_notifyCallbacks.has(projectId)) {
     _notifyCallbacks.set(projectId, new Map());

--- a/server/routes.js
+++ b/server/routes.js
@@ -14,6 +14,24 @@ const fileChat = require("./file-chat");
 
 const router = express.Router();
 
+// #715: per-project notification callback registry for MCP shims.
+// Map<projectId, Map<agentId, callbackUrl>>
+const _notifyCallbacks = new Map();
+
+function notifyMentionedAgents(projectId, msg) {
+  const callbacks = _notifyCallbacks.get(projectId);
+  if (!callbacks || !msg.mentions || msg.mentions.length === 0) return;
+  for (const mention of msg.mentions) {
+    const url = callbacks.get(mention);
+    if (!url) continue;
+    fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: msg.id, sender: msg.sender, text: msg.text, channel: msg.channel }),
+    }).catch(() => {});
+  }
+}
+
 const CONFIG_DIR = path.join(os.homedir(), ".quadwork");
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 const ENV_PATH = path.join(CONFIG_DIR, ".env");
@@ -1096,12 +1114,18 @@ router.post("/api/chat", async (req, res) => {
   if (getProjectChatMode(projectId) === "file") {
     const text = typeof req.body?.text === "string" ? req.body.text : "";
     if (!text) return res.status(400).json({ error: "text required" });
+    // #715: MCP shim identifies itself via X-Chat-Sender header with the
+    // agent ID injected at spawn time. Dashboard POSTs never set this
+    // header, so they always get sender: "user".
+    const shimSender = req.headers["x-chat-sender"];
+    const sender = shimSender || "user";
     const msg = fileChat.appendMessage(projectId, {
-      sender: "user",
+      sender,
       text: normalizeMentions(text),
       channel: req.body?.channel || "general",
       type: "message",
     });
+    notifyMentionedAgents(projectId, msg);
     return res.json({ ok: true, message: msg });
   }
 
@@ -1196,6 +1220,20 @@ router.post("/api/chat", async (req, res) => {
     console.warn(`[chat] send failed for project ${projectId}: ${err && err.message}`);
     return res.status(502).json({ error: "AgentChattr unreachable", detail: err && err.message });
   }
+});
+
+// #715: MCP shim notification callback registration
+router.post("/api/chat/notify-register", (req, res) => {
+  const projectId = req.query.project;
+  const { agent, callback_url } = req.body || {};
+  if (!projectId || !agent || !callback_url) {
+    return res.status(400).json({ error: "project, agent, and callback_url required" });
+  }
+  if (!_notifyCallbacks.has(projectId)) {
+    _notifyCallbacks.set(projectId, new Map());
+  }
+  _notifyCallbacks.get(projectId).set(agent, callback_url);
+  res.json({ ok: true });
 });
 
 // ─── Image upload (#466) ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `server/mcp-chat-shim.js` — a stdio MCP server (~170 lines) that exposes `chat_send` and `chat_read` tools, proxying to QuadWork's HTTP API
- Sender identity injected server-side via `X-Chat-Sender` header — agents cannot impersonate each other
- HTTP notification callback: shim registers a localhost callback on startup; QuadWork POSTs to it when a message @mentions the agent
- MCP config generation updated for file-chat mode: Claude (flag), Codex (proxy_flag), and Gemini (env) all get shim-based configs instead of AgentChattr configs
- Conformance test verifies round-trip: initialize → tools/list → chat_send → chat_read → since_id filtering → ping

## Test plan
- [x] `node server/mcp-chat-shim.test.js` — 14/14 passing
- [x] `npm run build` — passes

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)