### PR TITLE
[#771] Extend normalizeMentions command list + path-slash detection

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -292,7 +292,9 @@ function normalizeMentions(text) {
     (t, name) =>
       t.replace(new RegExp(`(?<![@\\w])\\b${name}\\b(?![\\w-])`, "gi"), (match, offset, str) => {
         const before = str.slice(Math.max(0, offset - 20), offset);
-        if (/[=\/]$/.test(before) || /\b(run|exec|npx|start)\s+$/i.test(before)) return match;
+        if (/[=\/]$/.test(before) || /\b(run|exec|npx|start|checkout|switch|rebase|cd|cat|ls|rm|mv|cp|mkdir)\s+$/i.test(before)) return match;
+        const after = str.slice(offset + name.length, offset + name.length + 1);
+        if (after === "/") return match;
         return `@${name}`;
       }),
     safe,


### PR DESCRIPTION
Fixes #771

Follow-up to #766. Two patterns still leaked through `normalizeMentions`:

1. `git checkout dev` → `git checkout @dev` ("checkout" not in command list)
2. `cat dev/README` → `@dev/README` (forward `/` means it's a path, not a mention)

Changes in `server/routes.js`:
- Extended command lookbehind list with `checkout|switch|rebase|cd|cat|ls|rm|mv|cp|mkdir`
- Added forward-look: if agent name is followed by `/`, treat as path and skip normalization

Verified: `git checkout dev`, `cat dev/README`, `cd dev` stay unchanged; prose `dev please review` still normalizes to `@dev`. Build passes.