### PR TITLE
[#783] Format chat timestamps client-side from raw ISO ts

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -268,11 +268,10 @@ router.get("/api/chat", (req, res) => {
     since_id: sinceId,
     limit: Number(req.query.limit) || 50,
   });
-  const normalized = messages.map((m) => ({
-    ...m,
-    time: m.time || (m.ts ? new Date(m.ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false }) : ""),
-  }));
-  return res.json(normalized);
+  // #783: return raw ISO `ts` only. The previous server-side `time`
+  // field used the server's local time, which on UTC VPS hosts gave
+  // wrong-timezone display. The frontend formats `ts` in the browser.
+  return res.json(messages);
 });
 
 // #693: Auto-normalize bare agent names to @mentions in outbound messages.
@@ -891,7 +890,7 @@ router.get("/api/projects", async (req, res) => {
     }
     if (projectName) {
       recentEvents.push({
-        time: m.time,
+        ts: m.ts,
         text: m.text.length > 120 ? m.text.slice(0, 120) + "…" : m.text,
         actor: m.sender,
         projectName,

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -13,10 +13,20 @@ interface Message {
   id: number;
   sender: string;
   text: string;
-  time: string;
+  ts: string;
   channel: string;
   type?: string;
   attachments?: Attachment[];
+}
+
+// #783: format ISO timestamp as HH:MM in the user's local timezone.
+// The server returns raw `ts` so VPS hosts (UTC) don't bake their
+// timezone into the displayed value.
+function formatLocalTime(ts: string | undefined): string {
+  if (!ts) return "";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
 const SENDER_COLORS: Record<string, string> = {
@@ -452,7 +462,7 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
         {displayMessages.map((msg) => (
           <div key={msg.id} className="group flex gap-2 text-[12px] leading-5">
             <span className="text-text-muted shrink-0 w-12 text-right tabular-nums">
-              {msg.time?.slice(0, 5) || ""}
+              {formatLocalTime(msg.ts)}
             </span>
             <span
               className="shrink-0 font-semibold w-10 text-right"

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -76,10 +76,18 @@ interface Project {
 }
 
 interface ActivityEvent {
-  time: string;
+  ts: string;
   text: string;
   actor: string;
   projectName: string;
+}
+
+// #783: format ISO timestamp as HH:MM in the user's local timezone.
+function formatLocalTime(ts: string | undefined): string {
+  if (!ts) return "";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
 function timeAgo(iso: string, t: typeof COPY["en"] | typeof COPY["ko"]): string {
@@ -281,11 +289,11 @@ export default function HomeDashboard() {
             )}
             {activity.map((item, i) => (
               <div
-                key={`${item.time}-${i}`}
+                key={`${item.ts}-${i}`}
                 className="flex gap-3 px-3 py-1.5 border-b border-border/50 last:border-b-0 text-[11px]"
               >
                 <span className="text-text-muted shrink-0 w-10 text-right tabular-nums">
-                  {item.time?.slice(0, 5) || ""}
+                  {formatLocalTime(item.ts)}
                 </span>
                 <span className="text-accent shrink-0 font-semibold w-12">
                   {item.projectName}


### PR DESCRIPTION
## Summary
- Closes #783
- Move timestamp formatting from server to browser so VPS hosts (UTC) stop displaying UTC time in chat
- `/api/chat` returns raw fileChat records with the existing `ts` ISO string; the previously injected server-side `time` field (computed via `toLocaleTimeString` in the server's timezone) is dropped
- `/api/projects` activity feed switches from the always-undefined `m.time` to `m.ts`
- Frontend (`ChatPanel`, `HomeDashboard`) renames `time → ts` on its interfaces and adds a small `formatLocalTime(ts)` helper that returns `HH:MM` in the user's locale via `Date#toLocaleTimeString`

## Files
- `server/routes.js` — drop server-side `time` injection on `/api/chat`; emit `ts` on activity feed events
- `src/components/ChatPanel.tsx` — `Message.ts`, `formatLocalTime`, render `formatLocalTime(msg.ts)`
- `src/components/HomeDashboard.tsx` — `ActivityEvent.ts`, same helper, render `formatLocalTime(item.ts)`

## Test plan
- [x] `npm run build` passes (TypeScript clean, all pages compile)
- [ ] Manual on VPS: open `/` activity feed and a project chat — timestamps should match operator's local timezone (e.g., 21:34 KST, not 12:34 UTC)
- [ ] Manual on Mac: same view — timestamps unchanged from current behavior (no regression)
- [ ] Invalid/missing `ts` → renders empty string instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)