### PR TITLE
[#737] Display chat timestamps in local time

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -287,7 +287,7 @@ router.get("/api/chat", async (req, res) => {
     });
     const normalized = messages.map((m) => ({
       ...m,
-      time: m.time || (m.ts ? m.ts.slice(11, 19) : ""),
+      time: m.time || (m.ts ? new Date(m.ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false }) : ""),
     }));
     return res.json(normalized);
   }


### PR DESCRIPTION
## Summary
- Convert UTC timestamps to local time in `GET /api/chat` response normalization
- Uses `toLocaleTimeString` with 24-hour format (HH:MM:SS) instead of slicing the UTC ISO string
- JSONL storage remains UTC — only display is converted
- QuadWork runs locally so server timezone matches user timezone

## Test plan
- [x] `npm run build` passes
- [ ] Manual: verify chat timestamps show local time instead of UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)