### PR TITLE
[#718] System messages for agent lifecycle events

### DIFF
--- a/server/file-chat.system-messages.test.js
+++ b/server/file-chat.system-messages.test.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const fileChat = require("./file-chat");
+
+const PROJECT = "__system_msg_test__";
+
+function cleanup() {
+  try { fileChat.shutdownProject(PROJECT); } catch {}
+  const dir = path.join(os.homedir(), ".quadwork", PROJECT);
+  try { fs.rmSync(dir, { recursive: true }); } catch {}
+}
+
+function runTests() {
+  let passed = 0;
+  let failed = 0;
+
+  function assert(condition, msg) {
+    if (condition) {
+      passed++;
+      console.log(`  PASS: ${msg}`);
+    } else {
+      failed++;
+      console.error(`  FAIL: ${msg}`);
+    }
+  }
+
+  // --- Test 1: system message is appended with correct fields ---
+  cleanup();
+  fileChat.initProject(PROJECT);
+  const msg = fileChat.appendMessage(PROJECT, { sender: "system", type: "system", text: "head joined" });
+  assert(msg.sender === "system", "sender is 'system'");
+  assert(msg.type === "system", "type is 'system'");
+  assert(msg.text === "head joined", "text matches lifecycle event");
+
+  // --- Test 2: system messages do not increment loop guard counter ---
+  fileChat.resetLoopGuard(PROJECT);
+  fileChat.appendMessage(PROJECT, { sender: "system", type: "system", text: "dev joined" });
+  fileChat.appendMessage(PROJECT, { sender: "system", type: "system", text: "re1 joined" });
+  fileChat.appendMessage(PROJECT, { sender: "system", type: "system", text: "Discord bridge connected" });
+  fileChat.checkLoopGuard(PROJECT, { sender: "system", type: "system" }, 3);
+  assert(!fileChat.isLoopGuardPaused(PROJECT), "system messages do not trigger loop guard");
+
+  // --- Test 3: system messages appear in readMessages output ---
+  const messages = fileChat.readMessages(PROJECT, { limit: 10 });
+  const systemMsgs = messages.filter((m) => m.type === "system");
+  assert(systemMsgs.length === 4, `readMessages returns system messages (got ${systemMsgs.length})`);
+
+  // --- Test 4: system messages have no @mentions parsed ---
+  const bridgeMsg = fileChat.appendMessage(PROJECT, { sender: "system", type: "system", text: "Telegram bridge disconnected" });
+  assert(
+    !bridgeMsg.mentions || bridgeMsg.mentions.length === 0,
+    "bridge system message has no mentions"
+  );
+
+  // --- Test 5: mixed agent + system messages — only agent messages count for loop guard ---
+  fileChat.resetLoopGuard(PROJECT);
+  for (let i = 0; i < 2; i++) {
+    const agentMsg = fileChat.appendMessage(PROJECT, { sender: "head", type: "message", text: `msg ${i}` });
+    fileChat.checkLoopGuard(PROJECT, agentMsg, 5);
+  }
+  fileChat.appendMessage(PROJECT, { sender: "system", type: "system", text: "re2 restarted" });
+  fileChat.checkLoopGuard(PROJECT, { sender: "system", type: "system" }, 5);
+  assert(!fileChat.isLoopGuardPaused(PROJECT), "system messages interleaved with agent messages don't affect hop count");
+
+  cleanup();
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,13 @@ const net = require("net");
 const config = readConfig();
 const PORT = config.port || 8400;
 
+function emitSystemMessage(projectId, text) {
+  if (routes.getProjectChatMode(projectId) !== "file") return;
+  try {
+    fileChat.appendMessage(projectId, { sender: "system", type: "system", text });
+  } catch {}
+}
+
 const app = express();
 // #412 / quadwork#279: bump the global JSON body limit to 10mb so
 // POST /api/project-history can accept full chat exports. The
@@ -621,7 +628,7 @@ async function recoverFrom409(projectId, agentId, session) {
 }
 
 // Helper: spawn a PTY for a project/agent and register in agentSessions
-async function spawnAgentPty(project, agent) {
+async function spawnAgentPty(project, agent, opts = {}) {
   const key = `${project}/${agent}`;
 
   const cwd = resolveAgentCwd(project, agent);
@@ -667,6 +674,10 @@ async function spawnAgentPty(project, agent) {
       scrollback: Buffer.alloc(0),
     };
     agentSessions.set(key, session);
+
+    if (!opts.suppressLifecycleMsg) {
+      emitSystemMessage(project, `${agent} joined`);
+    }
 
     // #418: capture PTY output into the scrollback ring buffer (64KB).
     // This runs independently of WS — even when no client is connected,
@@ -738,8 +749,11 @@ async function spawnAgentPty(project, agent) {
         const current = agentSessions.get(key);
         if (!current || !current.term || current.state !== "running") return;
         console.log(`[#565] Agent ${agent}: AC is now reachable — restarting agent to gain chat integration.`);
+        const cur = agentSessions.get(key);
+        if (cur) cur._suppressLifecycleMsg = true;
         await stopAgentSession(key);
-        await spawnAgentPty(project, agent);
+        await spawnAgentPty(project, agent, { suppressLifecycleMsg: true });
+        emitSystemMessage(project, `${agent} restarted`);
       };
       deferredRestart().catch(() => {});
     }
@@ -794,6 +808,9 @@ async function stopAgentSession(key) {
   if (!session) {
     agentSessions.set(key, { projectId: null, agentId: null, term: null, viewers: new Set(), viewerDims: new Map(), lastDims: null, state: "stopped", error: null });
     return;
+  }
+  if (session.projectId && session.agentId && !session._suppressLifecycleMsg) {
+    emitSystemMessage(session.projectId, `${session.agentId} left`);
   }
   if (session.term) {
     try { session.term.kill(); } catch {}
@@ -1353,6 +1370,8 @@ app.post("/api/agents/:project/reset", async (req, res) => {
 
     // Stop all agents first (handles deregistration best-effort)
     for (const agentId of allAgentIds) {
+      const s = agentSessions.get(`${projectId}/${agentId}`);
+      if (s) s._suppressLifecycleMsg = true;
       await stopAgentSession(`${projectId}/${agentId}`);
     }
 
@@ -1360,8 +1379,9 @@ app.post("/api/agents/:project/reset", async (req, res) => {
     let restarted = 0;
     const errors = [];
     for (const agentId of allAgentIds) {
-      const result = await spawnAgentPty(projectId, agentId);
+      const result = await spawnAgentPty(projectId, agentId, { suppressLifecycleMsg: true });
       if (result.ok) {
+        emitSystemMessage(projectId, `${agentId} restarted`);
         restarted++;
       } else {
         errors.push(`${agentId}: ${result.error}`);
@@ -1497,10 +1517,13 @@ app.post("/api/agents/:project/:agent/restart", async (req, res) => {
 
   // #241: must await deregister before respawn so the slot frees and
   // the fresh register lands at slot 1 instead of head-2.
+  const existing = agentSessions.get(key);
+  if (existing) existing._suppressLifecycleMsg = true;
   await stopAgentSession(key);
 
-  const result = await spawnAgentPty(project, agent);
+  const result = await spawnAgentPty(project, agent, { suppressLifecycleMsg: true });
   if (result.ok) {
+    emitSystemMessage(project, `${agent} restarted`);
     res.json({ ok: true, state: "running", pid: result.pid });
   } else {
     res.status(500).json({ ok: false, state: "error", error: result.error });

--- a/server/index.js
+++ b/server/index.js
@@ -23,8 +23,8 @@ const config = readConfig();
 const PORT = config.port || 8400;
 
 function emitSystemMessage(projectId, text) {
-  if (routes.getProjectChatMode(projectId) !== "file") return;
   try {
+    if (routes.getProjectChatMode(projectId) !== "file") return;
     fileChat.appendMessage(projectId, { sender: "system", type: "system", text });
   } catch {}
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -278,6 +278,13 @@ function getProjectChatMode(projectId) {
   return project?.chat_mode === "file" ? "file" : "ac";
 }
 
+function emitSystemMessage(projectId, text) {
+  if (getProjectChatMode(projectId) !== "file") return;
+  try {
+    fileChat.appendMessage(projectId, { sender: "system", type: "system", text });
+  } catch {}
+}
+
 function chatAuthHeaders(token) {
   if (!token) return {};
   return { "x-session-token": token };
@@ -3539,6 +3546,7 @@ router.post("/api/telegram", async (req, res) => {
             `Last log lines (${logPath}):\n${tail || "(log empty)"}`,
         });
       }
+      emitSystemMessage(projectId, "Telegram bridge connected");
       return res.json({ ok: true, running: true, pid: child.pid });
     }
     case "stop": {
@@ -3569,6 +3577,7 @@ router.post("/api/telegram", async (req, res) => {
         // #522: clear bridge log so last_error doesn't show stale
         // connection-refused messages after an intentional stop.
         try { fs.writeFileSync(telegramBridgeLog(projectId), ""); } catch {}
+        emitSystemMessage(projectId, "Telegram bridge disconnected");
         return res.json({ ok: true, running: false });
       } catch (err) {
         return res.json({ ok: false, error: err.message || "Stop failed" });
@@ -3953,6 +3962,7 @@ router.post("/api/discord", async (req, res) => {
             `Last log lines (${logPath}):\n${tail || "(log empty)"}`,
         });
       }
+      emitSystemMessage(projectId, "Discord bridge connected");
       return res.json({ ok: true, running: true, pid: child.pid });
     }
     case "stop": {
@@ -3980,6 +3990,7 @@ router.post("/api/discord", async (req, res) => {
         // #522: clear bridge log so last_error doesn't show stale
         // connection-refused messages after an intentional stop.
         try { fs.writeFileSync(discordBridgeLog(projectId), ""); } catch {}
+        emitSystemMessage(projectId, "Discord bridge disconnected");
         return res.json({ ok: true, running: false });
       } catch (err) {
         return res.json({ ok: false, error: err.message || "Stop failed" });

--- a/server/routes.js
+++ b/server/routes.js
@@ -279,8 +279,8 @@ function getProjectChatMode(projectId) {
 }
 
 function emitSystemMessage(projectId, text) {
-  if (getProjectChatMode(projectId) !== "file") return;
   try {
+    if (getProjectChatMode(projectId) !== "file") return;
     fileChat.appendMessage(projectId, { sender: "system", type: "system", text });
   } catch {}
 }


### PR DESCRIPTION
## Summary
- Emit file-chat system messages (`sender: "system"`, `type: "system"`) at agent lifecycle points: joined, left, restarted, and bridge connected/disconnected
- Only emits for projects using file-based chat mode (`chat_mode: "file"`)
- Restart flows (single agent, reset-all, deferred #565 restart) emit a single "restarted" message instead of "left" + "joined"
- Bridge start/stop handlers (Telegram + Discord) in routes.js emit connected/disconnected messages
- Loop guard system message already handled by #717 — no changes needed
- Migration system message deferred to #713-6

## Acceptance criteria
- [x] System messages appear in chat for all lifecycle events
- [x] Dashboard renders system messages with muted styling (existing `#737373` color + filter toggle)
- [x] System messages don't trigger loop guard counter (`type === "system"` bypass from #717)
- [x] System messages don't trigger agent notifications (emitted via direct `appendMessage`, not through POST /api/chat route)
- [x] `npm run build` passes
- [x] 7 new tests covering system message fields, loop guard bypass, and readMessages inclusion

## Test plan
- [x] Run `node server/file-chat.system-messages.test.js` — 7/7 pass
- [x] Run `node server/file-chat.loopguard.test.js` — 8/8 pass (no regression)
- [x] `npm run build` — compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)