### PR TITLE
[#744] Bridge skip for file-chat projects

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1816,6 +1816,10 @@ async function autoStopBridges(projectId, project, qwPort) {
 }
 
 async function autoStartBridges(projectId, project, qwPort) {
+  if (project?.chat_mode === "file") {
+    console.log(`[auto-bridge] ${projectId}: skipped (file-chat mode)`);
+    return;
+  }
   if (project?.telegram_auto) {
     try {
       // Check if already running before starting

--- a/server/routes.js
+++ b/server/routes.js
@@ -3407,6 +3407,9 @@ router.post("/api/telegram", async (req, res) => {
     case "start": {
       const projectId = body.project_id;
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      if (getProjectChatMode(projectId) === "file") {
+        return res.json({ ok: false, error: "Bridges use the new Node.js module in file-chat mode. Use the built-in bridge instead." });
+      }
       if (isTelegramRunning(projectId)) return res.json({ ok: true, running: true, message: "Already running" });
       const bridgeScript = path.join(BRIDGE_DIR, "telegram_bridge.py");
       if (!fs.existsSync(bridgeScript)) return res.json({ ok: false, error: "Bridge not installed. Click Install Bridge first." });
@@ -3865,6 +3868,9 @@ router.post("/api/discord", async (req, res) => {
     case "start": {
       const projectId = body.project_id;
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      if (getProjectChatMode(projectId) === "file") {
+        return res.json({ ok: false, error: "Bridges use the new Node.js module in file-chat mode. Use the built-in bridge instead." });
+      }
       if (isDiscordRunning(projectId)) return res.json({ ok: true, running: true, message: "Already running" });
       const bridgeScript = path.join(DISCORD_BRIDGE_DIR, "discord_bridge.py");
       if (!fs.existsSync(bridgeScript)) return res.json({ ok: false, error: "Bridge not installed. Click Install Bridge first." });

--- a/src/components/DiscordBridgeWidget.tsx
+++ b/src/components/DiscordBridgeWidget.tsx
@@ -63,6 +63,7 @@ interface BatchState {
 
 interface DiscordBridgeWidgetProps {
   projectId: string;
+  chatMode?: "ac" | "file";
 }
 
 interface DiscordStatus {
@@ -93,7 +94,7 @@ async function callDiscord(action: string, body: Record<string, unknown>) {
  * start/stop + a setup modal to configure bot_token + channel_id from
  * scratch.
  */
-export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetProps) {
+export default function DiscordBridgeWidget({ projectId, chatMode = "ac" }: DiscordBridgeWidgetProps) {
   const { locale } = useLocale();
   const t = COPY[locale];
   const [status, setStatus] = useState<DiscordStatus | null>(null);
@@ -296,7 +297,7 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
             </InfoTooltip>
           </div>
           <div className="flex items-center gap-1.5">
-            {configured && (
+            {configured && chatMode !== "file" && (
               <button
                 type="button"
                 onClick={toggleAutoDiscord}
@@ -316,7 +317,11 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
           </div>
         </div>
         <div className="p-3 flex flex-col gap-2">
-          {!configured ? (
+          {chatMode === "file" ? (
+            <div className="text-[11px] text-text-muted">
+              Bridges use the new Node.js module in file-chat mode. Use the built-in bridge instead.
+            </div>
+          ) : !configured ? (
             <>
               <div className="flex items-center gap-2 text-[11px] text-text-muted">
                 <span className="w-1.5 h-1.5 rounded-full bg-text-muted" />

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -49,7 +49,7 @@ const COPY = {
  * layout collapses back to the single-column stack so nothing
  * clips in cramped split-view / mobile.
  */
-export default function OperatorFeaturesPanel({ projectId }: { projectId: string }) {
+export default function OperatorFeaturesPanel({ projectId, chatMode = "ac" }: { projectId: string; chatMode?: "ac" | "file" }) {
   const { locale } = useLocale();
   const t = COPY[locale];
   return (
@@ -77,8 +77,8 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
             History. Scrolls independently of the left column. */}
         <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto flex flex-col gap-2">
           <AgentModelsWidget projectId={projectId} />
-          <TelegramBridgeWidget projectId={projectId} />
-          <DiscordBridgeWidget projectId={projectId} />
+          <TelegramBridgeWidget projectId={projectId} chatMode={chatMode} />
+          <DiscordBridgeWidget projectId={projectId} chatMode={chatMode} />
           <LoopGuardWidget projectId={projectId} />
           <ProjectHistoryWidget projectId={projectId} />
         </div>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -290,7 +290,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
 
         {/* Q4: Operator Features */}
         <div className="border-t border-border lg:border-t-0 flex flex-col overflow-hidden">
-          <OperatorFeaturesPanel projectId={projectId} />
+          <OperatorFeaturesPanel projectId={projectId} chatMode={chatMode} />
         </div>
       </div>
     </div>

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -63,6 +63,7 @@ interface BatchState {
 
 interface TelegramBridgeWidgetProps {
   projectId: string;
+  chatMode?: "ac" | "file";
 }
 
 interface TelegramStatus {
@@ -97,7 +98,7 @@ async function callTelegram(action: string, body: Record<string, unknown>) {
  * start/stop + a setup modal to configure bot_token + chat_id from
  * scratch.
  */
-export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidgetProps) {
+export default function TelegramBridgeWidget({ projectId, chatMode = "ac" }: TelegramBridgeWidgetProps) {
   const { locale } = useLocale();
   const t = COPY[locale];
   const [status, setStatus] = useState<TelegramStatus | null>(null);
@@ -326,7 +327,7 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
             </InfoTooltip>
           </div>
           <div className="flex items-center gap-1.5">
-            {configured && (
+            {configured && chatMode !== "file" && (
               <button
                 type="button"
                 onClick={toggleAutoTelegram}
@@ -346,7 +347,11 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
           </div>
         </div>
         <div className="p-3 flex flex-col gap-2">
-          {!configured ? (
+          {chatMode === "file" ? (
+            <div className="text-[11px] text-text-muted">
+              Bridges use the new Node.js module in file-chat mode. Use the built-in bridge instead.
+            </div>
+          ) : !configured ? (
             <>
               <div className="flex items-center gap-2 text-[11px] text-text-muted">
                 <span className="w-1.5 h-1.5 rounded-full bg-text-muted" />


### PR DESCRIPTION
## Summary
- Auto-start bridge logic (`autoStartBridges`) now skips projects with `chat_mode: "file"` and logs the skip
- Manual bridge start (`POST /api/telegram?action=start`, `POST /api/discord?action=start`) returns an error for file-chat projects
- Bridge widget UI (Telegram + Discord) shows a disabled message and hides the Auto toggle + Start button for file-chat projects

## Test plan
- [ ] Create/use a project with `chat_mode: "file"` — verify bridge widgets show disabled message
- [ ] Verify Start button is hidden and Auto toggle is hidden for file-chat projects
- [ ] Verify AC-mode projects' bridge widgets are unaffected (Start, Stop, Auto all work)
- [ ] Verify `npm run build` passes

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)