### PR TITLE
[#731] Remove dead MCP notification code from shim

### DIFF
--- a/server/mcp-chat-shim.js
+++ b/server/mcp-chat-shim.js
@@ -115,49 +115,12 @@ async function handleToolCall(id, name, params) {
   }
 }
 
-// --- Notification callback server ---
-
-let notifyServer = null;
-let notifyPort = null;
-
-function startNotifyServer() {
-  return new Promise((resolve) => {
-    notifyServer = http.createServer((req, res) => {
-      if (req.method === "POST") {
-        let body = "";
-        req.on("data", (c) => (body += c));
-        req.on("end", () => {
-          try {
-            const payload = JSON.parse(body);
-            const notification = JSON.stringify({
-              jsonrpc: "2.0",
-              method: "notifications/message",
-              params: payload,
-            });
-            process.stdout.write(notification + "\n");
-          } catch {}
-          res.writeHead(200);
-          res.end("ok");
-        });
-      } else {
-        res.writeHead(405);
-        res.end();
-      }
-    });
-    notifyServer.listen(0, "127.0.0.1", () => {
-      notifyPort = notifyServer.address().port;
-      resolve(notifyPort);
-    });
-  });
-}
-
 // --- MCP stdio protocol ---
 
 async function handleMessage(msg) {
   const { id, method, params } = msg;
 
   if (method === "initialize") {
-    await startNotifyServer();
     return jsonRpc(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
@@ -166,13 +129,6 @@ async function handleMessage(msg) {
   }
 
   if (method === "initialized") {
-    // Register notification callback with QuadWork
-    if (notifyPort) {
-      httpRequest("POST", `/api/chat/notify-register?project=${encodeURIComponent(PROJECT)}`, {
-        agent: AGENT,
-        callback_url: `http://127.0.0.1:${notifyPort}`,
-      }).catch(() => {});
-    }
     return null;
   }
 
@@ -211,6 +167,5 @@ rl.on("line", async (line) => {
 });
 
 rl.on("close", () => {
-  if (notifyServer) notifyServer.close();
   process.exit(0);
 });

--- a/server/mcp-chat-shim.test.js
+++ b/server/mcp-chat-shim.test.js
@@ -71,10 +71,6 @@ function startTestServer() {
       res.json({ ok: true, message: msg });
     });
 
-    app.post("/api/chat/notify-register", (req, res) => {
-      res.json({ ok: true });
-    });
-
     server = app.listen(0, "127.0.0.1", () => {
       serverPort = server.address().port;
       resolve();

--- a/server/routes.js
+++ b/server/routes.js
@@ -14,27 +14,9 @@ const fileChat = require("./file-chat");
 
 const router = express.Router();
 
-// #715: per-project notification callback registry for MCP shims.
-// Map<projectId, Map<agentId, callbackUrl>>
-const _notifyCallbacks = new Map();
-
 // #730: PTY dispatch callback — set by index.js at startup
 let _ptyDispatchCallback = null;
 function setPtyDispatchCallback(fn) { _ptyDispatchCallback = fn; }
-
-function notifyMentionedAgents(projectId, msg) {
-  const callbacks = _notifyCallbacks.get(projectId);
-  if (!callbacks || !msg.mentions || msg.mentions.length === 0) return;
-  for (const mention of msg.mentions) {
-    const url = callbacks.get(mention);
-    if (!url) continue;
-    fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id: msg.id, sender: msg.sender, text: msg.text, channel: msg.channel }),
-    }).catch(() => {});
-  }
-}
 
 const CONFIG_DIR = path.join(os.homedir(), ".quadwork");
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
@@ -1180,7 +1162,6 @@ router.post("/api/chat", async (req, res) => {
     const maxHops = getProjectMaxHops(projectId);
     fileChat.checkLoopGuard(projectId, msg, maxHops);
     if (!fileChat.isLoopGuardPaused(projectId)) {
-      notifyMentionedAgents(projectId, msg);
       if (_ptyDispatchCallback) _ptyDispatchCallback(projectId, msg);
     }
     return res.json({ ok: true, message: msg });
@@ -1277,25 +1258,6 @@ router.post("/api/chat", async (req, res) => {
     console.warn(`[chat] send failed for project ${projectId}: ${err && err.message}`);
     return res.status(502).json({ error: "AgentChattr unreachable", detail: err && err.message });
   }
-});
-
-// #715: MCP shim notification callback registration
-const LOCALHOST_CB_RE = /^http:\/\/127\.0\.0\.1:\d+\/?$/;
-
-router.post("/api/chat/notify-register", (req, res) => {
-  const projectId = req.query.project;
-  const { agent, callback_url } = req.body || {};
-  if (!projectId || !agent || !callback_url) {
-    return res.status(400).json({ error: "project, agent, and callback_url required" });
-  }
-  if (!LOCALHOST_CB_RE.test(callback_url)) {
-    return res.status(400).json({ error: "callback_url must be http://127.0.0.1:<port>" });
-  }
-  if (!_notifyCallbacks.has(projectId)) {
-    _notifyCallbacks.set(projectId, new Map());
-  }
-  _notifyCallbacks.get(projectId).set(agent, callback_url);
-  res.json({ ok: true });
 });
 
 // ─── Image upload (#466) ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removed `startNotifyServer()`, HTTP callback server, and notification registration from `server/mcp-chat-shim.js`
- Removed `notifyMentionedAgents()`, `_notifyCallbacks` map, `LOCALHOST_CB_RE`, and `POST /api/chat/notify-register` endpoint from `server/routes.js`
- Removed notify-register stub from `server/mcp-chat-shim.test.js`
- Net: -87 lines, one fewer localhost port per agent (4 fewer per project)

## Test plan
- [x] MCP shim tests pass (14/14) — chat_send, chat_read, since_id, ping all work
- [x] PTY dispatcher tests pass (18/18)
- [x] Shim still handles initialize/initialized without errors
- [ ] Manual: verify agents can still send and read chat via shim tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)