### PR TITLE
[#736] Suppress PTY injection for recently active agents

### DIFF
--- a/server/pty-dispatcher.js
+++ b/server/pty-dispatcher.js
@@ -85,6 +85,9 @@ function queuePendingWake(key, msgId, msg, session, deps) {
     _pendingSinceId.delete(key);
     cleanupDrainListener(key);
 
+    const lastSent = _lastChatSentAt.get(key);
+    if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) return;
+
     const formatted = buildDrainPrompt(session.agentId, pending.sinceId, pending.latestMsg);
     injectIntoTerm(session.term, formatted, deps);
   };
@@ -145,6 +148,9 @@ function scheduleCoalescedInjection(key, projectId, agentId, msg, agentSessions,
     _coalesceTimers.delete(key);
     const session = agentSessions.get(key);
     if (!session || !session.term || session.state !== "running") return;
+
+    const lastSent = _lastChatSentAt.get(key);
+    if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) return;
 
     const msgs = state.messages;
     let formatted;

--- a/server/pty-dispatcher.js
+++ b/server/pty-dispatcher.js
@@ -6,9 +6,13 @@
 
 const IDLE_THRESHOLD_MS = 5000;
 const COALESCE_WINDOW_MS = 1000;
+const ACTIVE_SUPPRESSION_MS = 30000;
 
 // Per-agent coalescing timers: key = "project/agent" → timeout handle
 const _coalesceTimers = new Map();
+
+// Per-agent last chat send timestamp: key = "project/agent" → epoch ms
+const _lastChatSentAt = new Map();
 
 // Per-agent pending state for drain: key = "project/agent" → { sinceId, latestMsg }
 const _pendingSinceId = new Map();
@@ -29,12 +33,22 @@ function dispatchToAgentPTY(projectId, msg, agentSessions, deps) {
   if (deps.isLoopGuardPaused(projectId)) return;
   if (!msg.mentions || msg.mentions.length === 0) return;
 
+  // Track when this sender last posted (for active-agent suppression)
+  const senderKey = `${projectId}/${msg.sender}`;
+  if (agentSessions.has(senderKey)) {
+    _lastChatSentAt.set(senderKey, Date.now());
+  }
+
   for (const agentId of msg.mentions) {
     const key = `${projectId}/${agentId}`;
     const session = agentSessions.get(key);
     if (!session || !session.term || session.state !== "running") continue;
-    // Don't inject a message back into the agent that sent it
     if (msg.sender === agentId) continue;
+
+    // #736: skip injection if agent recently sent a message — they're
+    // already active and will read chat via chat_read
+    const lastSent = _lastChatSentAt.get(key);
+    if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) continue;
 
     if (isAgentBusy(session)) {
       queuePendingWake(key, msg.id, msg, session, deps);
@@ -170,6 +184,7 @@ function cleanupSession(key) {
     _coalesceTimers.delete(key);
   }
   _pendingSinceId.delete(key);
+  _lastChatSentAt.delete(key);
   cleanupDrainListener(key);
 }
 
@@ -180,6 +195,8 @@ module.exports = {
   _coalesceTimers,
   _pendingSinceId,
   _drainListeners,
+  _lastChatSentAt,
   IDLE_THRESHOLD_MS,
   COALESCE_WINDOW_MS,
+  ACTIVE_SUPPRESSION_MS,
 };

--- a/server/pty-dispatcher.test.js
+++ b/server/pty-dispatcher.test.js
@@ -6,8 +6,10 @@ const {
   _coalesceTimers,
   _pendingSinceId,
   _drainListeners,
+  _lastChatSentAt,
   IDLE_THRESHOLD_MS,
   COALESCE_WINDOW_MS,
+  ACTIVE_SUPPRESSION_MS,
 } = require("./pty-dispatcher");
 
 async function runTests() {
@@ -159,6 +161,43 @@ async function runTests() {
     await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
     assert(written.length === 0, "stopped agent does not receive injection");
     cleanupSession("proj/dev");
+  }
+
+  // --- Test 10: active agent suppression — recently sent message skips injection ---
+  {
+    const { sessions, written } = makeSessions({ lastOutputAt: 0 });
+    const deps = makeDeps();
+    // Simulate dev having sent a message recently
+    _lastChatSentAt.set("proj/dev", Date.now());
+    dispatchToAgentPTY("proj", makeMsg({ sender: "head", mentions: ["dev"] }), sessions, deps);
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length === 0, "recently active agent is not injected");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 11: active suppression expires — agent receives injection after cooldown ---
+  {
+    const { sessions, written } = makeSessions({ lastOutputAt: 0 });
+    const deps = makeDeps();
+    // Set lastChatSentAt to well past the suppression window
+    _lastChatSentAt.set("proj/dev", Date.now() - ACTIVE_SUPPRESSION_MS - 1000);
+    dispatchToAgentPTY("proj", makeMsg({ sender: "head", mentions: ["dev"] }), sessions, deps);
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length >= 1, "agent receives injection after suppression window expires");
+    cleanupSession("proj/dev");
+  }
+
+  // --- Test 12: sender's lastChatSentAt is tracked ---
+  {
+    const { sessions } = makeSessions({ lastOutputAt: 0 });
+    // Add a "head" session so the sender is recognized as an agent
+    sessions.set("proj/head", { projectId: "proj", agentId: "head", term: null, state: "stopped" });
+    const deps = makeDeps();
+    _lastChatSentAt.delete("proj/head");
+    dispatchToAgentPTY("proj", makeMsg({ sender: "head", mentions: ["dev"] }), sessions, deps);
+    assert(_lastChatSentAt.has("proj/head"), "sender's lastChatSentAt is tracked");
+    cleanupSession("proj/dev");
+    cleanupSession("proj/head");
   }
 
   // --- Test 9: cleanupSession clears all state ---


### PR DESCRIPTION
## Summary
- Track per-agent `lastChatSentAt` timestamp when an agent sends a chat message
- Skip PTY injection if the target agent sent a message within the last 30 seconds — they're already active and reading chat via `chat_read`
- Prevents agent-to-agent reply loops (e.g., ping cascades) while still waking idle agents
- Cleanup on session stop/exit

## Test plan
- [x] 21 unit tests passing, including 3 new tests:
  - Recently active agent is not injected
  - Injection resumes after 30s suppression window expires
  - Sender's lastChatSentAt is tracked for agent sessions
- [ ] Manual: `@head ping dev, re1, re2` — agents respond once without looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)