### PR TITLE
[#812] Add per-project Idle toggle to pause GitHub polling/triggers/bridges

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1183,6 +1183,13 @@ app.get("/api/triggers", (_req, res) => {
   res.json(result);
 });
 
+// #812: a parked (idle) project gets no trigger starts/pulses. Read
+// the live config so a config-write that sets idle takes effect at once.
+function isProjectIdleId(projectId) {
+  try { return !!readConfig().projects?.find((p) => p.id === projectId)?.idle; }
+  catch { return false; }
+}
+
 function stopTrigger(project) {
   const existing = triggers.get(project);
   if (existing) {
@@ -1194,6 +1201,11 @@ function stopTrigger(project) {
 
 app.post("/api/triggers/:project/start", (req, res) => {
   const { project } = req.params;
+  // #812: refuse to start a trigger for a parked (idle) project — no
+  // timer created, no agents pulsed. Toggle the project off idle first.
+  if (isProjectIdleId(project)) {
+    return res.json({ ok: false, idle: true, enabled: false });
+  }
   // #418 / quadwork#306: sendImmediately was an always-true
   // send-and-start flag from the original #210 button; operators
   // asked for a pure scheduler (the button is now just "Start
@@ -1265,6 +1277,10 @@ app.post("/api/triggers/:project/stop", (req, res) => {
 
 app.post("/api/triggers/:project/send-now", (req, res) => {
   const { project } = req.params;
+  // #812: parked (idle) project — do not pulse agents.
+  if (isProjectIdleId(project)) {
+    return res.json({ ok: false, idle: true, sent: false });
+  }
   sendTriggerMessage(project);
   res.json({ ok: true, sent: true });
 });
@@ -1593,7 +1609,11 @@ function syncTriggersFromConfig() {
 
   if (cfg.projects) {
     for (const project of cfg.projects) {
-      if (project.trigger_enabled) {
+      // #812: idle (parked) projects get no trigger. Excluding them from
+      // activeIds also makes the cleanup loop below clear any timer they
+      // had — so writing idle:true via PUT /api/config (which calls this)
+      // stops a running trigger with no separate stop call.
+      if (project.trigger_enabled && !project.idle) {
         activeIds.add(project.id);
         const ms = (project.trigger_interval || 30) * 60 * 1000;
         const existing = triggers.get(project.id);
@@ -1631,6 +1651,7 @@ async function autoStopPollingTick() {
   if (!cfg.projects) return;
 
   for (const project of cfg.projects) {
+    if (project.idle) continue; // #812: parked project — no batch-progress polling
     const hasTriggerAuto = project.trigger_auto && triggers.has(project.id);
     const hasBridgeAuto = project.telegram_auto || project.discord_auto;
     if (!hasTriggerAuto && !hasBridgeAuto) continue;

--- a/server/routes.js
+++ b/server/routes.js
@@ -1851,6 +1851,14 @@ router.get("/api/batch-progress", async (req, res) => {
   if (!projectId) return res.status(400).json({ error: "Missing project" });
 
   const cached = _batchProgressCache.get(projectId);
+  // #812: parked (idle) project — never run batch-progress gh/GraphQL calls,
+  // and ALWAYS flag the payload _idle (even on a fresh cache hit), so the
+  // endpoint contract is consistent regardless of cache freshness. This must
+  // precede the fresh-cache and rate-limit returns below.
+  if (isProjectIdle(projectId)) {
+    if (cached) return res.json({ ...cached.data, _idle: true });
+    return res.json({ batch_number: null, items: [], summary: "", complete: false, _idle: true });
+  }
   const batchTTL = adaptiveTTL(BATCH_PROGRESS_TTL_MS);
   if (cached && Date.now() - cached.ts < batchTTL) {
     return res.json(cached.data);
@@ -1859,12 +1867,6 @@ router.get("/api/batch-progress", async (req, res) => {
   // firing N gh calls per batch item.
   if (isRateLimited() && cached) {
     return res.json({ ...cached.data, _stale: true, _rateLimited: true });
-  }
-  // #812: parked (idle) project — never run batch-progress gh/GraphQL calls.
-  // Serve last-known data (or an empty batch) flagged _idle.
-  if (isProjectIdle(projectId)) {
-    if (cached) return res.json({ ...cached.data, _idle: true });
-    return res.json({ batch_number: null, items: [], summary: "", complete: false, _idle: true });
   }
 
   const repo = getRepo(projectId);

--- a/server/routes.js
+++ b/server/routes.js
@@ -120,9 +120,12 @@ function _ghEnqueueRefresh(cacheKey, ghArgs, transform) {
   _ghDrainQueue();
 }
 
-function cachedGhEndpoint(cacheKey, ghArgs, res, { transform } = {}) {
-  const ttl = adaptiveTTL(GH_ENDPOINT_CACHE_TTL);
+function cachedGhEndpoint(cacheKey, ghArgs, res, { transform, idle } = {}) {
   const cached = _ghEndpointCache.get(cacheKey);
+  // #812: a parked (idle) project must never initiate a gh fetch.
+  // Serve whatever we last cached, or an empty list — never call gh.
+  if (idle) return res.json(cached ? cached.data : []);
+  const ttl = adaptiveTTL(GH_ENDPOINT_CACHE_TTL);
   if (cached && Date.now() - cached.ts < ttl) {
     return res.json(cached.stale ? { ...cached.data, _stale: true } : cached.data);
   }
@@ -850,6 +853,20 @@ router.get("/api/projects", async (req, res) => {
   async function fetchProjectGhData(p) {
     let openPrs = 0;
     let lastActivity = null;
+    // #812: parked (idle) project — no gh calls; return zero/last-known metadata.
+    if (p.idle) {
+      const hasAgentsIdle = p.agents && Object.keys(p.agents).length > 0;
+      return {
+        id: p.id,
+        name: p.name,
+        repo: p.repo,
+        agentCount: hasAgentsIdle ? Object.keys(p.agents).length : 0,
+        openPrs: 0,
+        state: "idle",
+        lastActivity: null,
+        _idle: true,
+      };
+    }
     if (REPO_RE.test(p.repo)) {
       try {
         const [prs, recentPrs] = await Promise.allSettled([
@@ -937,6 +954,20 @@ function getRepo(projectId) {
   }
 }
 
+// #812: per-project Idle toggle. When a project is idle, QuadWork must
+// initiate ZERO project-specific GitHub/API activity for it. Callers
+// (board fetch, per-endpoint handlers, batch-progress, /api/projects)
+// check this before issuing any gh call.
+function isProjectIdle(projectId) {
+  if (!projectId) return false;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    return !!cfg.projects?.find((p) => p.id === projectId)?.idle;
+  } catch {
+    return false;
+  }
+}
+
 // ─── #703: Batched GraphQL layer ──────────────────────────────────────────
 // Instead of spawning individual `gh issue list` / `gh pr list` subprocesses
 // per project per endpoint, we fetch ALL configured projects' GitHub data in
@@ -959,7 +990,7 @@ async function fetchAllProjectsGraphQL() {
   } catch {
     return null;
   }
-  const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo));
+  const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo) && !p.idle); // #812: skip idle (parked) projects
   if (projects.length === 0) return null;
 
   // Build aliased repository fields — one per project.
@@ -1238,7 +1269,7 @@ router.get("/api/github/all", async (req, res) => {
   const anyStale = (() => {
     let cfg;
     try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { return true; }
-    const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo));
+    const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo) && !p.idle); // #812: skip idle (parked) projects
     for (const p of projects) {
       const cached = _graphqlCache.get(p.repo);
       if (!cached || Date.now() - cached.ts > adaptiveTTL(GRAPHQL_CACHE_TTL)) return true;
@@ -1250,7 +1281,7 @@ router.get("/api/github/all", async (req, res) => {
   // Build response.
   let cfg;
   try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { return res.status(500).json({ error: "Config unreadable" }); }
-  const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo));
+  const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo) && !p.idle); // #812: skip idle (parked) projects
 
   const result = {};
   const fallbackNeeded = [];
@@ -1320,6 +1351,7 @@ router.get("/api/github/issues", (req, res) => {
     `issues:${repo}`,
     ["issue", "list", "-R", repo, "--json", "number,title,state,assignees,labels,createdAt,url", "--limit", "50"],
     res,
+    { idle: isProjectIdle(req.query.project || "") },
   );
 });
 
@@ -1330,6 +1362,7 @@ router.get("/api/github/prs", (req, res) => {
     `prs:${repo}`,
     ["pr", "list", "-R", repo, "--json", "number,title,state,author,assignees,reviewDecision,reviews,statusCheckRollup,url,createdAt", "--limit", "50"],
     res,
+    { idle: isProjectIdle(req.query.project || "") },
   );
 });
 
@@ -1351,6 +1384,7 @@ router.get("/api/github/closed-issues", (req, res) => {
     ["issue", "list", "-R", repo, "--state", "closed", "--json", "number,title,state,url,closedAt", "--limit", String(RECENT_FETCH_LIMIT)],
     res,
     {
+      idle: isProjectIdle(req.query.project || ""),
       transform: (items) =>
         Array.isArray(items)
           ? items
@@ -1378,6 +1412,7 @@ router.get("/api/github/merged-prs", (req, res) => {
     ["pr", "list", "-R", repo, "--state", "merged", "--json", "number,title,state,url,mergedAt,author", "--limit", String(RECENT_FETCH_LIMIT)],
     res,
     {
+      idle: isProjectIdle(req.query.project || ""),
       transform: (items) =>
         Array.isArray(items)
           ? items
@@ -1811,6 +1846,12 @@ router.get("/api/batch-progress", async (req, res) => {
   // firing N gh calls per batch item.
   if (isRateLimited() && cached) {
     return res.json({ ...cached.data, _stale: true, _rateLimited: true });
+  }
+  // #812: parked (idle) project — never run batch-progress gh/GraphQL calls.
+  // Serve last-known data (or an empty batch) flagged _idle.
+  if (isProjectIdle(projectId)) {
+    if (cached) return res.json({ ...cached.data, _idle: true });
+    return res.json({ batch_number: null, items: [], summary: "", complete: false, _idle: true });
   }
 
   const repo = getRepo(projectId);

--- a/server/routes.js
+++ b/server/routes.js
@@ -122,9 +122,14 @@ function _ghEnqueueRefresh(cacheKey, ghArgs, transform) {
 
 function cachedGhEndpoint(cacheKey, ghArgs, res, { transform, idle } = {}) {
   const cached = _ghEndpointCache.get(cacheKey);
-  // #812: a parked (idle) project must never initiate a gh fetch.
-  // Serve whatever we last cached, or an empty list — never call gh.
-  if (idle) return res.json(cached ? cached.data : []);
+  // #812: a parked (idle) project must never initiate a gh fetch. Serve
+  // whatever we last cached, or an empty list — never call gh. The list
+  // endpoints return a bare array (client contract), so signal idle via a
+  // response header rather than mutating the JSON shape.
+  if (idle) {
+    res.set("X-QuadWork-Idle", "1");
+    return res.json(cached ? cached.data : []);
+  }
   const ttl = adaptiveTTL(GH_ENDPOINT_CACHE_TTL);
   if (cached && Date.now() - cached.ts < ttl) {
     return res.json(cached.stale ? { ...cached.data, _stale: true } : cached.data);
@@ -1281,13 +1286,21 @@ router.get("/api/github/all", async (req, res) => {
   // Build response.
   let cfg;
   try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { return res.status(500).json({ error: "Config unreadable" }); }
-  const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo) && !p.idle); // #812: skip idle (parked) projects
+  const projects = (cfg.projects || []).filter((p) => p.repo && REPO_RE.test(p.repo)); // #812: include idle projects — served stale below, never fetched
 
   const result = {};
   const fallbackNeeded = [];
   for (const p of projects) {
     if (projectFilter && p.id !== projectFilter) continue;
     const cached = _graphqlCache.get(p.repo);
+    // #812: idle (parked) project — serve last-known data flagged _idle,
+    // never trigger a fetch or fall back to gh.
+    if (p.idle) {
+      result[p.id] = cached
+        ? { issues: cached.issues, prs: cached.prs, closedIssues: cached.closedIssues, mergedPrs: cached.mergedPrs, _idle: true }
+        : { issues: [], prs: [], closedIssues: [], mergedPrs: [], _idle: true };
+      continue;
+    }
     if (cached) {
       result[p.id] = {
         issues: cached.issues,

--- a/src/components/BatchProgressPanel.tsx
+++ b/src/components/BatchProgressPanel.tsx
@@ -32,6 +32,7 @@ interface BatchProgressPanelProps {
 const COPY = {
   en: {
     loading: "Loading batch progress…",
+    idlePaused: "Project is idle — batch progress polling is paused.",
     currentBatchNone: "Current Batch: (none)",
     noActiveBatch: "No active batch. Ask Head to start one via the chat.",
     currentBatch: (n: number | string) => `Current Batch: Batch ${n}`,
@@ -46,6 +47,7 @@ const COPY = {
   },
   ko: {
     loading: "배치 진행 상황 로딩 중...",
+    idlePaused: "프로젝트가 유휴 상태입니다 — 배치 진행 폴링이 일시 중지되었습니다.",
     currentBatchNone: "현재 배치: (없음)",
     noActiveBatch: "활성 배치가 없습니다. 채팅에서 Head에게 시작을 요청하세요.",
     currentBatch: (n: number | string) => `현재 배치: ${n}번`,
@@ -102,6 +104,20 @@ export default function BatchProgressPanel({ projectId, idle = false }: BatchPro
   }, [load, idle]);
 
   if (!data) {
+    // #812: a project that is already idle on open has no cached batch data
+    // and never fetches — show a paused state instead of "Loading…" forever.
+    if (idle) {
+      return (
+        <div className="border-t border-border">
+          <div className="px-3 py-1.5 flex items-center gap-2">
+            <span className="text-[10px] text-text-muted uppercase tracking-wider">Idle</span>
+          </div>
+          <div className="px-3 pb-2 text-[11px] text-text-muted">
+            {t.idlePaused}
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="px-3 py-1.5 text-[11px] text-text-muted border-t border-border">
         {t.loading}

--- a/src/components/BatchProgressPanel.tsx
+++ b/src/components/BatchProgressPanel.tsx
@@ -26,6 +26,7 @@ interface BatchProgressData {
 
 interface BatchProgressPanelProps {
   projectId: string;
+  idle?: boolean;
 }
 
 const COPY = {
@@ -81,7 +82,7 @@ function ProgressBar({ percent }: { percent: number }) {
  * label. Polls every 30s on the same cadence as the rest of the
  * GitHub panel.
  */
-export default function BatchProgressPanel({ projectId }: BatchProgressPanelProps) {
+export default function BatchProgressPanel({ projectId, idle = false }: BatchProgressPanelProps) {
   const { locale } = useLocale();
   const t = COPY[locale];
   const [data, setData] = useState<BatchProgressData | null>(null);
@@ -94,10 +95,11 @@ export default function BatchProgressPanel({ projectId }: BatchProgressPanelProp
   }, [projectId]);
 
   useEffect(() => {
+    if (idle) return; // #812: parked project — stop polling batch progress
     load();
     const id = setInterval(load, 30000);
     return () => clearInterval(id);
-  }, [load]);
+  }, [load, idle]);
 
   if (!data) {
     return (

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -307,7 +307,7 @@ function formatTime(seconds: number): string {
 const AWAKE_AUTO_POLL_MS = 30_000;
 const AWAKE_AUTO_DEFAULT_HOURS = 8;
 
-function SystemSection({ projectId }: { projectId: string }) {
+function SystemSection({ projectId, idle = false }: { projectId: string; idle?: boolean }) {
   const { locale } = useLocale();
   const t = COPY[locale].system;
   const [active, setActive] = useState(false);
@@ -493,7 +493,7 @@ function SystemSection({ projectId }: { projectId: string }) {
 
   // #441: Batch lifecycle polling (same pattern as ScheduledTriggerWidget)
   useEffect(() => {
-    if (!awakeAuto) return;
+    if (!awakeAuto || idle) return; // #812: parked project — suppress auto-awake batch-progress polling
     const check = async () => {
       if (!awakeAutoRef.current) return;
       try {
@@ -535,7 +535,7 @@ function SystemSection({ projectId }: { projectId: string }) {
     check();
     const interval = setInterval(check, AWAKE_AUTO_POLL_MS);
     return () => clearInterval(interval);
-  }, [awakeAuto, projectId, autoStart, autoStop, t]);
+  }, [awakeAuto, projectId, autoStart, autoStop, t, idle]);
 
   // #425 / quadwork#311: Keep Awake is now a standalone subsection
   // and renders even on non-darwin (the button just hides). The
@@ -753,9 +753,10 @@ function SystemSection({ projectId }: { projectId: string }) {
 
 interface ControlBarProps {
   projectId: string;
+  idle?: boolean;
 }
 
-export default function ControlBar({ projectId }: ControlBarProps) {
+export default function ControlBar({ projectId, idle = false }: ControlBarProps) {
   // #210: Keep Alive moved to the Scheduled Trigger widget in the
   // bottom-right Operator Features quadrant. ControlBar now only
   // carries the server lifecycle + system controls.
@@ -772,7 +773,7 @@ export default function ControlBar({ projectId }: ControlBarProps) {
       <div className="flex flex-col md:flex-row md:items-start gap-2 md:gap-6">
         <ServerSection projectId={projectId} />
         <div className="border-t border-border/40 md:border-t-0 md:w-px md:h-auto md:self-stretch md:bg-border" />
-        <SystemSection projectId={projectId} />
+        <SystemSection projectId={projectId} idle={idle} />
       </div>
     </div>
   );

--- a/src/components/DiscordBridgeWidget.tsx
+++ b/src/components/DiscordBridgeWidget.tsx
@@ -63,6 +63,7 @@ interface BatchState {
 
 interface DiscordBridgeWidgetProps {
   projectId: string;
+  idle?: boolean;
 }
 
 interface DiscordStatus {
@@ -93,7 +94,7 @@ async function callDiscord(action: string, body: Record<string, unknown>) {
  * start/stop + a setup modal to configure bot_token + channel_id from
  * scratch.
  */
-export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetProps) {
+export default function DiscordBridgeWidget({ projectId, idle = false }: DiscordBridgeWidgetProps) {
   const { locale } = useLocale();
   const t = COPY[locale];
   const [status, setStatus] = useState<DiscordStatus | null>(null);
@@ -146,10 +147,11 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
   }, [projectId]);
 
   useEffect(() => {
+    if (idle) return; // #812: parked project — stop polling bridge status
     load();
     const id = window.setInterval(load, 5000);
     return () => window.clearInterval(id);
-  }, [load]);
+  }, [load, idle]);
 
   const noteInstallResponse = (data: { patched_projects?: string[] }) => {
     const patched = Array.isArray(data?.patched_projects) ? data.patched_projects : [];
@@ -271,11 +273,11 @@ export default function DiscordBridgeWidget({ projectId }: DiscordBridgeWidgetPr
   }, [projectId, load, t]);
 
   useEffect(() => {
-    if (!autoDiscord) return;
+    if (!autoDiscord || idle) return; // #812: parked project — suppress bridge auto-lifecycle
     checkBatchLifecycle();
     const id = window.setInterval(checkBatchLifecycle, AUTO_POLL_MS);
     return () => window.clearInterval(id);
-  }, [autoDiscord, checkBatchLifecycle]);
+  }, [autoDiscord, checkBatchLifecycle, idle]);
 
   const configured = !!status?.configured;
   const running = !!status?.running;

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -142,6 +142,7 @@ function ciLabel(rollup: { state: string }[]): string {
 
 interface GitHubPanelProps {
   projectId: string;
+  idle?: boolean;
 }
 
 // #554: rate limit status shape from /api/github/rate-limit
@@ -153,7 +154,7 @@ interface RateLimitInfo {
   critical: boolean;
 }
 
-export default function GitHubPanel({ projectId }: GitHubPanelProps) {
+export default function GitHubPanel({ projectId, idle = false }: GitHubPanelProps) {
   const { locale } = useLocale();
   const t = COPY[locale];
   const [issues, setIssues] = useState<Issue[]>([]);
@@ -226,10 +227,11 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
   }, []);
 
   useEffect(() => {
+    if (idle) return; // #812: parked project — stop polling issues/PRs (last-known data stays)
     fetchData();
     const interval = setInterval(fetchData, 60000); // #698: 60s (was 30s)
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, idle]);
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -399,7 +401,7 @@ export default function GitHubPanel({ projectId }: GitHubPanelProps) {
           between the issues/PRs lists and the OVERNIGHT-QUEUE.md
           row. Reads /api/batch-progress on its own 30s cadence. */}
       <div className="shrink-0">
-        <BatchProgressPanel projectId={projectId} />
+        <BatchProgressPanel projectId={projectId} idle={idle} />
       </div>
 
       {/* #226: compact OVERNIGHT-QUEUE.md row at the bottom */}

--- a/src/components/OperatorFeaturesPanel.tsx
+++ b/src/components/OperatorFeaturesPanel.tsx
@@ -49,7 +49,7 @@ const COPY = {
  * layout collapses back to the single-column stack so nothing
  * clips in cramped split-view / mobile.
  */
-export default function OperatorFeaturesPanel({ projectId }: { projectId: string }) {
+export default function OperatorFeaturesPanel({ projectId, idle = false }: { projectId: string; idle?: boolean }) {
   const { locale } = useLocale();
   const t = COPY[locale];
   return (
@@ -69,7 +69,7 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
             any overshoot visually; the right column is the only
             independent scroll container. */}
         <div className="lg:flex-1 lg:min-w-[280px] lg:min-h-0">
-          <ScheduledTriggerWidget projectId={projectId} />
+          <ScheduledTriggerWidget projectId={projectId} idle={idle} />
         </div>
         {/* Vertical divider between the two columns, only at lg+. */}
         <div className="hidden lg:block w-px self-stretch bg-border" />
@@ -77,8 +77,8 @@ export default function OperatorFeaturesPanel({ projectId }: { projectId: string
             History. Scrolls independently of the left column. */}
         <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto flex flex-col gap-2">
           <AgentModelsWidget projectId={projectId} />
-          <TelegramBridgeWidget projectId={projectId} />
-          <DiscordBridgeWidget projectId={projectId} />
+          <TelegramBridgeWidget projectId={projectId} idle={idle} />
+          <DiscordBridgeWidget projectId={projectId} idle={idle} />
           <LoopGuardWidget projectId={projectId} />
           <ProjectHistoryWidget projectId={projectId} />
         </div>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -130,6 +130,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
   // triggers / bridge auto-lifecycle for this project, and the dashboard
   // stops its own batch-progress pollers. Agent terminals stay viewable.
   const [idle, setIdle] = useState(false);
+  const [idleError, setIdleError] = useState(false);
   const idleLoadedRef = useRef(false);
   useEffect(() => {
     idleLoadedRef.current = false;
@@ -148,45 +149,54 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
       .catch(() => {});
   }, [projectId]);
   const toggleIdle = useCallback(() => {
-    setIdle((prev) => {
-      const next = !prev;
-      // Persist to config. The server's syncTriggers hook fires on this
-      // PUT and clears any running trigger for a now-idle project (#812),
-      // so no separate stop call is needed.
-      fetch("/api/config")
-        .then((r) => (r.ok ? r.json() : null))
-        .then((cfg) => {
-          if (!cfg) return;
-          const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
-          if (entry) {
-            entry.idle = next;
-            return fetch("/api/config", {
-              method: "PUT",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(cfg),
-            });
-          }
-        })
-        .catch(() => {});
-      return next;
-    });
-  }, [projectId]);
+    const next = !idle;
+    // Optimistic flip so polling responds instantly.
+    setIdle(next);
+    setIdleError(false);
+    // Persist to config. The server's syncTriggers hook fires on this PUT
+    // and clears any running trigger for a now-idle project (#812), so no
+    // separate stop call is needed. If persistence fails, REVERT the local
+    // flag so the dashboard's polling state can't desync from the server.
+    (async () => {
+      try {
+        const r = await fetch("/api/config");
+        if (!r.ok) throw new Error("config read failed");
+        const cfg = await r.json();
+        const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+        if (!entry) throw new Error("project not found in config");
+        entry.idle = next;
+        const put = await fetch("/api/config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(cfg),
+        });
+        if (!put.ok) throw new Error("config write failed");
+      } catch {
+        setIdle(!next); // revert — keep UI in sync with the unchanged server state
+        setIdleError(true);
+      }
+    })();
+  }, [idle, projectId]);
   const idleToggle = useMemo(() => (
     <button
       type="button"
       onClick={toggleIdle}
-      title={idle
-        ? "Project is idle — GitHub polling, triggers & bridges are paused. Click to resume."
-        : "Idle this project — pause all GitHub polling, triggers & bridge auto-lifecycle. Click to park."}
+      title={idleError
+        ? "Failed to save idle state — reverted. Click to retry."
+        : idle
+          ? "Project is idle — GitHub polling, triggers & bridges are paused. Click to resume."
+          : "Idle this project — pause all GitHub polling, triggers & bridge auto-lifecycle. Click to park."}
       className={`px-1.5 py-0.5 text-[10px] border transition-colors ${
-        idle
-          ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
-          : "border-border text-text-muted hover:text-text hover:border-accent"
+        idleError
+          ? "border-error/60 text-error hover:bg-error/10"
+          : idle
+            ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
+            : "border-border text-text-muted hover:text-text hover:border-accent"
       }`}
     >
-      {idle ? "Idle ●" : "Idle ○"}
+      {idleError ? "Idle !" : idle ? "Idle ●" : "Idle ○"}
     </button>
-  ), [idle, toggleIdle]);
+  ), [idle, idleError, toggleIdle]);
 
   // Poll agent states
   useEffect(() => {

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -125,6 +125,69 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
     </button>
   ), [filterSystem, t, toggleFilter]);
 
+  // #812: per-project Idle toggle. Source of truth is the project config
+  // (project.idle). When idle, the server suspends all GitHub polling /
+  // triggers / bridge auto-lifecycle for this project, and the dashboard
+  // stops its own batch-progress pollers. Agent terminals stay viewable.
+  const [idle, setIdle] = useState(false);
+  const idleLoadedRef = useRef(false);
+  useEffect(() => {
+    idleLoadedRef.current = false;
+    setIdle(false);
+  }, [projectId]);
+  useEffect(() => {
+    if (idleLoadedRef.current) return;
+    fetch("/api/config")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (!cfg) return;
+        const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+        if (entry?.idle) setIdle(true);
+        idleLoadedRef.current = true;
+      })
+      .catch(() => {});
+  }, [projectId]);
+  const toggleIdle = useCallback(() => {
+    setIdle((prev) => {
+      const next = !prev;
+      // Persist to config. The server's syncTriggers hook fires on this
+      // PUT and clears any running trigger for a now-idle project (#812),
+      // so no separate stop call is needed.
+      fetch("/api/config")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((cfg) => {
+          if (!cfg) return;
+          const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+          if (entry) {
+            entry.idle = next;
+            return fetch("/api/config", {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(cfg),
+            });
+          }
+        })
+        .catch(() => {});
+      return next;
+    });
+  }, [projectId]);
+  const idleToggle = useMemo(() => (
+    <button
+      type="button"
+      onClick={toggleIdle}
+      title={idle
+        ? "Project is idle — GitHub polling, triggers & bridges are paused. Click to resume."
+        : "Idle this project — pause all GitHub polling, triggers & bridge auto-lifecycle. Click to park."}
+      className={`px-1.5 py-0.5 text-[10px] border transition-colors ${
+        idle
+          ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
+          : "border-border text-text-muted hover:text-text hover:border-accent"
+      }`}
+    >
+      {idle ? "Idle ●" : "Idle ○"}
+    </button>
+  ), [idle, toggleIdle]);
+
   // Poll agent states
   useEffect(() => {
     const poll = () => {
@@ -230,7 +293,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
           <div className="flex-1 min-h-0">
             <ChatPanel projectId={projectId} filterSystem={filterSystem} />
           </div>
-          <ControlBar projectId={projectId} />
+          <ControlBar projectId={projectId} idle={idle} />
         </div>
 
         {/* Vertical divider — top segment (desktop only) */}
@@ -273,9 +336,11 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
             <InfoTooltip>
               {t.githubTooltip}
             </InfoTooltip>
-          } />
+          }>
+            {idleToggle}
+          </PanelHeader>
           <div className="flex-1 min-h-0">
-            <GitHubPanel projectId={projectId} />
+            <GitHubPanel projectId={projectId} idle={idle} />
           </div>
         </div>
 
@@ -287,7 +352,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
 
         {/* Q4: Operator Features */}
         <div className="border-t border-border lg:border-t-0 flex flex-col overflow-hidden">
-          <OperatorFeaturesPanel projectId={projectId} />
+          <OperatorFeaturesPanel projectId={projectId} idle={idle} />
         </div>
       </div>
     </div>

--- a/src/components/ScheduledTriggerWidget.tsx
+++ b/src/components/ScheduledTriggerWidget.tsx
@@ -6,6 +6,7 @@ import { useLocale } from "@/components/LocaleProvider";
 
 interface ScheduledTriggerWidgetProps {
   projectId: string;
+  idle?: boolean;
 }
 
 // #408: batch progress shape from /api/batch-progress
@@ -139,7 +140,7 @@ function formatCountdown(ms: number): string {
  * State is sourced from GET /api/triggers every 5s so reopening the
  * project picks up the last-used message + running status.
  */
-export default function ScheduledTriggerWidget({ projectId }: ScheduledTriggerWidgetProps) {
+export default function ScheduledTriggerWidget({ projectId, idle = false }: ScheduledTriggerWidgetProps) {
   const { locale } = useLocale();
   const t = COPY[locale];
   const [trigger, setTrigger] = useState<TriggerInfo | null>(null);
@@ -254,10 +255,11 @@ export default function ScheduledTriggerWidget({ projectId }: ScheduledTriggerWi
   }, [initialMessage, message]);
 
   useEffect(() => {
+    if (idle) return; // #812: parked project — stop polling trigger status
     load();
     const id = window.setInterval(load, 5000);
     return () => window.clearInterval(id);
-  }, [load]);
+  }, [load, idle]);
 
   // 1-Hz tick for the live countdown while running.
   useEffect(() => {
@@ -441,11 +443,11 @@ export default function ScheduledTriggerWidget({ projectId }: ScheduledTriggerWi
   }, [projectId, durationHoursDraft, intervalDraft, initialMessage, load, t.autoStopStatus]);
 
   useEffect(() => {
-    if (!autoTrigger) return;
+    if (!autoTrigger || idle) return; // #812: parked project — suppress auto-trigger lifecycle polling
     checkBatchLifecycle();
     const id = window.setInterval(checkBatchLifecycle, AUTO_TRIGGER_POLL_MS);
     return () => window.clearInterval(id);
-  }, [autoTrigger, checkBatchLifecycle]);
+  }, [autoTrigger, checkBatchLifecycle, idle]);
 
   const running = !!trigger?.enabled;
 

--- a/src/components/TelegramBridgeWidget.tsx
+++ b/src/components/TelegramBridgeWidget.tsx
@@ -63,6 +63,7 @@ interface BatchState {
 
 interface TelegramBridgeWidgetProps {
   projectId: string;
+  idle?: boolean;
 }
 
 interface TelegramStatus {
@@ -97,7 +98,7 @@ async function callTelegram(action: string, body: Record<string, unknown>) {
  * start/stop + a setup modal to configure bot_token + chat_id from
  * scratch.
  */
-export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidgetProps) {
+export default function TelegramBridgeWidget({ projectId, idle = false }: TelegramBridgeWidgetProps) {
   const { locale } = useLocale();
   const t = COPY[locale];
   const [status, setStatus] = useState<TelegramStatus | null>(null);
@@ -161,10 +162,11 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
   }, [projectId]);
 
   useEffect(() => {
+    if (idle) return; // #812: parked project — stop polling bridge status
     load();
     const id = window.setInterval(load, 5000);
     return () => window.clearInterval(id);
-  }, [load]);
+  }, [load, idle]);
 
   const noteInstallResponse = (data: { patched_projects?: string[] }) => {
     const patched = Array.isArray(data?.patched_projects) ? data.patched_projects : [];
@@ -293,11 +295,11 @@ export default function TelegramBridgeWidget({ projectId }: TelegramBridgeWidget
   }, [projectId, load, t]);
 
   useEffect(() => {
-    if (!autoTelegram) return;
+    if (!autoTelegram || idle) return; // #812: parked project — suppress bridge auto-lifecycle
     checkBatchLifecycle();
     const id = window.setInterval(checkBatchLifecycle, AUTO_POLL_MS);
     return () => window.clearInterval(id);
-  }, [autoTelegram, checkBatchLifecycle]);
+  }, [autoTelegram, checkBatchLifecycle, idle]);
 
   const configured = !!status?.configured;
   const running = !!status?.running;


### PR DESCRIPTION
Fixes #812.

## What
Adds a per-project **Idle** toggle. When a project is parked (config flag `project.idle`), QuadWork initiates **zero project-specific GitHub/API activity** for it — across every server poller, request endpoint, and client poller — so unused projects don't consume the shared GitHub budget or pulse their agents.

## Server
- **`server/routes.js`**: `isProjectIdle()` helper; board GraphQL fetch + `/api/github/all` skip idle projects; per-endpoint `/api/github/{issues,prs,closed-issues,merged-prs}` serve cached/empty without a `gh` call (`cachedGhEndpoint` idle short-circuit); `/api/batch-progress` serves last-known/empty (`_idle`) without gh/GraphQL; `/api/projects` returns zero/last-known metadata (`_idle`) with no `gh` calls.
- **`server/index.js`**: `autoStopPollingTick` skips idle projects (kills the 30s batch-progress hit); `syncTriggersFromConfig` skips idle projects **and clears their timers** (so writing `idle:true` via `PUT /api/config` stops a running trigger with no separate stop call); trigger `start` + `send-now` no-op for idle projects (`stop` still works).

## Frontend
- `ProjectDashboard` owns the `idle` state (loaded from / persisted to config; mirrors the existing `bridge_filter_agents_only` pattern), with a toggle in the GitHub panel header.
- `idle` threaded to `GitHubPanel`, `BatchProgressPanel`, `ScheduledTriggerWidget`, `Telegram/DiscordBridgeWidget`, `ControlBar`→`SystemSection`. Each stops its poll interval(s) when idle: the five direct `/api/batch-progress` pollers, the GitHub issues/PRs poll, and bridge auto-lifecycle.

## Safety
- Every gate is conditioned on `idle`/`p.idle`, which **defaults to `false`** → non-idle behavior is byte-for-byte unchanged.
- Agent PTY terminals stay running/viewable; chat is unaffected; the **global** `/api/github/rate-limit` poll (not project-scoped) is intentionally left running.
- `npm run build` passes (TypeScript clean).

## Not verified by automated tests
No unit test added (the repo's route tests don't run under a wired runner yet — see #798/#799). Verified by `npm run build` + manual code review. Suggest manual QA: toggle a project idle, confirm via `gh api rate_limit` that `used` stops moving for an idle-only setup, and that un-idling resumes polling.
