### PR TITLE
[#717] Loop guard in QuadWork message processing

### DIFF
--- a/server/file-chat.js
+++ b/server/file-chat.js
@@ -137,7 +137,7 @@ function shutdownProject(projectId) {
   projectState.delete(projectId);
 }
 
-function appendMessage(projectId, { sender, channel = "general", text, type = "message" }) {
+function appendMessage(projectId, { sender, channel = "general", text, type = "message" }, _skipLoopGuard = false) {
   const state = getState(projectId);
   if (state.nextId === null) {
     throw new Error(`Project ${projectId} not initialized — call initProject first`);
@@ -235,6 +235,57 @@ function getNextId(projectId) {
   return state.nextId;
 }
 
+// #717: per-project loop guard state
+const _loopGuardState = new Map();
+
+function checkLoopGuard(projectId, msg, maxHops = 30) {
+  let state = _loopGuardState.get(projectId) || { hops: 0, paused: false };
+
+  if (msg.sender === "user") {
+    const isResume = typeof msg.text === "string" && msg.text.trim() === "/continue";
+    state.hops = 0;
+    state.paused = false;
+    _loopGuardState.set(projectId, state);
+    if (isResume) {
+      appendMessageInternal(projectId, {
+        sender: "system",
+        type: "system",
+        text: "Loop guard resumed.",
+        channel: msg.channel || "general",
+      });
+    }
+    return;
+  }
+
+  if (msg.type === "system") return;
+  if (state.paused) return;
+
+  state.hops++;
+  if (state.hops >= maxHops) {
+    state.paused = true;
+    appendMessageInternal(projectId, {
+      sender: "system",
+      type: "system",
+      text: `Loop guard: paused after ${maxHops} agent-to-agent messages with no human reply. Type /continue to resume.`,
+      channel: msg.channel || "general",
+    });
+  }
+  _loopGuardState.set(projectId, state);
+}
+
+function isLoopGuardPaused(projectId) {
+  const state = _loopGuardState.get(projectId);
+  return state ? state.paused : false;
+}
+
+function resetLoopGuard(projectId) {
+  _loopGuardState.delete(projectId);
+}
+
+function appendMessageInternal(projectId, opts) {
+  return appendMessage(projectId, opts, true);
+}
+
 // #715: per-agent shim tokens for authenticated sends.
 // Map<"projectId:agentId", token>
 const _shimTokens = new Map();
@@ -255,6 +306,9 @@ module.exports = {
   getNextId,
   parseMentions,
   MENTION_RE,
+  checkLoopGuard,
+  isLoopGuardPaused,
+  resetLoopGuard,
   registerShimToken,
   validateShimToken,
   // exposed for testing

--- a/server/file-chat.loopguard.test.js
+++ b/server/file-chat.loopguard.test.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const fileChat = require("./file-chat");
+
+const PROJECT = "__loop_guard_test__";
+
+function cleanup() {
+  try { fileChat.shutdownProject(PROJECT); } catch {}
+  try { fileChat.resetLoopGuard(PROJECT); } catch {}
+  const dir = path.join(os.homedir(), ".quadwork", PROJECT);
+  try { fs.rmSync(dir, { recursive: true }); } catch {}
+}
+
+function runTests() {
+  let passed = 0;
+  let failed = 0;
+
+  function assert(condition, msg) {
+    if (condition) {
+      passed++;
+      console.log(`  PASS: ${msg}`);
+    } else {
+      failed++;
+      console.error(`  FAIL: ${msg}`);
+    }
+  }
+
+  console.log("\n--- Loop Guard Tests ---\n");
+
+  // Test 1: agent messages trigger pause at threshold
+  cleanup();
+  fileChat.initProject(PROJECT);
+
+  const maxHops = 5;
+  for (let i = 0; i < maxHops; i++) {
+    const msg = fileChat.appendMessage(PROJECT, {
+      sender: "head",
+      text: `agent message ${i + 1}`,
+      channel: "general",
+    });
+    fileChat.checkLoopGuard(PROJECT, msg, maxHops);
+  }
+  assert(fileChat.isLoopGuardPaused(PROJECT), `pauses after ${maxHops} agent messages`);
+
+  // Check that a system message was appended
+  const msgs = fileChat.readMessages(PROJECT, { limit: 50 });
+  const systemMsg = msgs.find((m) => m.sender === "system" && m.text.includes("Loop guard"));
+  assert(!!systemMsg, "system pause message appended");
+
+  // Test 2: user message resets counter
+  cleanup();
+  fileChat.initProject(PROJECT);
+
+  for (let i = 0; i < 3; i++) {
+    const msg = fileChat.appendMessage(PROJECT, { sender: "dev", text: `msg ${i}` });
+    fileChat.checkLoopGuard(PROJECT, msg, maxHops);
+  }
+  assert(!fileChat.isLoopGuardPaused(PROJECT), "not paused after 3 of 5 hops");
+
+  const userMsg = fileChat.appendMessage(PROJECT, { sender: "user", text: "ok" });
+  fileChat.checkLoopGuard(PROJECT, userMsg, maxHops);
+
+  // Now send another batch — should start from 0
+  for (let i = 0; i < 4; i++) {
+    const msg = fileChat.appendMessage(PROJECT, { sender: "re1", text: `after reset ${i}` });
+    fileChat.checkLoopGuard(PROJECT, msg, maxHops);
+  }
+  assert(!fileChat.isLoopGuardPaused(PROJECT), "not paused after user reset + 4 more hops");
+
+  // Test 3: /continue resumes
+  cleanup();
+  fileChat.initProject(PROJECT);
+
+  for (let i = 0; i < maxHops; i++) {
+    const msg = fileChat.appendMessage(PROJECT, { sender: "head", text: `loop ${i}` });
+    fileChat.checkLoopGuard(PROJECT, msg, maxHops);
+  }
+  assert(fileChat.isLoopGuardPaused(PROJECT), "paused before /continue");
+
+  const continueMsg = fileChat.appendMessage(PROJECT, { sender: "user", text: "/continue" });
+  fileChat.checkLoopGuard(PROJECT, continueMsg, maxHops);
+  assert(!fileChat.isLoopGuardPaused(PROJECT), "/continue resumes loop guard");
+
+  const allMsgs = fileChat.readMessages(PROJECT, { limit: 100 });
+  const resumeMsg = allMsgs.find((m) => m.text === "Loop guard resumed.");
+  assert(!!resumeMsg, "/continue appends 'Loop guard resumed.' system message");
+
+  // Test 4: system messages don't count as hops
+  cleanup();
+  fileChat.initProject(PROJECT);
+
+  for (let i = 0; i < 3; i++) {
+    const msg = fileChat.appendMessage(PROJECT, { sender: "dev", text: `agent ${i}` });
+    fileChat.checkLoopGuard(PROJECT, msg, maxHops);
+  }
+  const sysMsg = fileChat.appendMessage(PROJECT, { sender: "system", text: "status", type: "system" });
+  fileChat.checkLoopGuard(PROJECT, sysMsg, maxHops);
+  // Should still be at 3 hops, not 4
+  const agentAfter = fileChat.appendMessage(PROJECT, { sender: "dev", text: "agent 3" });
+  fileChat.checkLoopGuard(PROJECT, agentAfter, maxHops);
+  assert(!fileChat.isLoopGuardPaused(PROJECT), "system messages don't count as hops (4 agent + 1 system = not paused at 5)");
+
+  // Cleanup
+  cleanup();
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/server/routes.js
+++ b/server/routes.js
@@ -255,6 +255,22 @@ function getChattrConfig(projectId) {
   return { url: resolved.url, token: resolved.token };
 }
 
+function getProjectMaxHops(projectId) {
+  if (!projectId) return 30;
+  const cfg = readConfigFile();
+  const project = (cfg.projects || []).find((p) => p.id === projectId);
+  if (project?.max_agent_hops != null) return project.max_agent_hops;
+  const tomlPath = resolveProjectConfigToml(projectId);
+  if (tomlPath && fs.existsSync(tomlPath)) {
+    try {
+      const content = fs.readFileSync(tomlPath, "utf-8");
+      const m = content.match(/^\s*max_agent_hops\s*=\s*(\d+)/m);
+      if (m) return parseInt(m[1], 10);
+    } catch {}
+  }
+  return 30;
+}
+
 function getProjectChatMode(projectId) {
   if (!projectId) return "ac";
   const cfg = readConfigFile();
@@ -534,12 +550,16 @@ function resolveProjectConfigToml(projectId) {
 router.get("/api/loop-guard", (req, res) => {
   const projectId = req.query.project;
   if (!projectId) return res.status(400).json({ error: "Missing project" });
+  // #717: file-chat mode reads from config.json or toml
+  const value = getProjectMaxHops(projectId);
+  if (getProjectChatMode(projectId) === "file") {
+    return res.json({ value, source: value === 30 ? "default" : "config" });
+  }
   const tomlPath = resolveProjectConfigToml(projectId);
   if (!tomlPath || !fs.existsSync(tomlPath)) return res.json({ value: 30, source: "default" });
   try {
     const content = fs.readFileSync(tomlPath, "utf-8");
     const m = content.match(/^\s*max_agent_hops\s*=\s*(\d+)/m);
-    const value = m ? parseInt(m[1], 10) : 30;
     res.json({ value, source: m ? "toml" : "default" });
   } catch (err) {
     res.status(500).json({ error: "Failed to read config.toml", detail: err.message });
@@ -551,13 +571,21 @@ router.put("/api/loop-guard", async (req, res) => {
   if (!projectId) return res.status(400).json({ error: "Missing project" });
   const raw = req.body?.value;
   const value = typeof raw === "number" ? raw : parseInt(raw, 10);
-  // AC's update_settings handler clamps to [1, 50]; mirror that
-  // here so we don't write a value AC will silently rewrite.
   if (!Number.isInteger(value) || value < 4 || value > 50) {
     return res.status(400).json({ error: "value must be an integer between 4 and 50" });
   }
 
-  // 1. Persist to config.toml so the next restart picks it up.
+  // #717: file-chat mode stores max_agent_hops in config.json
+  if (getProjectChatMode(projectId) === "file") {
+    const cfg = readConfigFile();
+    const project = (cfg.projects || []).find((p) => p.id === projectId);
+    if (!project) return res.status(404).json({ error: "Project not found" });
+    project.max_agent_hops = value;
+    writeConfigFile(cfg);
+    return res.json({ ok: true, value });
+  }
+
+  // AC mode: persist to config.toml
   const tomlPath = resolveProjectConfigToml(projectId);
   if (!tomlPath || !fs.existsSync(tomlPath)) {
     return res.status(404).json({ error: "config.toml not found for project" });
@@ -1137,7 +1165,12 @@ router.post("/api/chat", async (req, res) => {
       channel: req.body?.channel || "general",
       type: "message",
     });
-    notifyMentionedAgents(projectId, msg);
+    // #717: loop guard — count agent hops, pause if threshold reached
+    const maxHops = getProjectMaxHops(projectId);
+    fileChat.checkLoopGuard(projectId, msg, maxHops);
+    if (!fileChat.isLoopGuardPaused(projectId)) {
+      notifyMentionedAgents(projectId, msg);
+    }
     return res.json({ ok: true, message: msg });
   }
 


### PR DESCRIPTION
## Summary
- Per-project hop counter in file-chat engine: increments on agent messages, resets on user messages
- Pauses at configurable `max_agent_hops` (default 30) with system message
- `/continue` command resumes and appends "Loop guard resumed." system message
- System messages bypass hop counting (no re-entry)
- Agent notifications suppressed while paused
- LoopGuardWidget GET/PUT endpoints updated for file-chat mode (config.json instead of toml + AC WebSocket)

## Test plan
- [x] `node server/file-chat.loopguard.test.js` — 8/8 passing (pause at threshold, user reset, /continue resume, system message bypass)
- [x] `node server/file-chat.test.js` — all passing
- [x] `npm run build` — passes

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)