### PR TITLE
[#786] Log non-OK seed fetch + document stale-cursor trade-off

### DIFF
--- a/server/bridges/discord.js
+++ b/server/bridges/discord.js
@@ -9,6 +9,11 @@ const instances = new Map();
 // #782: cursor-lag threshold beyond which a valid cursor is treated as
 // stale (bridge stopped mid-backlog) and reseeded to latest on start.
 // Small lags within this window keep continuity for graceful restarts.
+//
+// #786: intentional trade-off — if the bridge was down while 11+ messages
+// arrived, those messages are skipped (not replayed to Discord). This
+// prevents the "old message flood" bug. If continuity is needed for long
+// downtimes, increase this threshold or remove the stale-cursor check.
 const STALE_CURSOR_THRESHOLD = 10;
 
 function cursorPath(projectId) {
@@ -199,6 +204,10 @@ async function start(projectId, botToken, channelId, qwPort) {
           writeCursor(projectId, inst.cursor);
         }
       }
+    } else {
+      // #786: surface HTTP failures so non-OK responses don't fall
+      // through silently (the catch only fires on thrown errors).
+      console.warn(`[bridge] discord ${projectId}: cursor seed fetch returned ${r.status}`);
     }
   } catch (err) {
     console.warn(`[bridge] discord ${projectId}: cursor seed failed (${err.message})`);

--- a/server/bridges/telegram.js
+++ b/server/bridges/telegram.js
@@ -9,6 +9,11 @@ const instances = new Map();
 // #782: cursor-lag threshold beyond which a valid cursor is treated as
 // stale (bridge stopped mid-backlog) and reseeded to latest on start.
 // Small lags within this window keep continuity for graceful restarts.
+//
+// #786: intentional trade-off — if the bridge was down while 11+ messages
+// arrived, those messages are skipped (not replayed to Telegram). This
+// prevents the "old message flood" bug. If continuity is needed for long
+// downtimes, increase this threshold or remove the stale-cursor check.
 const STALE_CURSOR_THRESHOLD = 10;
 
 function cursorPath(projectId) {
@@ -208,6 +213,10 @@ async function start(projectId, botToken, chatId, qwPort) {
           writeCursor(projectId, inst.cursor);
         }
       }
+    } else {
+      // #786: surface HTTP failures so non-OK responses don't fall
+      // through silently (the catch only fires on thrown errors).
+      console.warn(`[bridge] telegram ${projectId}: cursor seed fetch returned ${r.status}`);
     }
   } catch (err) {
     console.warn(`[bridge] telegram ${projectId}: cursor seed failed (${err.message})`);


### PR DESCRIPTION
## Summary
- Closes #786
- Two minor follow-ups to #782 / PR #784:
  1. Discord and Telegram bridges' cursor-seed fetch now emit `console.warn(\`[bridge] X <id>: cursor seed fetch returned <status>\`)` when the response is non-OK — the previous `try/catch` only fired for thrown errors, so HTTP failures (e.g., a 500 from `/api/chat`) fell through silently.
  2. Added a doc comment to `STALE_CURSOR_THRESHOLD` in both bridges explaining the trade-off: messages beyond the threshold are intentionally skipped to avoid replaying old conversations.

## Files
- `server/bridges/discord.js`
- `server/bridges/telegram.js`

## Test plan
- [x] `npm run build` passes
- [x] `node server/bridges/bridges.test.js` — all six existing bridge unit tests pass
- [x] Modules load cleanly after edits
- [ ] Manual: stop `quadwork` between seed fetch and bridge start (or otherwise make `/api/chat` return non-200) — confirm the new warn appears with the status code

🤖 Generated with [Claude Code](https://claude.com/claude-code)