### PR TITLE
[#742] Identity-aware injection prompt for PTY dispatcher

### DIFF
--- a/server/pty-dispatcher.js
+++ b/server/pty-dispatcher.js
@@ -14,8 +14,8 @@ const _coalesceTimers = new Map();
 // Per-agent last chat send timestamp: key = "project/agent" → epoch ms
 const _lastChatSentAt = new Map();
 
-// Per-agent pending state for drain: key = "project/agent" → { sinceId, latestMsg }
-const _pendingSinceId = new Map();
+// Per-agent pending wake flag: key = "project/agent" → true
+const _pendingWake = new Map();
 
 // Per-agent drain listeners: key = "project/agent" → { disposable, timeoutHandle }
 const _drainListeners = new Map();
@@ -51,7 +51,7 @@ function dispatchToAgentPTY(projectId, msg, agentSessions, deps) {
     if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) continue;
 
     if (isAgentBusy(session)) {
-      queuePendingWake(key, msg.id, msg, session, deps);
+      queuePendingWake(key, session, deps);
       continue;
     }
 
@@ -68,28 +68,21 @@ function isAgentBusy(session) {
  * Hooks term.onData to drain after idle period, with a fallback
  * timer so the wake fires even if no further PTY output arrives.
  */
-function queuePendingWake(key, msgId, msg, session, deps) {
-  const existing = _pendingSinceId.get(key);
-  if (!existing || msgId < existing.sinceId) {
-    _pendingSinceId.set(key, { sinceId: msgId, latestMsg: msg });
-  } else {
-    existing.latestMsg = msg;
-  }
+function queuePendingWake(key, session, deps) {
+  _pendingWake.set(key, true);
 
   const drainFn = () => {
-    const pending = _pendingSinceId.get(key);
-    if (pending == null) {
+    if (!_pendingWake.get(key)) {
       cleanupDrainListener(key);
       return;
     }
-    _pendingSinceId.delete(key);
+    _pendingWake.delete(key);
     cleanupDrainListener(key);
 
     const lastSent = _lastChatSentAt.get(key);
     if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) return;
 
-    const formatted = buildDrainPrompt(session.agentId, pending.sinceId, pending.latestMsg);
-    injectIntoTerm(session.term, formatted, deps);
+    injectIntoTerm(session.term, buildInjectionPrompt(session.agentId), deps);
   };
 
   if (_drainListeners.has(key)) return;
@@ -123,13 +116,12 @@ function cleanupDrainListener(key) {
   _drainListeners.delete(key);
 }
 
-function buildDrainPrompt(agentId, sinceId, latestMsg) {
-  const content = latestMsg
-    ? `[chat @${latestMsg.sender}]: ${latestMsg.text}`
-    : `You were mentioned while busy.`;
+function buildInjectionPrompt(agentId) {
   return (
-    `${content} ` +
-    `(Messages since ID ${sinceId - 1}. Call chat_read with sender "${agentId}" to see all.)`
+    `You are @${agentId}. New messages may be addressed to you in the project chat. ` +
+    `Call the chat_read MCP tool to read recent messages. ` +
+    `Act only on messages that explicitly mention @${agentId}. ` +
+    `Ignore messages addressed to other agents.`
   );
 }
 
@@ -152,19 +144,7 @@ function scheduleCoalescedInjection(key, projectId, agentId, msg, agentSessions,
     const lastSent = _lastChatSentAt.get(key);
     if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) return;
 
-    const msgs = state.messages;
-    let formatted;
-    if (msgs.length === 1) {
-      const m = msgs[0];
-      formatted = `[chat @${m.sender}]: ${m.text}`;
-    } else {
-      const latest = msgs[msgs.length - 1];
-      formatted =
-        `[chat] ${msgs.length} new messages mentioning @${agentId}. ` +
-        `Latest from @${latest.sender}: ${latest.text}`;
-    }
-
-    injectIntoTerm(session.term, formatted, deps);
+    injectIntoTerm(session.term, buildInjectionPrompt(agentId), deps);
   }, COALESCE_WINDOW_MS);
 
   state.timer = timer;
@@ -189,7 +169,7 @@ function cleanupSession(key) {
     clearTimeout(coalesce.timer);
     _coalesceTimers.delete(key);
   }
-  _pendingSinceId.delete(key);
+  _pendingWake.delete(key);
   _lastChatSentAt.delete(key);
   cleanupDrainListener(key);
 }
@@ -199,7 +179,7 @@ module.exports = {
   cleanupSession,
   // Exported for testing
   _coalesceTimers,
-  _pendingSinceId,
+  _pendingWake,
   _drainListeners,
   _lastChatSentAt,
   IDLE_THRESHOLD_MS,

--- a/server/pty-dispatcher.test.js
+++ b/server/pty-dispatcher.test.js
@@ -4,7 +4,7 @@ const {
   dispatchToAgentPTY,
   cleanupSession,
   _coalesceTimers,
-  _pendingSinceId,
+  _pendingWake,
   _drainListeners,
   _lastChatSentAt,
   IDLE_THRESHOLD_MS,
@@ -108,8 +108,9 @@ async function runTests() {
     // Coalesce timer is pending — wait for it
     await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
     assert(written.length >= 1, "idle agent receives injected message");
-    assert(written[0].includes("[chat @user]"), "injection has correct format");
-    assert(written[0].includes("hello @dev"), "injection contains message text");
+    assert(written[0].includes("You are @dev"), "injection includes agent identity");
+    assert(written[0].includes("chat_read"), "injection instructs agent to call chat_read");
+    assert(!written[0].includes("hello @dev"), "injection does NOT include raw message content");
     cleanupSession("proj/dev");
   }
 
@@ -120,13 +121,13 @@ async function runTests() {
     dispatchToAgentPTY("proj", makeMsg({ id: 42, text: "check PR #99" }), sessions, deps);
     await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
     assert(written.length === 0, "busy agent does not get immediate injection");
-    assert(_pendingSinceId.has("proj/dev"), "pending since_id is set for busy agent");
+    assert(_pendingWake.has("proj/dev"), "pending wake is set for busy agent");
     // Wait for fallback drain timer (IDLE_THRESHOLD_MS)
     await new Promise((r) => setTimeout(r, IDLE_THRESHOLD_MS + 100));
     assert(written.length >= 1, "fallback drain fires without further PTY output");
-    assert(written[0].includes("check PR #99"), "drain prompt includes latest message content");
-    assert(written[0].includes("since ID 41"), "drain prompt includes since_id for chat_read");
-    assert(!_pendingSinceId.has("proj/dev"), "pending state cleared after drain");
+    assert(written[0].includes("You are @dev"), "drain prompt includes agent identity");
+    assert(written[0].includes("chat_read"), "drain prompt instructs chat_read");
+    assert(!_pendingWake.has("proj/dev"), "pending wake cleared after drain");
     cleanupSession("proj/dev");
   }
 
@@ -139,7 +140,7 @@ async function runTests() {
     }
     await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
     assert(written.length >= 1, "coalesced injection fires");
-    assert(written[0].includes("5 new messages"), `coalesced injection mentions count (got: ${written[0].substring(0, 80)})`);
+    assert(written[0].includes("You are @dev"), "coalesced injection uses identity prompt");
     cleanupSession("proj/dev");
   }
 
@@ -203,10 +204,10 @@ async function runTests() {
   // --- Test 9: cleanupSession clears all state ---
   {
     _coalesceTimers.set("proj/dev", { timer: setTimeout(() => {}, 10000), messages: [] });
-    _pendingSinceId.set("proj/dev", { sinceId: 5, latestMsg: null });
+    _pendingWake.set("proj/dev", true);
     cleanupSession("proj/dev");
     assert(!_coalesceTimers.has("proj/dev"), "cleanupSession clears coalesce timer");
-    assert(!_pendingSinceId.has("proj/dev"), "cleanupSession clears pending since_id");
+    assert(!_pendingWake.has("proj/dev"), "cleanupSession clears pending wake");
   }
 
   console.log(`\n${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary
- Replace content-based PTY injection with identity-aware read instruction matching AC's proven pattern
- Agents now receive `You are @{id}. Call chat_read MCP tool...` instead of raw message text
- Prevents role confusion (Dev acting like Head) by letting agents read chat via MCP and filter for their own mentions
- Simplified pending wake state from `{sinceId, latestMsg}` to a boolean flag
- Net: -19 lines

## Test plan
- [x] 22 unit tests passing, updated to verify:
  - Injection includes agent identity ("You are @dev")
  - Injection instructs `chat_read` call
  - Injection does NOT include raw message content
  - Drain prompt uses same identity-aware format
  - Coalesced injection uses identity prompt
- [ ] Manual: `@head ping dev, re1, re2` — each agent preserves its own role
- [ ] Manual: `@head do X` — only Head receives injection, others do not act

🤖 Generated with [Claude Code](https://claude.com/claude-code)