### PR TITLE
[#746] Update all docs, seeds, and templates after AC removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
   <a href="#-quick-start"><strong>Quick Start</strong></a> ·
   <a href="#-how-it-works"><strong>How it Works</strong></a> ·
   <a href="#-features"><strong>Features</strong></a> ·
-  <a href="#-external-tools"><strong>Credits</strong></a> ·
-  <a href="https://github.com/bcurts/agentchattr"><strong>Built on AgentChattr</strong></a>
+  <a href="#-external-tools"><strong>Credits</strong></a>
 </p>
 
 <p>
@@ -21,7 +20,6 @@
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey" alt="platform" />
   <img src="https://img.shields.io/badge/runs-locally-00d4aa" alt="runs locally" />
   <img src="https://img.shields.io/badge/team-Head%20%C2%B7%20Dev%20%C2%B7%20RE1%20%C2%B7%20RE2-orange" alt="team: Head · Dev · RE1 · RE2" />
-  <a href="https://github.com/bcurts/agentchattr"><img src="https://img.shields.io/badge/built_on-AgentChattr-8b5cf6" alt="AgentChattr" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" /></a>
 </p>
 
@@ -103,7 +101,7 @@ npx quadwork init
 
 4. The wizard installs everything else and opens your dashboard.
 
-That's it. The wizard handles Python, GitHub CLI, AI tools, and
+That's it. The wizard handles GitHub CLI, AI tools, and
 authentication — you just follow the prompts. Subsequent runs are one
 command: `npx quadwork start`.
 
@@ -175,7 +173,7 @@ Head: merges, picks the next issue
 
 ### Workflow
 
-- 🧭 **Multi-project support** — each project has its own AgentChattr instance + isolated worktrees
+- 🧭 **Multi-project support** — each project has its own chat instance + isolated worktrees
 - 📝 **Per-project `OVERNIGHT-QUEUE.md`** with auto-incrementing batch numbers
 - 💬 **Slash commands** — `/continue`, `/clear`, `/summary`, `/poetry`, `/roastreview`
 - 🏷️ **Chat polish** — threaded replies, colored `@mentions`, short reviewer labels (RE1/RE2)
@@ -186,16 +184,15 @@ Head: merges, picks the next issue
 - 🚧 **GitHub branch protection** enforced on `main`
 - ✅ **2-of-2 reviewer approval** required before merge
 - 🛑 **Sender lockdown** — chat POSTs can't impersonate an agent (`head`, `dev`, …) from the UI
-- 🗄️ **Auto-snapshot** of chat history to `~/.quadwork/{project}/history-snapshots/` before every AgentChattr restart, with an in-dashboard **Restore** button and an optional auto-restore-on-restart opt-in
+- 🗄️ **Auto-snapshot** of chat history to `~/.quadwork/{project}/history-snapshots/` before every chat server restart, with an in-dashboard **Restore** button and an optional auto-restore-on-restart opt-in
 
 ## ─ External Tools
 
 QuadWork stands on top of some great open-source work. Explicit thanks:
 
 - **[AgentChattr](https://github.com/bcurts/agentchattr)** — by [@bcurts](https://github.com/bcurts).
-  The local chat server + MCP tooling that lets QuadWork's agents talk to
-  each other. **QuadWork would not exist without it** — huge thanks to
-  bcurts for building such a clean foundation.
+  QuadWork's file-based chat system was originally inspired by AgentChattr.
+  Thanks to bcurts for the foundational ideas.
 - **[GitHub CLI (`gh`)](https://cli.github.com)** — used by all four agents
   for issues, PRs, reviews, and merges.
 - **[Claude Code](https://github.com/anthropics/claude-code)** — Anthropic's
@@ -210,9 +207,8 @@ QuadWork stands on top of some great open-source work. Explicit thanks:
 
 ## ─ Configuration
 
-Global config lives at `~/.quadwork/config.json`. Per-project AgentChattr
-config lives at `~/.quadwork/{project_id}/agentchattr/config.toml`. The per-
-project queue lives at `~/.quadwork/{project_id}/OVERNIGHT-QUEUE.md`.
+Global config lives at `~/.quadwork/config.json`. The per-project queue
+lives at `~/.quadwork/{project_id}/OVERNIGHT-QUEUE.md`.
 
 ```json
 {
@@ -224,7 +220,6 @@ project queue lives at `~/.quadwork/{project_id}/OVERNIGHT-QUEUE.md`.
       "name": "My Project",
       "repo": "owner/repo",
       "working_dir": "/path/to/project",
-      "agentchattr_url": "http://127.0.0.1:8300",
       "mcp_http_port": 8200,
       "mcp_sse_port": 8201,
       "auto_continue_loop_guard": false,
@@ -241,7 +236,7 @@ project queue lives at `~/.quadwork/{project_id}/OVERNIGHT-QUEUE.md`.
 }
 ```
 
-Each project gets its own AgentChattr instance, ports, and git worktrees.
+Each project gets its own chat instance, MCP ports, and git worktrees.
 
 ## ─ Architecture
 
@@ -249,10 +244,10 @@ QuadWork runs as a single Express server on `127.0.0.1:8400`:
 
 - **Static frontend** — pre-built Next.js export (the `out/` directory)
 - **REST API** — agent lifecycle, config, GitHub proxy, chat proxy, triggers, loop guard, batch progress, project history
-- **WebSocket** — xterm.js terminal PTY sessions + AgentChattr ws fan-out
+- **WebSocket** — xterm.js terminal PTY sessions + chat event fan-out
 
-Per-project AgentChattr clones live at `~/.quadwork/{project}/agentchattr/`,
-each with their own ports. Per-project git worktrees sit next to the repo:
+Per-project chat data lives at `~/.quadwork/{project}/chat/`.
+Per-project git worktrees sit next to the repo:
 `{repo}-head`, `{repo}-dev`, `{repo}-re1`, `{repo}-re2`. The
 dashboard's xterm.js tiles attach to node-pty sessions over a WebSocket;
 nothing about the agent state is held client-side.
@@ -264,28 +259,19 @@ nothing about the agent state is held client-side.
 | `npx quadwork init` | One-time setup — installs prerequisites, opens the dashboard |
 | `npx quadwork start` | Start the dashboard server |
 | `npx quadwork stop` | Stop all processes |
-| `npx quadwork cleanup --project <id>` | Remove a project's AgentChattr clone and config entry |
-| `npx quadwork cleanup --legacy` | Remove the legacy `~/.quadwork/agentchattr/` install after migration |
+| `npx quadwork cleanup --project <id>` | Remove a project's data and config entry |
+| `npx quadwork cleanup --legacy` | Remove the legacy `~/.quadwork/agentchattr/` directory after migration |
 
 After `init`, create projects from the web UI at `http://127.0.0.1:8400/setup`.
 
 ### Disk usage
 
-Each project gets its own AgentChattr clone at
-`~/.quadwork/{project_id}/agentchattr/` (~77 MB per project):
+Each project stores its chat data at `~/.quadwork/{project_id}/chat/`.
+Disk usage is minimal — chat logs are plain JSON files.
 
-| Projects | Disk |
-|---------:|-----:|
-| 1 | ~77 MB |
-| 5 | ~385 MB |
-| 10 | ~770 MB |
-
-Per-project clones are necessary so multiple projects can run AgentChattr
-simultaneously without port conflicts. Existing v1 users are auto-migrated
-to per-project clones on the next `npx quadwork start`; once every project
-has a working clone, the legacy shared install can be removed safely via
-`npx quadwork cleanup --legacy` (which refuses to run if any project is
-still on the legacy install).
+Existing v1 users who had per-project AgentChattr clones can remove the
+legacy `~/.quadwork/agentchattr/` directory via
+`npx quadwork cleanup --legacy`.
 
 ## ─ Website
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Head: merges, picks the next issue
 - 📲 **Telegram bridge** — mirror the chat to your phone for remote monitoring
 - 💬 **Discord bridge** — forward agent chat to a Discord channel for team visibility
 - 💾 **Project history export/import** — JSON snapshots of the full chat transcript
-- 🧯 **Loop Guard control** — raise the hop limit and auto-resume stuck chains without restarting AC
+- 🧯 **Loop Guard control** — raise the hop limit and auto-resume stuck chains
 - 🔔 **Notification sounds** — Web Audio chime on new agent messages with a background-only mode
 - 🎞️ **Current Batch Progress panel** — per-issue progress bars computed from live GitHub state
 - 🗂️ **Recently closed / merged feed** — so finished work doesn't disappear from the GitHub panel
@@ -184,7 +184,7 @@ Head: merges, picks the next issue
 - 🚧 **GitHub branch protection** enforced on `main`
 - ✅ **2-of-2 reviewer approval** required before merge
 - 🛑 **Sender lockdown** — chat POSTs can't impersonate an agent (`head`, `dev`, …) from the UI
-- 🗄️ **Auto-snapshot** of chat history to `~/.quadwork/{project}/history-snapshots/` before every chat server restart, with an in-dashboard **Restore** button and an optional auto-restore-on-restart opt-in
+- 🗄️ **Auto-snapshot** of chat history to `~/.quadwork/{project}/history-snapshots/` with an in-dashboard **Restore** button
 
 ## ─ External Tools
 
@@ -260,7 +260,7 @@ nothing about the agent state is held client-side.
 | `npx quadwork start` | Start the dashboard server |
 | `npx quadwork stop` | Stop all processes |
 | `npx quadwork cleanup --project <id>` | Remove a project's data and config entry |
-| `npx quadwork cleanup --legacy` | Remove the legacy `~/.quadwork/agentchattr/` directory after migration |
+| `npx quadwork cleanup --legacy` | Remove legacy pre-v2 files |
 
 After `init`, create projects from the web UI at `http://127.0.0.1:8400/setup`.
 
@@ -269,9 +269,7 @@ After `init`, create projects from the web UI at `http://127.0.0.1:8400/setup`.
 Each project stores its chat data at `~/.quadwork/{project_id}/chat/`.
 Disk usage is minimal — chat logs are plain JSON files.
 
-Existing v1 users who had per-project AgentChattr clones can remove the
-legacy `~/.quadwork/agentchattr/` directory via
-`npx quadwork cleanup --legacy`.
+Existing v1 users can remove legacy files via `npx quadwork cleanup --legacy`.
 
 ## ─ Website
 

--- a/docs/install-mac.md
+++ b/docs/install-mac.md
@@ -10,7 +10,6 @@ Step-by-step guide for installing QuadWork on macOS. Designed for both humans an
 
 ```bash
 node --version   # Need 20+ (24 recommended)
-python3 --version # Need 3.x
 git --version
 gh --version
 ```
@@ -25,11 +24,6 @@ nvm install 24
 nvm use 24
 ```
 
-**Python 3** (via Homebrew if not already installed):
-```bash
-brew install python3
-```
-
 **Git** (included with Xcode Command Line Tools):
 ```bash
 xcode-select --install
@@ -39,18 +33,6 @@ xcode-select --install
 ```bash
 brew install gh
 ```
-
-### Fix macOS Python SSL certificates
-
-macOS Python installations often fail SSL verification. Run this once after installing Python:
-
-```bash
-/Applications/Python\ 3.*/Install\ Certificates.command
-```
-
-> **This requires operator input.** If the path doesn't match, ask the user to check their Python version: `ls /Applications/ | grep Python`
-
-Without this fix, AgentChattr's Python dependencies (fastapi, uvicorn) may fail to install with SSL errors.
 
 ### Authenticate GitHub CLI
 
@@ -132,7 +114,6 @@ quadwork start
 You should see output like:
 ```
 QuadWork dashboard: http://localhost:8400
-AgentChattr:        http://127.0.0.1:8300
 ```
 
 Open the dashboard URL in your browser to access the web UI.
@@ -152,7 +133,6 @@ Open the dashboard URL in your browser to access the web UI.
 
 QuadWork will:
 - Create worktree directories for each agent (e.g., `project-head/`, `project-dev/`, `project-re1/`, `project-re2/`)
-- Generate AgentChattr config
 - Seed AGENTS.md files for each role
 
 ---

--- a/docs/install-mac.md
+++ b/docs/install-mac.md
@@ -169,7 +169,7 @@ cd /path/to/project-re2 && claude -p "echo ok"
 3. Enter your Telegram bot token and chat ID
 4. Click **Start**
 
-> **Note:** Bridge agent sections (`[agents.dc]`, `[agents.tg]`) are automatically included in config.toml for projects created on v1.14.6+. If upgrading from an older version, restart QuadWork — the startup migration will add them.
+> **Note:** Bridges are configured per-project in `~/.quadwork/config.json`. See the dashboard Telegram/Discord widgets for setup.
 
 ---
 

--- a/docs/install-vps.md
+++ b/docs/install-vps.md
@@ -75,10 +75,10 @@ Update local `~/.ssh/config` — change `User root` to `User quadwork`. **All su
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y python3.12-venv git apache2-utils
+sudo apt-get install -y git apache2-utils
 ```
 
-`python3.12-venv` is required for AgentChattr's Python venv. Without it, the venv is created without pip, and AgentChattr crashes with `ModuleNotFoundError: No module named 'fastapi'`. `apache2-utils` provides `htpasswd` (used in Step 10 for HTTP basic auth).
+`apache2-utils` provides `htpasswd` (used in Step 10 for HTTP basic auth).
 
 ---
 
@@ -148,8 +148,6 @@ Optional — pre-create config at `~/.quadwork/config.json`:
 ```json
 {
   "port": 3000,
-  "agentchattr_url": "http://127.0.0.1:8300",
-  "agentchattr_dir": "",
   "projects": []
 }
 ```
@@ -159,6 +157,20 @@ Run interactive setup:
 ```bash
 quadwork init
 ```
+
+---
+
+## Migrating from Older Versions (AgentChattr cleanup)
+
+If upgrading from a version that used AgentChattr (the separate Python/FastAPI chat service), remove its pm2 processes:
+
+```bash
+pm2 stop agentchattr-*
+pm2 delete agentchattr-*
+pm2 save
+```
+
+Chat is now file-based (JSONL + MCP shim) and no longer requires a separate service. You can also remove `agentchattr_url` and `agentchattr_dir` from `~/.quadwork/config.json` if present.
 
 ---
 
@@ -337,7 +349,7 @@ chmod 600 ~/.quadwork/.env
 1. Create Hetzner VPS (CPX32, Ubuntu 24.04, Regular Performance)
 2. SSH in as root, create `quadwork` user with sudo + SSH keys
 3. Update local SSH config to `User quadwork`
-4. Install system packages: `python3.12-venv`, `git`, `apache2-utils`
+4. Install system packages: `git`, `apache2-utils`
 5. Install nvm + Node.js 24
 6. Install GitHub CLI
 7. Install Claude Code + Codex CLI

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -49,10 +49,10 @@ nvm install 24
 nvm use 24
 ```
 
-**Python 3 + venv** (required for AgentChattr):
+**System packages:**
 ```bash
 sudo apt-get update
-sudo apt-get install -y python3 python3-venv git
+sudo apt-get install -y git
 ```
 
 **GitHub CLI:**
@@ -103,4 +103,4 @@ QuadWork runs on `http://127.0.0.1:8400` by default. WSL2 shares localhost with 
 
 ## For AI Agents
 
-After WSL2 is installed by the operator: follow Steps 3–4 in this guide for prerequisites, then continue with `docs/install-mac.md` starting from the **"Install AI Coding Agents"** section. Do not run the macOS-specific prerequisite steps (Homebrew, Xcode, SSL certificates) — those are already handled by Step 3 above.
+After WSL2 is installed by the operator: follow Steps 3–4 in this guide for prerequisites, then continue with `docs/install-mac.md` starting from the **"Install AI Coding Agents"** section. Do not run the macOS-specific prerequisite steps (Homebrew, Xcode) — those are already handled by Step 3 above.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,72 +23,59 @@ QuadWork v1.14.5+ automatically pre-trusts worktree directories for Claude-confi
 
 ---
 
-## Agent suffix proliferation (head-2, dev-2)
+## Chat file permissions
 
-**Symptom:** Agents register as `head-2`, `dev-2`, `re1-3` instead of their base names. Chat mentions break because agents look for `@head-2` instead of `@head`.
+**Symptom:** Chat messages fail to send or load. Agents report errors reading/writing chat files.
 
-**Cause:** AgentChattr assigns a numeric suffix when another session with the same base name is still registered (e.g., from a crashed process that didn't clean up).
-
-**Fix:**
-1. Stop all agents: stop the QuadWork server
-2. Restart AgentChattr (or restart QuadWork entirely)
-3. Agents will re-register with their base names
-
-QuadWork v1.15.0+ includes suffix-awareness in AGENTS.md seeds — agents will match mentions by base role name regardless of suffix.
-
----
-
-## AgentChattr not reachable on port 8300
-
-**Symptom:** Agents fail to register. Logs show connection refused to `127.0.0.1:8300`.
-
-**Cause:** AgentChattr may not have started yet, or crashed during startup.
+**Cause:** The JSONL chat files at `~/.quadwork/<project>/chat/` aren't readable or writable by the QuadWork server process.
 
 **Fix:**
-1. Check if AgentChattr is running:
+1. Check file permissions on the chat directory and its files:
    ```bash
-   curl http://127.0.0.1:8300/healthz
+   ls -la ~/.quadwork/<project>/chat/
    ```
-2. If not running, check the AgentChattr logs in the project's data directory
-3. Restart QuadWork — it will restart AgentChattr automatically
+2. Fix permissions:
+   ```bash
+   chmod 600 ~/.quadwork/<project>/chat/*.jsonl
+   ```
+3. Ensure the directory itself is accessible:
+   ```bash
+   chmod 700 ~/.quadwork/<project>/chat/
+   ```
 
 ---
 
-## Discord/Telegram bridge: 400 "unknown base: dc"
+## JSONL corruption recovery
 
-**Symptom:** Bridge shows "Running" but messages don't forward. Bridge log shows: `Initial AC registration failed: 400 Client Error` / `unknown base: dc` (or `tg`).
+**Symptom:** Chat history loads partially or shows errors. Server logs mention a JSON parse error for a chat file.
 
-**Cause:** The project's `config.toml` is missing `[agents.dc]` and/or `[agents.tg]` sections. AgentChattr validates the `base` field against `[agents.*]` keys during registration.
+**Cause:** A chat JSONL file has a corrupted line (e.g., incomplete write due to crash). The server skips corrupted lines on read, but the bad line remains in the file.
 
 **Fix:**
-1. Restart QuadWork — the startup migration (`bridge-migrate`) will add the missing sections
-2. If the bridge still fails, manually add to the project's `config.toml`:
-   ```toml
-   [agents.dc]
-   label = "Discord Bridge"
-
-   [agents.tg]
-   label = "Telegram Bridge"
+1. Backup the corrupted file:
+   ```bash
+   cp ~/.quadwork/<project>/chat/<channel>.jsonl ~/.quadwork/<project>/chat/<channel>.jsonl.bak
    ```
-3. Restart AgentChattr for the project (use the dashboard SERVER > Restart button)
-
-QuadWork v1.14.6+ includes bridge sections in config.toml for all new projects.
+2. Identify the corrupted line — the server log will reference the line number
+3. Remove the corrupted line manually (e.g., open in an editor and delete it)
+4. Restart the QuadWork server to reload the file
 
 ---
 
-## SSL certificate error on macOS Python
+## Agent not receiving messages
 
-**Symptom:** AgentChattr dependency installation fails with `ssl.SSLCertVerificationError` or `[SSL: CERTIFICATE_VERIFY_FAILED]`.
+**Symptom:** An agent doesn't respond to chat messages. Other agents can send and receive normally.
 
-**Cause:** macOS Python installations ship without root certificates configured. The system certificates are not linked to Python's `certifi` package.
+**Cause:** PTY injection isn't delivering messages to the agent process. The agent's MCP shim may not be configured, or the agent process may not be running.
 
 **Fix:**
-
-```bash
-/Applications/Python\ 3.*/Install\ Certificates.command
-```
-
-> **This requires operator input.** If the path doesn't match, check: `ls /Applications/ | grep Python`
+1. Check that the agent process is running:
+   ```bash
+   ps aux | grep -E "claude|codex|gemini"
+   ```
+2. Verify the agent's MCP shim is configured in the project's agent settings
+3. Check the agent's terminal in the QuadWork dashboard for errors
+4. Restart the agent from the dashboard if needed
 
 ---
 
@@ -137,39 +124,3 @@ chmod 440 /etc/sudoers.d/quadwork
 
 See the [VPS Installation Guide](install-vps.md#step-2-create-non-root-user-critical) for full setup.
 
----
-
-## python3-venv missing on Ubuntu
-
-**Symptom:** AgentChattr crashes on startup with `ModuleNotFoundError: No module named 'fastapi'`.
-
-**Cause:** Ubuntu 24.04 ships Python 3.12 without the `python3.12-venv` package. AgentChattr creates a venv during setup, but without this package the venv has no pip — dependencies are never installed.
-
-**Fix:**
-
-```bash
-sudo apt-get install -y python3.12-venv
-```
-
-If you already hit this error, recreate the venv:
-
-```bash
-cd ~/.quadwork/<project-id>/agentchattr
-rm -rf .venv
-python3 -m venv .venv
-.venv/bin/pip install -r requirements.txt
-```
-
-Then restart QuadWork: `pm2 restart quadwork`
-
----
-
-## Duplicate TOML keys crash AgentChattr
-
-**Symptom:** AgentChattr crashes with a TOML parse error on startup.
-
-**Cause:** Manual edits to `config.toml` introduced duplicate keys (e.g., two `max_agent_hops` entries). TOML does not allow duplicate keys.
-
-**Fix:** Open the project's `config.toml` and remove the duplicate entry. Search for the key mentioned in the error message and ensure it appears only once.
-
-**Prevention:** Avoid manually editing `config.toml` fields that QuadWork's startup migrations also manage (e.g., `max_agent_hops`, `[agents.dc]`, `[agents.tg]`).

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,6 +1,6 @@
 # {{project_name}} — Development Rules
 
-## Multi-Agent System (AgentChattr)
+## Multi-Agent System
 
 | Agent | Role | Can Code? | Authority |
 |-------|------|-----------|-----------|
@@ -10,7 +10,7 @@
 | Dev | Full-Stack Builder | Yes | Implementation |
 
 - **Each agent = ONE role** — escalate to Head/RE1/RE2 if task doesn't match
-- **AGENTS.md is the primary instruction set** when running as an AgentChattr agent — it overrides these rules where they conflict
+- **AGENTS.md is the primary instruction set** when running as a QuadWork agent — it overrides these rules where they conflict
 
 ## GitHub Workflow
 

--- a/templates/OVERNIGHT-QUEUE.md
+++ b/templates/OVERNIGHT-QUEUE.md
@@ -32,4 +32,4 @@
 2. One ticket assigned to Dev at a time.
 3. Wait for both reviewers to approve before merging.
 4. After merge, immediately assign next item.
-5. Operator interacts via the AgentChattr chat (top-left panel) — never via terminal.
+5. Operator interacts via the project chat panel (top-left) — never via terminal.

--- a/templates/seeds/butler.CLAUDE.md
+++ b/templates/seeds/butler.CLAUDE.md
@@ -335,7 +335,7 @@ Read `docs/troubleshooting.md` first for known issues. Then use the architecture
 
 ## 11. Project Launch Guidance
 
-Ask for repo/CLIs/creds, guide through dashboard wizard, verify worktrees/AC/registration, help with bridges and first batch.
+Ask for repo/CLIs/creds, guide through dashboard wizard, verify worktrees and chat connectivity, help with bridges and first batch.
 
 ## 12. Design Awareness
 
@@ -370,7 +370,7 @@ Butler can create batches on any project directly by editing that project's OVER
 **Started:** <YYYY-MM-DD HH:MM>
 **Status:** pending kickoff
 
-- #598 Fix double AC restart
+- #598 Fix duplicate restart
 - #600 Display version in sidebar
 - #601 Head AGENTS.md queue format
 ```

--- a/templates/seeds/butler.CLAUDE.md
+++ b/templates/seeds/butler.CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Rule 1: Communication
 **Your terminal output is INVISIBLE to all other agents. No agent can see what you print.**
-The ONLY way to communicate is by calling the AgentChattr MCP tool `chat_send` with an `@mention`.
+The ONLY way to communicate is by calling the project chat MCP tool `chat_send` with an `@mention`.
 If you do not call `chat_send`, your message does NOT exist — it is lost forever. There is no exception.
 - CORRECT: Call `chat_send` with message "@user here's the batch I created"
 - WRONG: Printing "I'll message the operator now" in your terminal output
@@ -276,42 +276,41 @@ Butler must understand QuadWork's internal architecture to diagnose issues:
   - Runs on configurable port (default 8400)
   - Serves static Next.js frontend from `out/` directory
   - Manages PTY sessions for each agent via `node-pty`
-  - WebSocket connections for terminal I/O and chat proxy
+  - WebSocket connections for terminal I/O and chat
 
-- **AgentChattr (AC)** (Python/FastAPI/uvicorn): chat server for agent communication
-  - Separate process, one per project
-  - Default port 8300, auto-increments for multiple projects (8300, 8301, 8302...)
-  - Config: `~/.quadwork/<project>/agentchattr/config.toml`
-  - Data: `~/.quadwork/<project>/agentchattr/data/`
-  - Log: `~/.quadwork/<project>/agentchattr.log`
-  - Pinned to commit via git checkout (see AGENTCHATTR_PIN in `bin/quadwork.js`)
-  - Session token: required for API access, synced between QuadWork and AC
+- **File-based Chat** (`server/file-chat.js`): chat system for agent communication
+  - Chat messages stored as JSONL files in `~/.quadwork/<project>/chat/`
+  - One JSONL file per channel (e.g., `general.jsonl`)
+  - Server reads/writes JSONL directly — no external process or port needed
+  - Corrupted lines are skipped on read for resilience
+
+- **MCP Shim**: bridges chat into agent CLI sessions
+  - Exposes `chat_send`, `chat_read`, and other chat tools to agents via MCP
+  - Configured per agent in the project settings
+
+- **PTY Dispatcher**: delivers chat messages to agents via terminal injection
+  - Watches for new messages in JSONL files
+  - Injects relevant messages into the agent's PTY session
 
 - **Agent PTYs**: 4 terminal sessions per project (head, dev, re1, re2)
   - Each runs a CLI tool (claude/codex/gemini) in its own git worktree
   - Worktree layout: `<project-dir>-head`, `<project-dir>-dev`, etc.
-  - Registered with AC for chat integration via MCP
-  - Heartbeat every 5s to keep AC registration alive
-  - If heartbeat misses for `_CRASH_TIMEOUT` seconds, AC deregisters the agent
+  - Receives chat messages via PTY injection from the dispatcher
 
-- **Bridges** (Python): Discord and Telegram message forwarding
-  - Discord bridge: bundled in `bridges/discord/discord_bridge.py`
-  - Telegram bridge: cloned separately to `~/.quadwork/agentchattr-telegram/`
-  - Both register with AC as agents (`dc` and `tg` slugs)
-  - Config: `~/.quadwork/discord-<project>.toml`, `~/.quadwork/telegram-<project>.toml`
-  - Logs: `~/.quadwork/dc-bridge-<project>.log`, `~/.quadwork/tg-bridge-<project>.log`
+- **Bridges** (Node.js in-process): Discord and Telegram message forwarding
+  - Discord bridge: `server/bridges/discord.js`
+  - Telegram bridge: `server/bridges/telegram.js`
+  - Configured per-project in `~/.quadwork/config.json` (telegram/discord blocks)
 
 ### Key Files
 | File | Purpose |
 |------|---------|
 | `~/.quadwork/config.json` | Global QuadWork config (port, projects, agents) |
-| `~/.quadwork/<project>/agentchattr/config.toml` | Per-project AC config (ports, agents, routing) |
-| `~/.quadwork/<project>/agentchattr.log` | AC process stdout/stderr log |
+| `~/.quadwork/<project>/chat/*.jsonl` | Per-project chat messages (one file per channel) |
 | `~/.quadwork/<project>/OVERNIGHT-QUEUE.md` | Task queue for the project's Head agent |
-| `~/.quadwork/<project>/agent-token-<agent>.txt` | Persisted AC registration tokens |
-| `server/index.js` | Main server: agent spawning, AC health monitor, registration |
-| `server/routes.js` | API routes: setup wizard, chat proxy, bridges, GitHub |
-| `server/agentchattr-registry.js` | AC registration, heartbeat, deregistration |
+| `server/index.js` | Main server: agent spawning, chat integration |
+| `server/file-chat.js` | File-based chat: read/write JSONL, message dispatch |
+| `server/routes.js` | API routes: setup wizard, chat, bridges, GitHub |
 | `server/config.js` | Config read/write, project resolution, secure file helpers |
 | `bin/quadwork.js` | CLI: init wizard, start, stop, doctor commands |
 
@@ -319,51 +318,20 @@ Butler must understand QuadWork's internal architecture to diagnose issues:
 | Service | Default | Config key |
 |---------|---------|------------|
 | QuadWork dashboard | 8400 | config.json `port` |
-| AgentChattr (project 1) | 8300 | config.toml `[server] port` |
-| AgentChattr (project 2) | 8301 | auto-incremented |
 | MCP HTTP | 8200 | config.json `mcp_http_port` |
 | MCP SSE | 8201 | config.json `mcp_sse_port` |
-
-### Agent Registration Flow
-1. QuadWork spawns agent PTY with CLI command + MCP flags
-2. Before spawn, calls `waitForAgentChattrReady(port, 30s)` — polls AC root `/`
-3. Deregisters stale slot using persisted token (if exists)
-4. Registers with AC: `POST /api/register { base: "head", label: "Head Owner", force: true }`
-5. AC returns `{ name, token, slot }` — name may be suffixed if slot conflict
-6. Starts heartbeat: `POST /api/heartbeat/<name>` every 5s with Bearer token
-7. On heartbeat 409: triggers re-registration recovery
-
-### Health Monitor
-- Runs every 30s, checks if AC port is alive for each project
-- 60s grace period after AC starts (skips checks during startup)
-- If AC down for 3 consecutive checks -> auto-restart AC
-- On AC recovery -> restarts unregistered agents
-- Auto-reset dedup: only one reset per 30s per project
-
-### Common Log Patterns
-| Log pattern | Meaning |
-|-------------|---------|
-| `[#565] Agent X: AC not reachable on port` | AC wasn't ready when agent tried to register |
-| `[#565] Agent X: AC not reachable after 60s` | Deferred restart timeout — health monitor will handle |
-| `Crash timeout: deregistering X (no heartbeat for Ns)` | AC killed agent slot — heartbeat starvation |
-| `auto-reset N agent(s) after AC restart` | Health monitor restarting agents after AC recovery |
-| `unknown base: X` | AC config.toml missing `[agents.X]` section |
-| `409 Conflict` on heartbeat | Agent slot was taken by another registration |
-| `restart: port NNNN is free, spawning AC` | AC restart in progress |
-| `bridge-migrate` | Startup migration renaming bridge slugs |
 
 ## 10. Troubleshooting Workflow
 
 Read `docs/troubleshooting.md` first for known issues. Then use the architecture knowledge above to diagnose:
 
 1. Check server logs for error patterns
-2. Check AC logs: `~/.quadwork/<project>/agentchattr.log`
+2. Check chat files: `ls -la ~/.quadwork/<project>/chat/`
 3. Check agent processes: `ps aux | grep -E "claude|codex"`
 4. Check port status: `lsof -iTCP:<port> -sTCP:LISTEN`
-5. Check AC health: `curl http://127.0.0.1:<port>/`
-6. Check agent status via API: `curl http://127.0.0.1:8400/api/agents/<project>`
-7. Diagnose root cause before suggesting fixes
-8. File a ticket if it's a code bug, guide operator for config issues
+5. Check agent status via API: `curl http://127.0.0.1:8400/api/agents/<project>`
+6. Diagnose root cause before suggesting fixes
+7. File a ticket if it's a code bug, guide operator for config issues
 
 ## 11. Project Launch Guidance
 

--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Rule 1: Communication
 **Your terminal output is INVISIBLE to all other agents. No agent can see what you print.**
-The ONLY way to communicate is by calling the AgentChattr MCP tool `chat_send` with an `@mention`.
+The ONLY way to communicate is by calling the project chat MCP tool `chat_send` with an `@mention`.
 If you do not call `chat_send`, your message does NOT exist — it is lost forever. There is no exception.
 - CORRECT: Call `chat_send` with message "@re1 @re2 please review PR #50"
 - WRONG: Printing "I'll notify the reviewers" in your terminal output

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Rule 1: Communication
 **Your terminal output is INVISIBLE to all other agents. No agent can see what you print.**
-The ONLY way to communicate is by calling the AgentChattr MCP tool `chat_send` with an `@mention`.
+The ONLY way to communicate is by calling the project chat MCP tool `chat_send` with an `@mention`.
 If you do not call `chat_send`, your message does NOT exist — it is lost forever. There is no exception.
 - CORRECT: Call `chat_send` with message "@dev please implement issue #42"
 - WRONG: Printing "I'll message Dev now" in your terminal output
@@ -61,7 +61,7 @@ When checking for mentions addressed to you, match your **base role name** regar
 - If a task requires coding, delegate to Dev via @dev mention
 
 ## Combined Operator + Head Role
-In QuadWork, **the human operator talks to you through the AgentChattr chat panel**, not the terminal. Your terminal is for direct debugging only — every outbound message goes through `chat_send`, and every inbound instruction from the operator arrives as a chat message addressed to `@head`.
+In QuadWork, **the human operator talks to you through the project chat panel**, not the terminal. Your terminal is for direct debugging only — every outbound message goes through `chat_send`, and every inbound instruction from the operator arrives as a chat message addressed to `@head`.
 
 You are therefore the *combined* T1 + operator-relay: you receive high-level instructions from the operator in chat and translate them into GitHub issues + `OVERNIGHT-QUEUE.md` updates + ticket assignments.
 

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -88,7 +88,7 @@ When the operator asks you in chat to start a task or batch:
    **Started:** <YYYY-MM-DD HH:MM>
    **Status:** pending kickoff
 
-   - #598 Fix double AC restart
+   - #598 Fix duplicate restart
    - #600 Display version in sidebar
    ```
 

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Rule 1: Communication
 **Your terminal output is INVISIBLE to all other agents. No agent can see what you print.**
-The ONLY way to communicate is by calling the AgentChattr MCP tool `chat_send` with an `@mention`.
+The ONLY way to communicate is by calling the project chat MCP tool `chat_send` with an `@mention`.
 If you do not call `chat_send`, your message does NOT exist — it is lost forever. There is no exception.
 - CORRECT: Call `chat_send` with message "@dev PR #50 — REQUEST CHANGES: [findings]"
 - WRONG: Printing "Review complete" in your terminal output
@@ -30,7 +30,7 @@ This rule applies to ALL output that touches GitHub or git — issues, PR bodies
 
 ---
 
-You are **RE1**, the first reviewer agent. Your AgentChattr identity is `re1`.
+You are **RE1**, the first reviewer agent. Your chat identity is `re1`.
 The other reviewer is **RE2** (`re2`). You are independent — review separately.
 
 ### Identity & Suffix Awareness
@@ -127,7 +127,7 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 8. On approve, notify @dev (Dev aggregates approvals and notifies Head)
 
 ## Error Recovery
-- **Network failures** (`gh` API errors, DNS issues): retry the `gh` command automatically up to 5 times with 30-second intervals. Do NOT ask the user — just retry silently. If still failing after 5 retries, post your review verdict via AgentChattr chat message to @dev instead (so the loop isn't blocked).
+- **Network failures** (`gh` API errors, DNS issues): retry the `gh` command automatically up to 5 times with 30-second intervals. Do NOT ask the user — just retry silently. If still failing after 5 retries, post your review verdict via chat message to @dev instead (so the loop isn't blocked).
 
 ## Communication
 - **ALL messages MUST be sent via `chat_send` MCP tool** — terminal output is invisible, printing text is NOT communicating

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Rule 1: Communication
 **Your terminal output is INVISIBLE to all other agents. No agent can see what you print.**
-The ONLY way to communicate is by calling the AgentChattr MCP tool `chat_send` with an `@mention`.
+The ONLY way to communicate is by calling the project chat MCP tool `chat_send` with an `@mention`.
 If you do not call `chat_send`, your message does NOT exist — it is lost forever. There is no exception.
 - CORRECT: Call `chat_send` with message "@dev PR #50 — REQUEST CHANGES: [findings]"
 - WRONG: Printing "Review complete" in your terminal output
@@ -30,7 +30,7 @@ This rule applies to ALL output that touches GitHub or git — issues, PR bodies
 
 ---
 
-You are **RE2**, the second reviewer agent. Your AgentChattr identity is `re2`.
+You are **RE2**, the second reviewer agent. Your chat identity is `re2`.
 The other reviewer is **RE1** (`re1`). You are independent — review separately.
 
 ### Identity & Suffix Awareness
@@ -127,7 +127,7 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 8. On approve, notify @dev (Dev aggregates approvals and notifies Head)
 
 ## Error Recovery
-- **Network failures** (`gh` API errors, DNS issues): retry the `gh` command automatically up to 5 times with 30-second intervals. Do NOT ask the user — just retry silently. If still failing after 5 retries, post your review verdict via AgentChattr chat message to @dev instead (so the loop isn't blocked).
+- **Network failures** (`gh` API errors, DNS issues): retry the `gh` command automatically up to 5 times with 30-second intervals. Do NOT ask the user — just retry silently. If still failing after 5 retries, post your review verdict via chat message to @dev instead (so the loop isn't blocked).
 
 ## Communication
 - **ALL messages MUST be sent via `chat_send` MCP tool** — terminal output is invisible, printing text is NOT communicating


### PR DESCRIPTION
## Summary
- **README.md**: Remove AC badges, Python prerequisites, per-project clone references; update architecture to file-based chat; keep AgentChattr credit link
- **Install guides** (mac/vps/windows): Remove Python prerequisite sections, AC setup steps, SSL cert fix; add VPS migration steps for pm2 cleanup
- **Troubleshooting**: Remove 7 AC sections (suffixes, port 8300, TOML crashes, SSL, venv); add 3 file-chat sections (permissions, JSONL recovery, PTY injection)
- **Agent seeds**: Replace "AgentChattr MCP tool" → "project chat MCP tool"; update butler architecture to JSONL/MCP shim/PTY dispatcher; update bridge descriptions to Node.js modules
- **Templates**: Remove AC references from CLAUDE.md and OVERNIGHT-QUEUE.md

## Test plan
- [ ] Zero non-legacy "AgentChattr" references in README
- [ ] Zero Python prerequisite mentions in install guides
- [ ] Troubleshooting has new file-chat sections
- [ ] Butler seed architecture section describes file-chat system
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)