### PR TITLE
[#716] Dashboard chat panel — REST polling from JSONL

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -271,11 +271,16 @@ router.get("/api/chat", async (req, res) => {
   const projectId = req.query.project;
 
   if (getProjectChatMode(projectId) === "file") {
+    const sinceId = Number(req.query.since_id) || Number(req.query.cursor) || 0;
     const messages = fileChat.readMessages(projectId, {
-      since_id: Number(req.query.since_id) || 0,
+      since_id: sinceId,
       limit: Number(req.query.limit) || 50,
     });
-    return res.json(messages);
+    const normalized = messages.map((m) => ({
+      ...m,
+      time: m.time || (m.ts ? m.ts.slice(11, 19) : ""),
+    }));
+    return res.json(normalized);
   }
 
   const apiPath = req.query.path || "/api/messages";

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -129,14 +129,15 @@ interface ChatPanelProps {
   projectId?: string;
   /** #523: filter state lifted to parent so toggle renders in PanelHeader */
   filterSystem?: boolean;
+  chatMode?: "ac" | "file";
 }
 
-export default function ChatPanel({ projectId, filterSystem }: ChatPanelProps) {
-  return <ChatPanelAPI projectId={projectId} filterSystem={filterSystem} />;
+export default function ChatPanel({ projectId, filterSystem, chatMode }: ChatPanelProps) {
+  return <ChatPanelAPI projectId={projectId} filterSystem={filterSystem} chatMode={chatMode} />;
 }
 
 /** API-driven fallback when iframe is blocked */
-function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string; filterSystem?: boolean }) {
+function ChatPanelAPI({ projectId, filterSystem = false, chatMode = "ac" }: { projectId?: string; filterSystem?: boolean; chatMode?: "ac" | "file" }) {
   const channel = "general";
   const [messages, setMessages] = useState<Message[]>([]);
   // #410: track whether the initial fetch has completed so we don't
@@ -190,12 +191,14 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
     if (retryTimerRef.current) { clearTimeout(retryTimerRef.current); retryTimerRef.current = null; }
   }, [projectId]);
 
-  // Poll messages via proxy
+  // Poll messages via proxy (AC mode) or direct REST (file mode)
   const fetchMessages = useCallback(() => {
-    fetch(`/api/chat?path=/api/messages&channel=${encodeURIComponent(channel)}&cursor=${cursorRef.current}${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`)
+    const url = chatMode === "file"
+      ? `/api/chat?project=${encodeURIComponent(projectId || "")}&since_id=${cursorRef.current}&channel=${encodeURIComponent(channel)}`
+      : `/api/chat?path=/api/messages&channel=${encodeURIComponent(channel)}&cursor=${cursorRef.current}${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`;
+    fetch(url)
       .then((r) => {
         if (r.status === 403) {
-          // Token may still be syncing — clear error on next successful poll
           if (authRetryRef.current < 3) setAuthError(null);
           else setAuthError("Chat authentication failed (403). Set agentchattr_token in Settings or ~/.quadwork/config.json.");
           throw new Error("auth failed");
@@ -215,23 +218,15 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
           const maxId = Math.max(...msgs.map((m) => m.id));
           if (maxId > cursorRef.current) cursorRef.current = maxId;
         }
-        // #436: only mark loaded after a successful fetch. This is
-        // the ONLY place `loaded` flips to true — error paths below
-        // leave it false so the component shows "Loading messages..."
-        // instead of the welcome screen while retries are pending.
         setLoaded(true);
       })
       .catch(() => {
-        // #436: if the initial load hasn't succeeded yet, schedule a
-        // retry after a delay. Once loaded is true (first success),
-        // failures in subsequent polls are harmless — the component
-        // already has messages and the next 3s poll will retry.
         if (!loaded && initialRetryRef.current < MAX_INITIAL_RETRIES) {
           initialRetryRef.current += 1;
           retryTimerRef.current = setTimeout(fetchMessages, INITIAL_RETRY_DELAY_MS);
         }
       });
-  }, [channel, projectId, loaded]);
+  }, [channel, projectId, loaded, chatMode]);
 
   useEffect(() => {
     fetchMessages();

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -72,9 +72,11 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
   // config (bridge_filter_agents_only), so dashboard and bridges stay in sync.
   const [filterSystem, setFilterSystem] = useState(false);
   const filterLoadedRef = useRef(false);
+  const [chatMode, setChatMode] = useState<"ac" | "file">("ac");
   useEffect(() => {
     filterLoadedRef.current = false;
     setFilterSystem(false);
+    setChatMode("ac");
   }, [projectId]);
   useEffect(() => {
     if (filterLoadedRef.current) return;
@@ -84,6 +86,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
         if (!cfg) return;
         const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
         if (entry?.bridge_filter_agents_only) setFilterSystem(true);
+        if (entry?.chat_mode === "file") setChatMode("file");
         filterLoadedRef.current = true;
       })
       .catch(() => {});
@@ -228,7 +231,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
             {filterToggle}
           </PanelHeader>
           <div className="flex-1 min-h-0">
-            <ChatPanel projectId={projectId} filterSystem={filterSystem} />
+            <ChatPanel projectId={projectId} filterSystem={filterSystem} chatMode={chatMode} />
           </div>
           <ControlBar projectId={projectId} />
         </div>


### PR DESCRIPTION
## Summary
- ChatPanel detects `chat_mode: "file"` via project config and polls using `since_id` instead of AC-specific `cursor`/`path` params
- Server route normalizes file-chat responses: derives `time` from `ts`, accepts `cursor` as `since_id` alias for backward compatibility
- GlobalNotificationListener works for file-mode without changes (route normalization handles it)
- Same UI preserved: chat bubbles, @mention pills, input bar, presets, notification sound, system log filter

## Test plan
- [x] `npm run build` — passes
- [x] `node server/file-chat.test.js` — all passing
- [x] `node server/mcp-chat-shim.test.js` — 14/14 passing
- [ ] Manual: verify chat panel renders messages for a file-mode project
- [ ] Manual: verify sending a message appends to JSONL and appears on next poll

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)