### PR TITLE
[#756] Fix getProjectChatMode + restore bridge start guards

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -249,7 +249,9 @@ function getProjectMaxHops(projectId) {
 }
 
 function getProjectChatMode(projectId) {
-  return "file";
+  const cfg = readConfigFile();
+  const project = cfg.projects?.find((p) => p.id === projectId);
+  return project?.chat_mode || "file";
 }
 
 function emitSystemMessage(projectId, text) {
@@ -2413,6 +2415,7 @@ router.post("/api/telegram", async (req, res) => {
     case "start": {
       const projectId = body.project_id;
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      if (getProjectChatMode(projectId) === "file") return res.json({ ok: false, error: "Bridge is not available in file-chat mode." });
       if (telegramBridge.isRunning(projectId)) return res.json({ ok: true, running: true, message: "Already running" });
       const tg = getProjectTelegram(projectId);
       if (!tg || !tg.bot_token || !tg.chat_id) return res.json({ ok: false, error: "Save bot_token and chat_id in project settings first." });
@@ -2588,6 +2591,7 @@ router.post("/api/discord", async (req, res) => {
     case "start": {
       const projectId = body.project_id;
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
+      if (getProjectChatMode(projectId) === "file") return res.json({ ok: false, error: "Bridge is not available in file-chat mode." });
       if (discordBridge.isRunning(projectId)) return res.json({ ok: true, running: true, message: "Already running" });
       const dc = getProjectDiscord(projectId);
       if (!dc || !dc.bot_token || !dc.channel_id) return res.json({ ok: false, error: "Save bot_token and channel_id in project settings first." });


### PR DESCRIPTION
## Summary
- `getProjectChatMode` now reads from project config instead of returning hardcoded `"file"` — allows per-project chat_mode override
- Restored `chat_mode === "file"` guards on Telegram and Discord bridge `start` handlers (lost during #747 merge, originally added in #748)

## Test plan
- [ ] `getProjectChatMode` returns project's configured `chat_mode` (or `"file"` as default)
- [ ] POST `/api/telegram?action=start` returns error for file-mode projects
- [ ] POST `/api/discord?action=start` returns error for file-mode projects
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)