### PR TITLE
[#775] Init file-chat for new wizard projects in add-config

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2202,6 +2202,12 @@ router.post("/api/setup", (req, res) => {
       ensureSecureDir(dir);
       writeConfig(cfg);
 
+      // #775: initialize file-chat for the new project so the first
+      // chat send doesn't error with "Project not initialized" before
+      // the next server restart. Boot init only runs for projects
+      // already in config.json at startup.
+      fileChat.initProject(id);
+
       // Batch 25 / #204: seed the per-project OVERNIGHT-QUEUE.md at
       // ~/.quadwork/{id}/OVERNIGHT-QUEUE.md.
       writeOvernightQueueFileSafe(id, name || id, repo);


### PR DESCRIPTION
## Summary
- Closes #775
- Adds `fileChat.initProject(id)` to the `add-config` step of `/api/setup` so wizard-created projects can send chat immediately
- Without this, the chat engine only learns about new projects on the next server boot, causing `Error: Project not initialized — call initProject first` on the first send

## Test plan
- [x] `npm run build` passes
- [x] `node -e "require('./server/routes.js')"` loads cleanly
- [ ] Manual: run wizard, create a fresh project, send a chat message in File-chat without restarting the server — expect no "Project not initialized" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)