### PR TITLE
[#778] Log Discord/Telegram bridge inbound message failures

### DIFF
--- a/server/bridges/discord.js
+++ b/server/bridges/discord.js
@@ -134,7 +134,11 @@ async function start(projectId, botToken, channelId, qwPort) {
       if (message.channel.id !== channelId) return;
 
       const from = message.author.username || "unknown";
-      await fetch(`http://127.0.0.1:${qwPort}/api/chat?project=${encodeURIComponent(projectId)}`, {
+      console.log(`[bridge] discord ${projectId}: received message from ${from}`);
+      if (!message.content) {
+        console.warn(`[bridge] discord ${projectId}: empty message content — check MESSAGE_CONTENT intent`);
+      }
+      const res = await fetch(`http://127.0.0.1:${qwPort}/api/chat?project=${encodeURIComponent(projectId)}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -147,9 +151,22 @@ async function start(projectId, botToken, channelId, qwPort) {
         }),
         signal: AbortSignal.timeout(5000),
       });
+      if (!res.ok) {
+        console.error(`[bridge] discord ${projectId} inbound POST failed: ${res.status}`);
+      }
     } catch (err) {
-      if (!inst.stopping) inst.lastError = err.message;
+      if (!inst.stopping) {
+        console.error(`[bridge] discord ${projectId} inbound error: ${err.message}`);
+        inst.lastError = err.message;
+      }
     }
+  });
+
+  client.on("error", (err) => {
+    console.error(`[bridge] discord ${projectId} client error: ${err?.message || err}`);
+  });
+  client.on("warn", (msg) => {
+    console.warn(`[bridge] discord ${projectId} client warn: ${msg}`);
   });
 
   pollLoop(projectId, channel, qwPort).catch((err) => {

--- a/server/bridges/telegram.js
+++ b/server/bridges/telegram.js
@@ -123,7 +123,7 @@ async function startTelegramUpdates(projectId, botToken, chatId, qwPort) {
           if (!text || msgChatId !== String(chatId)) continue;
 
           try {
-            await fetch(`http://127.0.0.1:${qwPort}/api/chat?project=${encodeURIComponent(projectId)}`, {
+            const r = await fetch(`http://127.0.0.1:${qwPort}/api/chat?project=${encodeURIComponent(projectId)}`, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -136,7 +136,12 @@ async function startTelegramUpdates(projectId, botToken, chatId, qwPort) {
               }),
               signal: AbortSignal.timeout(5000),
             });
-          } catch {}
+            if (!r.ok) {
+              console.error(`[bridge] telegram ${projectId} inbound POST failed: ${r.status}`);
+            }
+          } catch (err) {
+            console.error(`[bridge] telegram ${projectId} inbound error: ${err.message}`);
+          }
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Closes #778
- Adds console logging for bridge inbound failures — no changes to connect/reconnect logic, no shard manipulation, no `isRunning()` changes
- Discord `messageCreate`: received-message log, empty-content warn, POST `res.ok` check, `console.error` on catch, passive `client.on('error'|'warn')` listeners
- Telegram `startTelegramUpdates`: POST `res.ok` check, `console.error` on catch (previously silently swallowed)

## Test plan
- [x] `npm run build` passes
- [x] `node -e "require('./server/bridges/discord.js'); require('./server/bridges/telegram.js')"` loads cleanly
- [ ] Manual on a real bridge: confirm `[bridge] discord <id>: received message from ...` appears in pm2 logs when a Discord message arrives, and that POST failures surface via `[bridge] discord <id> inbound POST failed: <status>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)