### PR TITLE
[#722] Switch all projects to file-based chat on boot

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3034,6 +3034,20 @@ server.listen(PORT, "127.0.0.1", async () => {
   // Failed projects stay on AC mode — do not initialize file-chat for them.
   const migrationFailed = new Set(runAcMigration(startupCfg));
 
+  // #722: Switch all projects to file-based chat on boot.
+  // Projects whose AC migration failed stay on "ac" (handled below).
+  {
+    let switched = false;
+    for (const p of (startupCfg.projects || [])) {
+      if (p.chat_mode !== "file" && !migrationFailed.has(p.id)) {
+        p.chat_mode = "file";
+        switched = true;
+        console.log(`[startup] ${p.id}: switched to file-based chat`);
+      }
+    }
+    if (switched) writeConfig(startupCfg);
+  }
+
   // #714: Initialize file-chat engine for projects with chat_mode: "file".
   // If the writer lock is held by another live process, refuse to start —
   // enforces the single-writer invariant against the "two terminals" scenario.

--- a/server/index.js
+++ b/server/index.js
@@ -3034,9 +3034,10 @@ server.listen(PORT, "127.0.0.1", async () => {
   // Failed projects stay on AC mode — do not initialize file-chat for them.
   const migrationFailed = new Set(runAcMigration(startupCfg));
 
-  // #722: Switch all projects to file-based chat on boot.
-  // Projects whose AC migration failed stay on "ac" (handled below).
-  {
+  // #722: One-time switchover — set all projects to file-based chat.
+  // Runs once per install; operator can revert individual projects to "ac"
+  // afterward without them being flipped back on next boot.
+  if (!startupCfg.file_chat_switchover_done) {
     let switched = false;
     for (const p of (startupCfg.projects || [])) {
       if (p.chat_mode !== "file" && !migrationFailed.has(p.id)) {
@@ -3045,7 +3046,9 @@ server.listen(PORT, "127.0.0.1", async () => {
         console.log(`[startup] ${p.id}: switched to file-based chat`);
       }
     }
-    if (switched) writeConfig(startupCfg);
+    startupCfg.file_chat_switchover_done = true;
+    writeConfig(startupCfg);
+    if (switched) console.log("[startup] file-chat switchover complete");
   }
 
   // #714: Initialize file-chat engine for projects with chat_mode: "file".


### PR DESCRIPTION
## Summary
- Adds a startup migration block that sets `chat_mode: "file"` for all projects on boot
- Projects whose AC migration failed (from #719) are excluded and stay on `"ac"`
- Persists the change to `config.json` so it survives restarts
- `chat_mode` field is preserved (not removed) for revert safety per spec

## Test plan
- [ ] Verify projects without `chat_mode` or with `chat_mode: "ac"` get switched to `"file"` on boot
- [ ] Verify projects whose AC migration failed remain on `"ac"`
- [ ] Verify `config.json` is updated on disk after switchover
- [ ] Verify operator can manually revert a project by setting `chat_mode: "ac"` in config
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)