### PR TITLE
[#762] Remove incorrect bridge file-chat guards + stale AC text + chat_mode validation

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -251,7 +251,7 @@ function getProjectMaxHops(projectId) {
 function getProjectChatMode(projectId) {
   const cfg = readConfigFile();
   const project = cfg.projects?.find((p) => p.id === projectId);
-  return project?.chat_mode || "file";
+  return project?.chat_mode === "ac" ? "ac" : "file";
 }
 
 function emitSystemMessage(projectId, text) {
@@ -2415,7 +2415,6 @@ router.post("/api/telegram", async (req, res) => {
     case "start": {
       const projectId = body.project_id;
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
-      if (getProjectChatMode(projectId) === "file") return res.json({ ok: false, error: "Bridge is not available in file-chat mode." });
       if (telegramBridge.isRunning(projectId)) return res.json({ ok: true, running: true, message: "Already running" });
       const tg = getProjectTelegram(projectId);
       if (!tg || !tg.bot_token || !tg.chat_id) return res.json({ ok: false, error: "Save bot_token and chat_id in project settings first." });
@@ -2591,7 +2590,6 @@ router.post("/api/discord", async (req, res) => {
     case "start": {
       const projectId = body.project_id;
       if (!projectId) return res.json({ ok: false, error: "Missing project_id" });
-      if (getProjectChatMode(projectId) === "file") return res.json({ ok: false, error: "Bridge is not available in file-chat mode." });
       if (discordBridge.isRunning(projectId)) return res.json({ ok: true, running: true, message: "Already running" });
       const dc = getProjectDiscord(projectId);
       if (!dc || !dc.bot_token || !dc.channel_id) return res.json({ ok: false, error: "Save bot_token and channel_id in project settings first." });

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -59,7 +59,7 @@ function generateTemplate(issues: Issue[], repo: string): string {
   lines.push("4. PR titles: [#<issue>] Short description");
   lines.push("5. Branch naming: task/<issue-number>-<slug>");
   lines.push("6. NEVER store keys/secrets");
-  lines.push("7. Communicate via AgentChattr MCP chat by tagging agents");
+  lines.push("7. Communicate via project chat by tagging agents");
   lines.push("8. Do NOT push to main — only merge approved PRs");
   lines.push("");
 


### PR DESCRIPTION
## Summary
- Removed incorrect file-chat guards on Telegram and Discord bridge start endpoints (re-added by #759, should have stayed removed per #747)
- Tightened `getProjectChatMode` to return only `"ac"` or `"file"` — invalid values like `"foo"` now default to `"file"`
- Updated QueueManager stale "AgentChattr MCP chat" → "project chat"
- Audited `getProjectChatMode` callers: 2 valid callers remain in `server/index.js` (system message file-chat gate, watchdog skip) — function kept

## Test plan
- [ ] Verify Telegram bridge starts successfully in file-chat mode projects
- [ ] Verify Discord bridge starts successfully in file-chat mode projects
- [ ] Verify `getProjectChatMode` returns `"file"` for invalid/missing `chat_mode` values
- [ ] Verify QueueManager prompt text says "project chat" not "AgentChattr"
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)