### PR TITLE
[#732] Skip watchdog Ctrl+C for file-chat projects

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2780,6 +2780,8 @@ function watchdogCheck() {
   for (const [key, session] of agentSessions) {
     if (session.state !== "running" || !session.term) continue;
     if (!session.lastOutputAt) continue;
+    // #732: skip file-chat projects — idle is normal, PTY dispatch wakes them
+    if (routes.getProjectChatMode(session.projectId) === "file") continue;
     if (Date.now() - session.lastOutputAt > WATCHDOG_TIMEOUT_MS) {
       console.log(`[watchdog] ${key}: no output for 10m — sending Ctrl+C`);
       safeWrite(session.term, "\x03");


### PR DESCRIPTION
## Summary
- Gate watchdog `Ctrl+C` by `chat_mode`: file-chat projects are skipped since idle is the normal state (PTY dispatch from #730 wakes them)
- AC-mode projects keep existing 10m timeout behavior unchanged
- `lastOutputAt` tracking preserved unconditionally

## Test plan
- [ ] Manual: file-chat project agent idles >10m without receiving Ctrl+C
- [ ] Manual: AC-mode project agent still receives Ctrl+C after 10m idle
- [ ] Manual: Interrupt button (#706) still works for all project types

🤖 Generated with [Claude Code](https://claude.com/claude-code)