### PR TITLE
[#719] AC → JSONL migration on first boot

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ const { waitForAgentChattrReady, registerAgent, registerAgentWithRetry, deregist
 const { patchAgentchattrCss, patchCrashTimeout } = require("./install-agentchattr");
 const { startQueueWatcher, stopQueueWatcher } = require("./queue-watcher");
 const { dispatchToAgentPTY, cleanupSession: cleanupPtyDispatcher } = require("./pty-dispatcher");
+const { runAcMigration } = require("./migrate-ac");
 
 const net = require("net");
 const config = readConfig();
@@ -3033,6 +3034,9 @@ server.listen(PORT, "127.0.0.1", async () => {
       console.log(`[startup] ${p.id}: AC already alive on port ${acPort} — tracking`);
     }
   }
+  // #719: Migrate AC chat history to JSONL before initializing file-chat.
+  runAcMigration(startupCfg);
+
   // #714: Initialize file-chat engine for projects with chat_mode: "file".
   // If the writer lock is held by another live process, refuse to start —
   // enforces the single-writer invariant against the "two terminals" scenario.

--- a/server/index.js
+++ b/server/index.js
@@ -3044,8 +3044,14 @@ server.listen(PORT, "127.0.0.1", async () => {
   for (const p of (startupCfg.projects || [])) {
     if (p.chat_mode === "file") {
       if (migrationFailed.has(p.id)) {
-        console.error(`[startup] ${p.id}: migration failed — keeping AC mode, skipping file-chat init`);
+        console.error(`[startup] ${p.id}: migration failed — reverting to AC mode, skipping file-chat init`);
         p.chat_mode = "ac";
+        const cfg = readConfig();
+        const entry = (cfg.projects || []).find((pr) => pr.id === p.id);
+        if (entry) {
+          entry.chat_mode = "ac";
+          writeConfig(cfg);
+        }
         continue;
       }
       try {

--- a/server/index.js
+++ b/server/index.js
@@ -3035,13 +3035,19 @@ server.listen(PORT, "127.0.0.1", async () => {
     }
   }
   // #719: Migrate AC chat history to JSONL before initializing file-chat.
-  runAcMigration(startupCfg);
+  // Failed projects stay on AC mode — do not initialize file-chat for them.
+  const migrationFailed = new Set(runAcMigration(startupCfg));
 
   // #714: Initialize file-chat engine for projects with chat_mode: "file".
   // If the writer lock is held by another live process, refuse to start —
   // enforces the single-writer invariant against the "two terminals" scenario.
   for (const p of (startupCfg.projects || [])) {
     if (p.chat_mode === "file") {
+      if (migrationFailed.has(p.id)) {
+        console.error(`[startup] ${p.id}: migration failed — keeping AC mode, skipping file-chat init`);
+        p.chat_mode = "ac";
+        continue;
+      }
       try {
         fileChat.initProject(p.id);
         console.log(`[startup] ${p.id}: file-chat engine initialized`);

--- a/server/migrate-ac.js
+++ b/server/migrate-ac.js
@@ -81,6 +81,11 @@ function migrateProject(projectId) {
 
   if (converted.length === 0 && skipped === 0) return null;
 
+  if (converted.length === 0 && skipped > 0) {
+    console.log(`[migration] ${projectId}: AC log has ${skipped} lines but none are valid JSON — skipping`);
+    return null;
+  }
+
   ensureSecureDir(chatDir);
 
   const tmpPath = targetPath + ".tmp";
@@ -132,6 +137,7 @@ function migrateProject(projectId) {
 }
 
 function runAcMigration(config) {
+  const failed = [];
   const projects = config.projects || [];
   for (const project of projects) {
     if (!project || !project.id) continue;
@@ -139,8 +145,10 @@ function runAcMigration(config) {
       migrateProject(project.id);
     } catch (err) {
       console.error(`[migration] ${project.id}: failed — ${err.message}`);
+      failed.push(project.id);
     }
   }
+  return failed;
 }
 
 module.exports = { runAcMigration, migrateProject, convertAcRecord };

--- a/server/migrate-ac.js
+++ b/server/migrate-ac.js
@@ -1,0 +1,146 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { ensureSecureDir, writeSecureFile } = require("./config");
+const { parseMentions } = require("./file-chat");
+
+const KNOWN_FIELDS = new Set([
+  "id", "timestamp", "ts", "sender", "channel", "type", "text", "message", "mentions",
+]);
+
+function convertAcRecord(record, nextId) {
+  let ts;
+  if (record.timestamp) {
+    ts = typeof record.timestamp === "number"
+      ? new Date(record.timestamp * 1000).toISOString()
+      : String(record.timestamp);
+  } else if (record.ts) {
+    ts = String(record.ts);
+  } else {
+    ts = new Date().toISOString();
+  }
+
+  const text = record.text || record.message || "";
+  const known = {
+    id: nextId,
+    seq: nextId,
+    ts,
+    sender: record.sender || "unknown",
+    channel: record.channel || "general",
+    type: record.type === "system" ? "system" : "message",
+    text,
+    mentions: parseMentions(text),
+  };
+
+  const legacy = {};
+  for (const [key, val] of Object.entries(record)) {
+    if (!KNOWN_FIELDS.has(key)) {
+      legacy[key] = val;
+    }
+  }
+  if (record.type && record.type !== known.type) {
+    legacy.type = record.type;
+  }
+  if (Object.keys(legacy).length > 0) known._legacy = legacy;
+  return known;
+}
+
+function migrateProject(projectId) {
+  const chatDir = path.join(os.homedir(), ".quadwork", projectId, "chat");
+  const migratedPath = path.join(chatDir, ".migrated");
+  const targetPath = path.join(chatDir, "general.jsonl");
+
+  if (fs.existsSync(migratedPath)) return null;
+
+  if (fs.existsSync(targetPath)) {
+    console.log(`[migration] ${projectId}: general.jsonl already exists without .migrated — skipping (Phase 1 test project)`);
+    return null;
+  }
+
+  const acLogPath = path.join(
+    os.homedir(), ".quadwork", projectId, "agentchattr", "data", "agentchattr_log.jsonl"
+  );
+  if (!fs.existsSync(acLogPath)) return null;
+
+  const content = fs.readFileSync(acLogPath, "utf-8");
+  const lines = content.split("\n");
+  const converted = [];
+  let nextId = 0;
+  let skipped = 0;
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const record = JSON.parse(line);
+      converted.push(convertAcRecord(record, nextId));
+      nextId++;
+    } catch {
+      skipped++;
+    }
+  }
+
+  if (converted.length === 0 && skipped === 0) return null;
+
+  ensureSecureDir(chatDir);
+
+  const tmpPath = targetPath + ".tmp";
+  const output = converted.map((r) => JSON.stringify(r)).join("\n") + "\n";
+  writeSecureFile(tmpPath, output);
+
+  const verifyContent = fs.readFileSync(tmpPath, "utf-8");
+  const verifyLines = verifyContent.trim().split("\n");
+  let verified = 0;
+  for (const vl of verifyLines) {
+    try {
+      JSON.parse(vl);
+      verified++;
+    } catch {
+      fs.unlinkSync(tmpPath);
+      throw new Error(`Migration validation failed for ${projectId}: corrupt line in tmp file`);
+    }
+  }
+  if (verified !== converted.length) {
+    fs.unlinkSync(tmpPath);
+    throw new Error(`Migration validation failed for ${projectId}: expected ${converted.length} records, got ${verified}`);
+  }
+
+  fs.renameSync(tmpPath, targetPath);
+  try { fs.chmodSync(targetPath, 0o600); } catch {}
+
+  const systemMsg = {
+    id: nextId,
+    seq: nextId,
+    ts: new Date().toISOString(),
+    sender: "system",
+    channel: "general",
+    type: "system",
+    text: `Chat history migrated from AC (${converted.length} messages)`,
+    mentions: [],
+  };
+  fs.appendFileSync(targetPath, JSON.stringify(systemMsg) + "\n", { mode: 0o600 });
+
+  const manifest = {
+    migrated_at: new Date().toISOString(),
+    source: acLogPath,
+    messages: converted.length,
+    skipped,
+  };
+  writeSecureFile(migratedPath, JSON.stringify(manifest, null, 2) + "\n");
+
+  console.log(`[migration] ${projectId}: migrated ${converted.length} messages, ${skipped} skipped (invalid JSON)`);
+  return { messages: converted.length, skipped };
+}
+
+function runAcMigration(config) {
+  const projects = config.projects || [];
+  for (const project of projects) {
+    if (!project || !project.id) continue;
+    try {
+      migrateProject(project.id);
+    } catch (err) {
+      console.error(`[migration] ${project.id}: failed — ${err.message}`);
+    }
+  }
+}
+
+module.exports = { runAcMigration, migrateProject, convertAcRecord };

--- a/server/migrate-ac.test.js
+++ b/server/migrate-ac.test.js
@@ -1,0 +1,172 @@
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const TEST_DIR = path.join(os.tmpdir(), `migrate-ac-test-${process.pid}-${Date.now()}`);
+
+const origHome = os.homedir;
+os.homedir = () => TEST_DIR;
+
+const { migrateProject, convertAcRecord } = require("./migrate-ac");
+
+function cleanup() {
+  os.homedir = origHome;
+  try { fs.rmSync(TEST_DIR, { recursive: true, force: true }); } catch {}
+}
+
+process.on("exit", cleanup);
+
+// --- Test: convertAcRecord converts Unix timestamp to ISO ---
+{
+  const record = {
+    id: 5,
+    uid: "abc-123",
+    sender: "dev",
+    text: "hello @head",
+    type: "chat",
+    timestamp: 1777370726.154467,
+    time: "19:05:26",
+    attachments: [],
+    channel: "general",
+  };
+  const result = convertAcRecord(record, 0);
+  assert.equal(result.id, 0);
+  assert.equal(result.seq, 0);
+  assert.equal(result.sender, "dev");
+  assert.equal(result.text, "hello @head");
+  assert.equal(result.type, "message");
+  assert.equal(result.channel, "general");
+  assert.deepEqual(result.mentions, ["head"]);
+  assert.ok(result.ts.includes("T"), "ts should be ISO format");
+  assert.ok(result._legacy, "should have _legacy");
+  assert.equal(result._legacy.uid, "abc-123");
+  assert.equal(result._legacy.time, "19:05:26");
+  assert.deepEqual(result._legacy.attachments, []);
+  assert.equal(result._legacy.id, undefined, "known field id should not be in _legacy");
+  console.log("PASS: convertAcRecord converts Unix timestamp and preserves unknown fields");
+}
+
+// --- Test: convertAcRecord preserves system type ---
+{
+  const record = { sender: "system", text: "paused", type: "system", timestamp: 1777370726 };
+  const result = convertAcRecord(record, 1);
+  assert.equal(result.type, "system");
+  console.log("PASS: convertAcRecord preserves system type");
+}
+
+// --- Test: convertAcRecord maps non-system types to message ---
+{
+  const record = { sender: "dev", text: "left", type: "leave", timestamp: 1777370726 };
+  const result = convertAcRecord(record, 2);
+  assert.equal(result.type, "message");
+  assert.equal(result._legacy.type, "leave");
+  console.log("PASS: convertAcRecord maps non-system type to message, preserves original in _legacy");
+}
+
+// --- Test: round-trip migration ---
+{
+  const projectId = "test-roundtrip";
+  const acDataDir = path.join(TEST_DIR, ".quadwork", projectId, "agentchattr", "data");
+  fs.mkdirSync(acDataDir, { recursive: true });
+
+  const acRecords = [
+    { id: 0, uid: "a", sender: "user", text: "hello @dev", type: "chat", timestamp: 1777370000, time: "10:00:00", attachments: [], channel: "general" },
+    { id: 1, uid: "b", sender: "dev", text: "hi @user", type: "chat", timestamp: 1777370010, time: "10:00:10", attachments: [], channel: "general", reply_to: 0 },
+    { id: 2, uid: "c", sender: "system", text: "paused", type: "system", timestamp: 1777370020, time: "10:00:20", attachments: [], channel: "general" },
+  ];
+  const acContent = acRecords.map((r) => JSON.stringify(r)).join("\n") + "\n";
+  fs.writeFileSync(path.join(acDataDir, "agentchattr_log.jsonl"), acContent);
+
+  const result = migrateProject(projectId);
+  assert.ok(result, "migration should return stats");
+  assert.equal(result.messages, 3);
+  assert.equal(result.skipped, 0);
+
+  const chatDir = path.join(TEST_DIR, ".quadwork", projectId, "chat");
+  const outputPath = path.join(chatDir, "general.jsonl");
+  assert.ok(fs.existsSync(outputPath), "general.jsonl should exist");
+
+  const outputLines = fs.readFileSync(outputPath, "utf-8").trim().split("\n");
+  assert.equal(outputLines.length, 4, "3 records + 1 system message");
+
+  const parsed = outputLines.map((l) => JSON.parse(l));
+  assert.equal(parsed[0].sender, "user");
+  assert.equal(parsed[0].text, "hello @dev");
+  assert.deepEqual(parsed[0].mentions, ["dev"]);
+  assert.equal(parsed[0]._legacy.uid, "a");
+
+  assert.equal(parsed[1]._legacy.reply_to, 0);
+
+  assert.equal(parsed[2].type, "system");
+
+  assert.equal(parsed[3].sender, "system");
+  assert.ok(parsed[3].text.includes("3 messages"));
+
+  const migratedPath = path.join(chatDir, ".migrated");
+  assert.ok(fs.existsSync(migratedPath), ".migrated should exist");
+  const manifest = JSON.parse(fs.readFileSync(migratedPath, "utf-8"));
+  assert.equal(manifest.messages, 3);
+  assert.equal(manifest.skipped, 0);
+
+  // Verify AC source is untouched
+  const acSource = fs.readFileSync(path.join(acDataDir, "agentchattr_log.jsonl"), "utf-8");
+  assert.equal(acSource, acContent, "AC log should be untouched");
+
+  console.log("PASS: round-trip migration preserves all records");
+}
+
+// --- Test: invalid lines are skipped ---
+{
+  const projectId = "test-invalid-lines";
+  const acDataDir = path.join(TEST_DIR, ".quadwork", projectId, "agentchattr", "data");
+  fs.mkdirSync(acDataDir, { recursive: true });
+
+  const acContent = [
+    JSON.stringify({ id: 0, sender: "user", text: "hello", type: "chat", timestamp: 1777370000 }),
+    "this is not json",
+    JSON.stringify({ id: 2, sender: "dev", text: "world", type: "chat", timestamp: 1777370010 }),
+    "{broken json",
+  ].join("\n") + "\n";
+  fs.writeFileSync(path.join(acDataDir, "agentchattr_log.jsonl"), acContent);
+
+  const result = migrateProject(projectId);
+  assert.equal(result.messages, 2);
+  assert.equal(result.skipped, 2);
+
+  console.log("PASS: invalid lines are skipped and counted");
+}
+
+// --- Test: re-running migration is a no-op ---
+{
+  const projectId = "test-roundtrip"; // already migrated above
+  const result = migrateProject(projectId);
+  assert.equal(result, null, "should be no-op");
+  console.log("PASS: re-running migration on migrated project is a no-op");
+}
+
+// --- Test: existing general.jsonl without .migrated skips ---
+{
+  const projectId = "test-phase1";
+  const chatDir = path.join(TEST_DIR, ".quadwork", projectId, "chat");
+  fs.mkdirSync(chatDir, { recursive: true });
+  fs.writeFileSync(path.join(chatDir, "general.jsonl"), '{"id":0}\n');
+
+  const acDataDir = path.join(TEST_DIR, ".quadwork", projectId, "agentchattr", "data");
+  fs.mkdirSync(acDataDir, { recursive: true });
+  fs.writeFileSync(path.join(acDataDir, "agentchattr_log.jsonl"), '{"id":0,"sender":"user","text":"test","type":"chat","timestamp":1}\n');
+
+  const result = migrateProject(projectId);
+  assert.equal(result, null, "should skip Phase 1 test project");
+  console.log("PASS: existing general.jsonl without .migrated is skipped (Phase 1)");
+}
+
+// --- Test: no AC log means nothing to migrate ---
+{
+  const projectId = "test-new-project";
+  const result = migrateProject(projectId);
+  assert.equal(result, null);
+  console.log("PASS: no AC log means nothing to migrate");
+}
+
+console.log("\nAll migrate-ac tests passed.");

--- a/server/migrate-ac.test.js
+++ b/server/migrate-ac.test.js
@@ -161,6 +161,24 @@ process.on("exit", cleanup);
   console.log("PASS: existing general.jsonl without .migrated is skipped (Phase 1)");
 }
 
+// --- Test: AC log with only invalid lines is skipped ---
+{
+  const projectId = "test-all-invalid";
+  const acDataDir = path.join(TEST_DIR, ".quadwork", projectId, "agentchattr", "data");
+  fs.mkdirSync(acDataDir, { recursive: true });
+
+  const acContent = "not json\nalso not json\n{broken\n";
+  fs.writeFileSync(path.join(acDataDir, "agentchattr_log.jsonl"), acContent);
+
+  const result = migrateProject(projectId);
+  assert.equal(result, null, "should skip when all lines are invalid");
+
+  const chatDir = path.join(TEST_DIR, ".quadwork", projectId, "chat");
+  assert.ok(!fs.existsSync(path.join(chatDir, "general.jsonl")), "should not create general.jsonl");
+  assert.ok(!fs.existsSync(path.join(chatDir, ".migrated")), "should not create .migrated");
+  console.log("PASS: AC log with only invalid lines is skipped gracefully");
+}
+
 // --- Test: no AC log means nothing to migrate ---
 {
   const projectId = "test-new-project";


### PR DESCRIPTION
## Summary
- New `server/migrate-ac.js` module converts AC `agentchattr_log.jsonl` to file-chat `general.jsonl` format on server boot
- Converts Unix epoch timestamps to ISO 8601, maps AC types to message/system, preserves unknown fields in `_legacy`
- Writes to `.tmp` file first, validates all records parse as JSON, then renames atomically
- Creates `.migrated` manifest to prevent re-migration (idempotent)
- Skips projects that already have `general.jsonl` without `.migrated` (Phase 1 test projects)
- AC source files are read-only — never modified
- Wired into server boot before file-chat initialization

## Test plan
- [x] Round-trip test: AC JSONL converts with no record loss
- [x] Unknown fields preserved in `_legacy` object
- [x] Original AC type preserved in `_legacy` when mapped (e.g. `leave` → `message`)
- [x] Invalid lines skipped and counted
- [x] Re-running migration is a no-op (`.migrated` check)
- [x] Phase 1 test project with existing `general.jsonl` is skipped
- [x] New project with no AC log is skipped
- [x] `npm run build` passes

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)