### PR TITLE
[#730] PTY injection dispatcher for file-chat agents

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,7 @@ const {
 const { waitForAgentChattrReady, registerAgent, registerAgentWithRetry, deregisterAgent, startHeartbeat, stopHeartbeat } = require("./agentchattr-registry");
 const { patchAgentchattrCss, patchCrashTimeout } = require("./install-agentchattr");
 const { startQueueWatcher, stopQueueWatcher } = require("./queue-watcher");
+const { dispatchToAgentPTY, cleanupSession: cleanupPtyDispatcher } = require("./pty-dispatcher");
 
 const net = require("net");
 const config = readConfig();
@@ -40,6 +41,14 @@ app.use(express.json({ limit: "10mb" }));
 
 // --- Mount migrated API routes (from Next.js) ---
 app.use(routes);
+
+// #730: wire PTY injection dispatcher into the chat route
+routes.setPtyDispatchCallback((projectId, msg) => {
+  dispatchToAgentPTY(projectId, msg, agentSessions, {
+    isLoopGuardPaused: fileChat.isLoopGuardPaused,
+    safeWrite,
+  });
+});
 
 const server = http.createServer(app);
 
@@ -761,6 +770,7 @@ async function spawnAgentPty(project, agent, opts = {}) {
     term.onExit(({ exitCode }) => {
       const current = agentSessions.get(key);
       if (current && current.term === term) {
+        cleanupPtyDispatcher(key);
         current.state = "stopped";
         current.error = exitCode ? `exit:${exitCode}` : null;
         current.term = null;
@@ -812,6 +822,7 @@ async function stopAgentSession(key) {
   if (session.projectId && session.agentId && !session._suppressLifecycleMsg) {
     emitSystemMessage(session.projectId, `${session.agentId} left`);
   }
+  cleanupPtyDispatcher(key);
   if (session.term) {
     try { session.term.kill(); } catch {}
     session.term = null;

--- a/server/pty-dispatcher.js
+++ b/server/pty-dispatcher.js
@@ -10,10 +10,10 @@ const COALESCE_WINDOW_MS = 1000;
 // Per-agent coalescing timers: key = "project/agent" → timeout handle
 const _coalesceTimers = new Map();
 
-// Per-agent pending since_id for drain: key = "project/agent" → oldest undelivered msg id
+// Per-agent pending state for drain: key = "project/agent" → { sinceId, latestMsg }
 const _pendingSinceId = new Map();
 
-// Per-agent drain listeners: key = "project/agent" → { disposable, timeout }
+// Per-agent drain listeners: key = "project/agent" → { disposable, timeoutHandle }
 const _drainListeners = new Map();
 
 /**
@@ -37,7 +37,7 @@ function dispatchToAgentPTY(projectId, msg, agentSessions, deps) {
     if (msg.sender === agentId) continue;
 
     if (isAgentBusy(session)) {
-      queuePendingWake(key, msg.id, session, deps);
+      queuePendingWake(key, msg.id, msg, session, deps);
       continue;
     }
 
@@ -51,34 +51,47 @@ function isAgentBusy(session) {
 
 /**
  * Queue a pending wake using high-water mark (since_id).
- * Hooks term.onData to drain after idle period.
+ * Hooks term.onData to drain after idle period, with a fallback
+ * timer so the wake fires even if no further PTY output arrives.
  */
-function queuePendingWake(key, msgId, session, deps) {
+function queuePendingWake(key, msgId, msg, session, deps) {
   const existing = _pendingSinceId.get(key);
-  if (!existing || msgId < existing) {
-    _pendingSinceId.set(key, msgId);
+  if (!existing || msgId < existing.sinceId) {
+    _pendingSinceId.set(key, { sinceId: msgId, latestMsg: msg });
+  } else {
+    existing.latestMsg = msg;
   }
+
+  const drainFn = () => {
+    const pending = _pendingSinceId.get(key);
+    if (pending == null) {
+      cleanupDrainListener(key);
+      return;
+    }
+    _pendingSinceId.delete(key);
+    cleanupDrainListener(key);
+
+    const formatted = buildDrainPrompt(session.agentId, pending.sinceId, pending.latestMsg);
+    injectIntoTerm(session.term, formatted, deps);
+  };
 
   if (_drainListeners.has(key)) return;
 
-  let idleTimeout = null;
-  const disposable = session.term.onData(() => {
-    if (idleTimeout) clearTimeout(idleTimeout);
-    idleTimeout = setTimeout(() => {
-      const sinceId = _pendingSinceId.get(key);
-      if (sinceId == null) {
-        cleanupDrainListener(key);
-        return;
-      }
-      _pendingSinceId.delete(key);
-      cleanupDrainListener(key);
+  const state = { timeoutHandle: null };
 
-      const formatted = buildDrainPrompt(session.agentId, sinceId);
-      injectIntoTerm(session.term, formatted, deps);
-    }, IDLE_THRESHOLD_MS);
+  function resetIdleTimer() {
+    if (state.timeoutHandle) clearTimeout(state.timeoutHandle);
+    state.timeoutHandle = setTimeout(drainFn, IDLE_THRESHOLD_MS);
+  }
+
+  // Start fallback timer immediately so drain fires even without further output
+  resetIdleTimer();
+
+  const disposable = session.term.onData(() => {
+    resetIdleTimer();
   });
 
-  _drainListeners.set(key, { disposable, timeout: idleTimeout });
+  _drainListeners.set(key, { disposable, state });
 }
 
 function cleanupDrainListener(key) {
@@ -87,16 +100,19 @@ function cleanupDrainListener(key) {
   if (listener.disposable && typeof listener.disposable.dispose === "function") {
     listener.disposable.dispose();
   }
-  if (listener.timeout) clearTimeout(listener.timeout);
+  if (listener.state && listener.state.timeoutHandle) {
+    clearTimeout(listener.state.timeoutHandle);
+  }
   _drainListeners.delete(key);
 }
 
-function buildDrainPrompt(agentId, sinceId) {
+function buildDrainPrompt(agentId, sinceId, latestMsg) {
+  const content = latestMsg
+    ? `[chat @${latestMsg.sender}]: ${latestMsg.text}`
+    : `You were mentioned while busy.`;
   return (
-    `You are @${agentId} in this AgentChattr instance. ` +
-    `mcp read #general with sender: "${agentId}" — ` +
-    `look for @${agentId} mentions (NOT @claude). ` +
-    `You were mentioned while busy, take appropriate action.`
+    `${content} ` +
+    `(Messages since ID ${sinceId - 1}. Call chat_read with sender "${agentId}" to see all.)`
   );
 }
 

--- a/server/pty-dispatcher.js
+++ b/server/pty-dispatcher.js
@@ -1,0 +1,169 @@
+/**
+ * #730: PTY injection dispatcher — deliver chat messages to agents via
+ * terminal stdin when they are @mentioned. Primary delivery mechanism
+ * for file-chat mode; agents treat injected text as user prompts.
+ */
+
+const IDLE_THRESHOLD_MS = 5000;
+const COALESCE_WINDOW_MS = 1000;
+
+// Per-agent coalescing timers: key = "project/agent" → timeout handle
+const _coalesceTimers = new Map();
+
+// Per-agent pending since_id for drain: key = "project/agent" → oldest undelivered msg id
+const _pendingSinceId = new Map();
+
+// Per-agent drain listeners: key = "project/agent" → { disposable, timeout }
+const _drainListeners = new Map();
+
+/**
+ * Dispatch a chat message to mentioned agents' PTYs.
+ *
+ * @param {string} projectId
+ * @param {object} msg - The appended message record (has .mentions, .sender, .text, .id, .type)
+ * @param {Map} agentSessions - The global agentSessions map
+ * @param {object} deps - { isLoopGuardPaused, safeWrite }
+ */
+function dispatchToAgentPTY(projectId, msg, agentSessions, deps) {
+  if (!msg || msg.type === "system") return;
+  if (deps.isLoopGuardPaused(projectId)) return;
+  if (!msg.mentions || msg.mentions.length === 0) return;
+
+  for (const agentId of msg.mentions) {
+    const key = `${projectId}/${agentId}`;
+    const session = agentSessions.get(key);
+    if (!session || !session.term || session.state !== "running") continue;
+    // Don't inject a message back into the agent that sent it
+    if (msg.sender === agentId) continue;
+
+    if (isAgentBusy(session)) {
+      queuePendingWake(key, msg.id, session, deps);
+      continue;
+    }
+
+    scheduleCoalescedInjection(key, projectId, agentId, msg, agentSessions, deps);
+  }
+}
+
+function isAgentBusy(session) {
+  return session.lastOutputAt && (Date.now() - session.lastOutputAt < IDLE_THRESHOLD_MS);
+}
+
+/**
+ * Queue a pending wake using high-water mark (since_id).
+ * Hooks term.onData to drain after idle period.
+ */
+function queuePendingWake(key, msgId, session, deps) {
+  const existing = _pendingSinceId.get(key);
+  if (!existing || msgId < existing) {
+    _pendingSinceId.set(key, msgId);
+  }
+
+  if (_drainListeners.has(key)) return;
+
+  let idleTimeout = null;
+  const disposable = session.term.onData(() => {
+    if (idleTimeout) clearTimeout(idleTimeout);
+    idleTimeout = setTimeout(() => {
+      const sinceId = _pendingSinceId.get(key);
+      if (sinceId == null) {
+        cleanupDrainListener(key);
+        return;
+      }
+      _pendingSinceId.delete(key);
+      cleanupDrainListener(key);
+
+      const formatted = buildDrainPrompt(session.agentId, sinceId);
+      injectIntoTerm(session.term, formatted, deps);
+    }, IDLE_THRESHOLD_MS);
+  });
+
+  _drainListeners.set(key, { disposable, timeout: idleTimeout });
+}
+
+function cleanupDrainListener(key) {
+  const listener = _drainListeners.get(key);
+  if (!listener) return;
+  if (listener.disposable && typeof listener.disposable.dispose === "function") {
+    listener.disposable.dispose();
+  }
+  if (listener.timeout) clearTimeout(listener.timeout);
+  _drainListeners.delete(key);
+}
+
+function buildDrainPrompt(agentId, sinceId) {
+  return (
+    `You are @${agentId} in this AgentChattr instance. ` +
+    `mcp read #general with sender: "${agentId}" — ` +
+    `look for @${agentId} mentions (NOT @claude). ` +
+    `You were mentioned while busy, take appropriate action.`
+  );
+}
+
+/**
+ * Coalesce burst mentions within a 1s window per agent.
+ */
+function scheduleCoalescedInjection(key, projectId, agentId, msg, agentSessions, deps) {
+  const existing = _coalesceTimers.get(key);
+  if (existing) {
+    existing.messages.push(msg);
+    return;
+  }
+
+  const state = { messages: [msg] };
+  const timer = setTimeout(() => {
+    _coalesceTimers.delete(key);
+    const session = agentSessions.get(key);
+    if (!session || !session.term || session.state !== "running") return;
+
+    const msgs = state.messages;
+    let formatted;
+    if (msgs.length === 1) {
+      const m = msgs[0];
+      formatted = `[chat @${m.sender}]: ${m.text}`;
+    } else {
+      const latest = msgs[msgs.length - 1];
+      formatted =
+        `[chat] ${msgs.length} new messages mentioning @${agentId}. ` +
+        `Latest from @${latest.sender}: ${latest.text}`;
+    }
+
+    injectIntoTerm(session.term, formatted, deps);
+  }, COALESCE_WINDOW_MS);
+
+  state.timer = timer;
+  _coalesceTimers.set(key, state);
+}
+
+function injectIntoTerm(term, text, deps) {
+  const flat = text.replace(/\n/g, " ");
+  deps.safeWrite(term, flat);
+  const submitDelayMs = Math.max(300, flat.length);
+  setTimeout(() => {
+    try { deps.safeWrite(term, "\r"); } catch {}
+  }, submitDelayMs);
+}
+
+/**
+ * Cleanup all timers for a session (call on stop/exit).
+ */
+function cleanupSession(key) {
+  const coalesce = _coalesceTimers.get(key);
+  if (coalesce) {
+    clearTimeout(coalesce.timer);
+    _coalesceTimers.delete(key);
+  }
+  _pendingSinceId.delete(key);
+  cleanupDrainListener(key);
+}
+
+module.exports = {
+  dispatchToAgentPTY,
+  cleanupSession,
+  // Exported for testing
+  _coalesceTimers,
+  _pendingSinceId,
+  _drainListeners,
+  IDLE_THRESHOLD_MS,
+  COALESCE_WINDOW_MS,
+};

--- a/server/pty-dispatcher.test.js
+++ b/server/pty-dispatcher.test.js
@@ -111,14 +111,20 @@ async function runTests() {
     cleanupSession("proj/dev");
   }
 
-  // --- Test 5: busy agent queues pending wake ---
+  // --- Test 5: busy agent queues pending wake, fallback timer drains it ---
   {
-    const { sessions, written, onDataCallbacks } = makeSessions({ lastOutputAt: Date.now() });
+    const { sessions, written } = makeSessions({ lastOutputAt: Date.now() });
     const deps = makeDeps();
-    dispatchToAgentPTY("proj", makeMsg({ id: 42 }), sessions, deps);
+    dispatchToAgentPTY("proj", makeMsg({ id: 42, text: "check PR #99" }), sessions, deps);
     await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
     assert(written.length === 0, "busy agent does not get immediate injection");
     assert(_pendingSinceId.has("proj/dev"), "pending since_id is set for busy agent");
+    // Wait for fallback drain timer (IDLE_THRESHOLD_MS)
+    await new Promise((r) => setTimeout(r, IDLE_THRESHOLD_MS + 100));
+    assert(written.length >= 1, "fallback drain fires without further PTY output");
+    assert(written[0].includes("check PR #99"), "drain prompt includes latest message content");
+    assert(written[0].includes("since ID 41"), "drain prompt includes since_id for chat_read");
+    assert(!_pendingSinceId.has("proj/dev"), "pending state cleared after drain");
     cleanupSession("proj/dev");
   }
 
@@ -158,7 +164,7 @@ async function runTests() {
   // --- Test 9: cleanupSession clears all state ---
   {
     _coalesceTimers.set("proj/dev", { timer: setTimeout(() => {}, 10000), messages: [] });
-    _pendingSinceId.set("proj/dev", 5);
+    _pendingSinceId.set("proj/dev", { sinceId: 5, latestMsg: null });
     cleanupSession("proj/dev");
     assert(!_coalesceTimers.has("proj/dev"), "cleanupSession clears coalesce timer");
     assert(!_pendingSinceId.has("proj/dev"), "cleanupSession clears pending since_id");

--- a/server/pty-dispatcher.test.js
+++ b/server/pty-dispatcher.test.js
@@ -1,0 +1,175 @@
+"use strict";
+
+const {
+  dispatchToAgentPTY,
+  cleanupSession,
+  _coalesceTimers,
+  _pendingSinceId,
+  _drainListeners,
+  IDLE_THRESHOLD_MS,
+  COALESCE_WINDOW_MS,
+} = require("./pty-dispatcher");
+
+async function runTests() {
+  let passed = 0;
+  let failed = 0;
+
+  function assert(condition, msg) {
+    if (condition) {
+      passed++;
+      console.log(`  PASS: ${msg}`);
+    } else {
+      failed++;
+      console.error(`  FAIL: ${msg}`);
+    }
+  }
+
+  function makeSessions(overrides = {}) {
+    const written = [];
+    const onDataCallbacks = [];
+    const term = {
+      write: (data) => written.push(data),
+      onData: (cb) => {
+        onDataCallbacks.push(cb);
+        return { dispose: () => {} };
+      },
+    };
+    const session = {
+      projectId: "proj",
+      agentId: "dev",
+      term,
+      state: "running",
+      lastOutputAt: 0,
+      ...overrides,
+    };
+    const sessions = new Map();
+    sessions.set("proj/dev", session);
+    return { sessions, session, term, written, onDataCallbacks };
+  }
+
+  function makeDeps(loopPaused = false) {
+    const writes = [];
+    return {
+      isLoopGuardPaused: () => loopPaused,
+      safeWrite: (term, data) => {
+        term.write(data);
+        writes.push(data);
+        return true;
+      },
+      _writes: writes,
+    };
+  }
+
+  function makeMsg(overrides = {}) {
+    return {
+      id: 1,
+      sender: "user",
+      text: "hello @dev",
+      type: "message",
+      mentions: ["dev"],
+      ...overrides,
+    };
+  }
+
+  // --- Test 1: system messages are not injected ---
+  {
+    const { sessions, written } = makeSessions();
+    const deps = makeDeps();
+    dispatchToAgentPTY("proj", makeMsg({ type: "system" }), sessions, deps);
+    assert(written.length === 0, "system messages not injected");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 2: loop guard paused — no injection ---
+  {
+    const { sessions, written } = makeSessions();
+    const deps = makeDeps(true);
+    dispatchToAgentPTY("proj", makeMsg(), sessions, deps);
+    assert(written.length === 0, "no injection when loop guard paused");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 3: message without mentions — no injection ---
+  {
+    const { sessions, written } = makeSessions();
+    const deps = makeDeps();
+    dispatchToAgentPTY("proj", makeMsg({ mentions: [] }), sessions, deps);
+    assert(written.length === 0, "no injection without mentions");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 4: idle agent receives injection ---
+  {
+    const { sessions, written } = makeSessions({ lastOutputAt: 0 });
+    const deps = makeDeps();
+    dispatchToAgentPTY("proj", makeMsg(), sessions, deps);
+    // Coalesce timer is pending — wait for it
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length >= 1, "idle agent receives injected message");
+    assert(written[0].includes("[chat @user]"), "injection has correct format");
+    assert(written[0].includes("hello @dev"), "injection contains message text");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 5: busy agent queues pending wake ---
+  {
+    const { sessions, written, onDataCallbacks } = makeSessions({ lastOutputAt: Date.now() });
+    const deps = makeDeps();
+    dispatchToAgentPTY("proj", makeMsg({ id: 42 }), sessions, deps);
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length === 0, "busy agent does not get immediate injection");
+    assert(_pendingSinceId.has("proj/dev"), "pending since_id is set for busy agent");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 6: burst coalescing — multiple mentions produce one injection ---
+  {
+    const { sessions, written } = makeSessions({ lastOutputAt: 0 });
+    const deps = makeDeps();
+    for (let i = 0; i < 5; i++) {
+      dispatchToAgentPTY("proj", makeMsg({ id: i + 1, sender: `agent${i}`, text: `msg ${i}` }), sessions, deps);
+    }
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length >= 1, "coalesced injection fires");
+    assert(written[0].includes("5 new messages"), `coalesced injection mentions count (got: ${written[0].substring(0, 80)})`);
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 7: agent does not inject message to itself ---
+  {
+    const { sessions, written } = makeSessions({ lastOutputAt: 0 });
+    const deps = makeDeps();
+    dispatchToAgentPTY("proj", makeMsg({ sender: "dev", mentions: ["dev"] }), sessions, deps);
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length === 0, "agent does not inject its own message");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 8: stopped agent session — no injection ---
+  {
+    const { sessions, written } = makeSessions({ state: "stopped", lastOutputAt: 0 });
+    const deps = makeDeps();
+    dispatchToAgentPTY("proj", makeMsg(), sessions, deps);
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length === 0, "stopped agent does not receive injection");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 9: cleanupSession clears all state ---
+  {
+    _coalesceTimers.set("proj/dev", { timer: setTimeout(() => {}, 10000), messages: [] });
+    _pendingSinceId.set("proj/dev", 5);
+    cleanupSession("proj/dev");
+    assert(!_coalesceTimers.has("proj/dev"), "cleanupSession clears coalesce timer");
+    assert(!_pendingSinceId.has("proj/dev"), "cleanupSession clears pending since_id");
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+// Wrap in async IIFE for await support
+(async () => { await runTests(); })().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/routes.js
+++ b/server/routes.js
@@ -18,6 +18,10 @@ const router = express.Router();
 // Map<projectId, Map<agentId, callbackUrl>>
 const _notifyCallbacks = new Map();
 
+// #730: PTY dispatch callback — set by index.js at startup
+let _ptyDispatchCallback = null;
+function setPtyDispatchCallback(fn) { _ptyDispatchCallback = fn; }
+
 function notifyMentionedAgents(projectId, msg) {
   const callbacks = _notifyCallbacks.get(projectId);
   if (!callbacks || !msg.mentions || msg.mentions.length === 0) return;
@@ -1177,6 +1181,7 @@ router.post("/api/chat", async (req, res) => {
     fileChat.checkLoopGuard(projectId, msg, maxHops);
     if (!fileChat.isLoopGuardPaused(projectId)) {
       notifyMentionedAgents(projectId, msg);
+      if (_ptyDispatchCallback) _ptyDispatchCallback(projectId, msg);
     }
     return res.json({ ok: true, message: msg });
   }
@@ -4135,3 +4140,5 @@ module.exports.sendViaWebSocket = sendViaWebSocket;
 module.exports.normalizeMentions = normalizeMentions;
 // #714: expose for file-chat integration
 module.exports.getProjectChatMode = getProjectChatMode;
+// #730: PTY dispatch callback setter
+module.exports.setPtyDispatchCallback = setPtyDispatchCallback;


### PR DESCRIPTION
## Summary
- Adds `server/pty-dispatcher.js` — delivers chat messages to agents via terminal stdin when @mentioned in file-chat mode
- Idle gating: queues injection when agent is mid-output (last output <5s ago), drains via `term.onData` + high-water mark `since_id`
- Burst coalescing: multiple mentions within 1s window produce a single combined injection
- Loop guard suppression: no injection when loop guard is paused
- Self-mention filtering: agents don't receive their own messages
- Wired into `POST /api/chat` via callback pattern (routes.js → index.js) so scheduled triggers also go through this path
- Cleanup on session stop/exit to prevent timer leaks

## Test plan
- [x] 14 unit tests in `server/pty-dispatcher.test.js` covering:
  - System messages not injected
  - Loop guard paused blocks injection
  - No injection without mentions
  - Idle agent receives formatted injection
  - Busy agent queues pending wake
  - 5 rapid mentions coalesce into one injection
  - Agent doesn't inject its own message
  - Stopped session receives no injection
  - `cleanupSession` clears all timers/state
- [x] Existing tests pass (`file-chat.system-messages.test.js`)
- [ ] Manual: send `@head ping` from dashboard → Head terminal shows message → Head responds
- [ ] Manual: verify with both Claude Code and Codex CLIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)