### PR TITLE
[#766] Fix normalizeMentions skipping code contexts

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -282,10 +282,23 @@ router.get("/api/chat", (req, res) => {
 const MENTION_AGENT_NAMES = ["head", "dev", "re1", "re2"];
 function normalizeMentions(text) {
   if (typeof text !== "string" || !text) return text || "";
-  return MENTION_AGENT_NAMES.reduce(
-    (t, name) => t.replace(new RegExp(`(?<![@\\w])\\b${name}\\b(?![\\w-])`, "gi"), `@${name}`),
-    text,
+  const preserved = [];
+  const ph = "\x00CODE\x00";
+  let safe = text.replace(/```[\s\S]*?```|`[^`]+`/g, (m) => {
+    preserved.push(m);
+    return ph;
+  });
+  safe = MENTION_AGENT_NAMES.reduce(
+    (t, name) =>
+      t.replace(new RegExp(`(?<![@\\w])\\b${name}\\b(?![\\w-])`, "gi"), (match, offset, str) => {
+        const before = str.slice(Math.max(0, offset - 20), offset);
+        if (/[=\/]$/.test(before) || /\b(run|exec|npx|start)\s+$/i.test(before)) return match;
+        return `@${name}`;
+      }),
+    safe,
   );
+  let i = 0;
+  return safe.replace(new RegExp(ph, "g"), () => preserved[i++] || "");
 }
 
 router.get("/api/loop-guard", (req, res) => {


### PR DESCRIPTION
## Summary
- Extract backtick code spans and fenced code blocks before normalizing mentions, then re-insert them unchanged
- Skip normalization after command prefixes (`run`, `exec`, `npx`, `start`) and after `=` or `/` characters
- Preserves `npm run dev`, `--omit=dev`, `/path/to/dev`, and backtick-wrapped code while still normalizing bare prose mentions

## Test plan
- [ ] `npm run dev` stays as `npm run dev`
- [ ] `--omit=dev` stays as `--omit=dev`
- [ ] `` `npm run dev` `` inside backticks not normalized
- [ ] `dev please review` → `@dev please review` (bare prose)
- [ ] `npm run build` passes

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)