### PR TITLE
[#765] Fix notification sound type filter for file-chat messages

### DIFF
--- a/src/components/GlobalNotificationListener.tsx
+++ b/src/components/GlobalNotificationListener.tsx
@@ -118,7 +118,7 @@ export default function GlobalNotificationListener() {
           const hasNewAgentMessage = msgs.some(
             (m) =>
               m.id > prevCursor &&
-              (m.type === undefined || m.type === "chat") &&
+              m.type !== "system" &&
               m.sender !== "user" &&
               m.sender !== opName &&
               m.sender !== "system",


### PR DESCRIPTION
## Summary
- Replaced allow-list type filter (`m.type === undefined || m.type === "chat"`) with `m.type !== "system"` so file-chat messages (`type: "message"`) trigger the notification chime
- System messages are still excluded from triggering sound

## Test plan
- [ ] Notification sound plays when agents post messages in file-chat projects
- [ ] System messages don't trigger notification sound
- [ ] `npm run build` passes

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)