### PR TITLE
[#797] Self-heal: auto-restart claude agents bricked by thinking-block API 400

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ const routes = require("./routes");
 const fileChat = require("./file-chat");
 const { dispatchToAgentPTY, cleanupSession: cleanupPtyDispatcher } = require("./pty-dispatcher");
 const { runAcMigration } = require("./migrate-ac");
+const selfHeal = require("./self-heal");
 
 const net = require("net");
 const config = readConfig();
@@ -502,6 +503,37 @@ async function spawnAgentPty(project, agent, opts = {}) {
       if (session.scrollback.length > SCROLLBACK_SIZE) {
         session.scrollback = session.scrollback.slice(-SCROLLBACK_SIZE);
       }
+
+      // #797: observe-only self-heal detector. Wrapped in its own try/catch so
+      // a detector bug can never break the PTY → xterm pipeline; the chunk is
+      // never consumed or altered (the WS viewer forwards it independently).
+      try {
+        selfHeal.observeChunk(key, data, {
+          now: Date.now(),
+          recovering: !!session._autoRecovering,
+          onRestart: () => {
+            session._autoRecovering = true;
+            console.log(`[self-heal] ${key}: thinking-block 400 detected — restarting session`);
+            restartAgentSession(key, { reason: "thinking-block-400" })
+              .then((result) => {
+                if (result && result.ok) {
+                  emitSystemMessage(project, `${agent} auto-restarted (recovered from thinking-block API error)`);
+                }
+              })
+              .catch((err) => console.error(`[self-heal] ${key}: auto-restart failed:`, err.message))
+              .finally(() => {
+                const s = agentSessions.get(key);
+                if (s) s._autoRecovering = false;
+              });
+          },
+          onBreaker: (message) => {
+            console.log(`[self-heal] ${key}: ${message}`);
+            emitSystemMessage(project, message);
+          },
+        });
+      } catch (err) {
+        console.error(`[self-heal] ${key}: detector error (ignored):`, err.message);
+      }
     });
 
     term.onExit(({ exitCode }) => {
@@ -713,9 +745,12 @@ app.post("/api/agents/:project/:agent/stop", async (req, res) => {
 
 // --- Lifecycle: restart ---
 
-app.post("/api/agents/:project/:agent/restart", async (req, res) => {
-  const { project, agent } = req.params;
-  const key = `${project}/${agent}`;
+// #797: shared restart sequence, used by both the manual restart route and
+// the self-heal detector. Exactly the prior route body — no new lifecycle
+// logic. The `reason` is informational (logged by callers).
+async function restartAgentSession(key, { reason } = {}) {
+  const [project, agent] = key.split("/");
+  console.log(`[restart] ${key}: restarting session (reason: ${reason || "unspecified"})`);
 
   // #241: must await deregister before respawn so the slot frees and
   // the fresh register lands at slot 1 instead of head-2.
@@ -723,7 +758,14 @@ app.post("/api/agents/:project/:agent/restart", async (req, res) => {
   if (existing) existing._suppressLifecycleMsg = true;
   await stopAgentSession(key);
 
-  const result = await spawnAgentPty(project, agent, { suppressLifecycleMsg: true });
+  return spawnAgentPty(project, agent, { suppressLifecycleMsg: true });
+}
+
+app.post("/api/agents/:project/:agent/restart", async (req, res) => {
+  const { project, agent } = req.params;
+  const key = `${project}/${agent}`;
+
+  const result = await restartAgentSession(key, { reason: "manual" });
   if (result.ok) {
     emitSystemMessage(project, `${agent} restarted`);
     res.json({ ok: true, state: "running", pid: result.pid });

--- a/server/self-heal.js
+++ b/server/self-heal.js
@@ -1,0 +1,100 @@
+"use strict";
+
+// #797: Self-heal detector for the Opus 4.8 thinking-block API 400 that
+// permanently bricks a `claude` agent. Once a session hits this state every
+// subsequent turn 400s instantly and the agent does nothing while QuadWork
+// still shows it "online". A bricked conversation is unrecoverable, so the
+// only safe fix is to restart the session (which the agent re-seeds from chat
+// on its next trigger).
+//
+// This module is pure decision + per-agent guard state so it is unit-testable
+// without booting the server. The actual restart / message side effects are
+// supplied by the caller as callbacks; this file performs no I/O of its own.
+
+const COOLDOWN_MS = 60 * 1000;
+const CIRCUIT_WINDOW_MS = 15 * 60 * 1000;
+const CIRCUIT_MAX = 3;
+
+// Per-agent guard state: key -> { lastAutoRestartAt, restarts: number[], breakerNotified }
+const _state = new Map();
+
+// Conservative, Anthropic-API-specific signature. `codex` agents never emit
+// it. We require BOTH substrings so normal output that merely mentions
+// "thinking" can never trip the detector.
+function isThinkingBlock400(data) {
+  return typeof data === "string"
+    && data.includes("cannot be modified")
+    && data.includes("thinking");
+}
+
+function breakerMessage(agent) {
+  return `${agent} repeatedly hitting the thinking-block API error — auto-recovery paused, manual attention needed`;
+}
+
+// Observe a single PTY chunk and decide whether to auto-restart. Never throws:
+// callback failures are swallowed so a self-heal bug can never break the PTY
+// data pipeline. Returns the action taken for logging/tests:
+//   "no-match" | "recovering" | "cooldown" | "breaker" | "restart"
+//
+// opts:
+//   now         - current epoch ms (injected for testability)
+//   recovering  - true while a restart for this agent is already in flight
+//   onRestart   - (reason) => void  invoked when a restart should happen
+//   onBreaker   - (message) => void invoked once when the circuit breaker trips
+function observeChunk(key, data, opts = {}) {
+  try {
+    if (!isThinkingBlock400(data)) return "no-match";
+
+    const now = opts.now;
+    const agent = key.split("/")[1] || key;
+    const st = _state.get(key) || { lastAutoRestartAt: -Infinity, restarts: [], breakerNotified: false };
+
+    // Re-entrancy: a restart for this agent is already underway. The wedge
+    // keeps printing the 400 on the dying PTY — ignore those lines.
+    if (opts.recovering) return "recovering";
+
+    // Cooldown: also absorbs the burst of repeated 400 lines from one wedge.
+    if (now - st.lastAutoRestartAt < COOLDOWN_MS) return "cooldown";
+
+    // Circuit breaker: drop restarts older than the window, then refuse if we
+    // have already restarted CIRCUIT_MAX times inside it. An infinite restart
+    // loop would only mask a deeper failure.
+    st.restarts = st.restarts.filter((t) => now - t < CIRCUIT_WINDOW_MS);
+    if (st.restarts.length >= CIRCUIT_MAX) {
+      const firstTrip = !st.breakerNotified;
+      st.breakerNotified = true;
+      _state.set(key, st);
+      if (firstTrip && typeof opts.onBreaker === "function") {
+        try { opts.onBreaker(breakerMessage(agent)); } catch {}
+      }
+      return "breaker";
+    }
+
+    st.lastAutoRestartAt = now;
+    st.restarts.push(now);
+    _state.set(key, st);
+    if (typeof opts.onRestart === "function") {
+      try { opts.onRestart("thinking-block-400"); } catch {}
+    }
+    return "restart";
+  } catch {
+    // A detector bug must never break the PTY → xterm pipeline.
+    return "no-match";
+  }
+}
+
+// Drop guard state for an agent (e.g. on permanent stop).
+function clearState(key) {
+  _state.delete(key);
+}
+
+module.exports = {
+  observeChunk,
+  isThinkingBlock400,
+  breakerMessage,
+  clearState,
+  _state,
+  COOLDOWN_MS,
+  CIRCUIT_WINDOW_MS,
+  CIRCUIT_MAX,
+};

--- a/server/self-heal.test.js
+++ b/server/self-heal.test.js
@@ -1,0 +1,121 @@
+"use strict";
+
+const selfHeal = require("./self-heal");
+const { observeChunk, isThinkingBlock400, breakerMessage, _state, COOLDOWN_MS } = selfHeal;
+
+// The real thinking-block 400 line emitted by claude on Opus 4.8.
+const SIGNATURE =
+  "API Error: 400 messages.3.content.1: 'thinking' or 'redacted_thinking' " +
+  "blocks in the latest assistant message cannot be modified. These blocks " +
+  "must remain as they were in the original response.";
+
+function runTests() {
+  let passed = 0;
+  let failed = 0;
+
+  function assert(condition, msg) {
+    if (condition) {
+      passed++;
+      console.log(`  PASS: ${msg}`);
+    } else {
+      failed++;
+      console.error(`  FAIL: ${msg}`);
+    }
+  }
+
+  const KEY = "proj/dev";
+
+  // --- Test 1: signature match is conservative ---
+  {
+    assert(isThinkingBlock400(SIGNATURE), "matches the real 400 signature");
+    assert(!isThinkingBlock400("I am thinking about the problem"), "does NOT match prose containing 'thinking'");
+    assert(!isThinkingBlock400("this file cannot be modified"), "does NOT match 'cannot be modified' without 'thinking'");
+    assert(!isThinkingBlock400(""), "does NOT match empty output");
+    assert(!isThinkingBlock400(undefined), "does NOT match non-string input");
+  }
+
+  // --- Test 2: detection restarts once; second chunk within cooldown does not ---
+  {
+    _state.clear();
+    let restarts = 0;
+    const opts = { now: 1000, recovering: false, onRestart: () => { restarts++; } };
+
+    const r1 = observeChunk(KEY, SIGNATURE, opts);
+    assert(r1 === "restart" && restarts === 1, "first signature chunk triggers exactly one restart");
+
+    // Second identical line 5s later (same wedge burst) — within 60s cooldown.
+    const r2 = observeChunk(KEY, SIGNATURE, { ...opts, now: 6000 });
+    assert(r2 === "cooldown" && restarts === 1, "second chunk within 60s is suppressed by cooldown");
+  }
+
+  // --- Test 3: normal output never triggers ---
+  {
+    _state.clear();
+    let restarts = 0;
+    const r = observeChunk(KEY, "● Done. The agent is thinking through next steps.", {
+      now: 1000, recovering: false, onRestart: () => { restarts++; },
+    });
+    assert(r === "no-match" && restarts === 0, "normal output containing 'thinking' never restarts");
+  }
+
+  // --- Test 4: re-entrancy guard ---
+  {
+    _state.clear();
+    let restarts = 0;
+    const r = observeChunk(KEY, SIGNATURE, {
+      now: 1000, recovering: true, onRestart: () => { restarts++; },
+    });
+    assert(r === "recovering" && restarts === 0, "no restart while a restart is already in flight");
+  }
+
+  // --- Test 5: circuit breaker after 3 restarts in 15 min ---
+  {
+    _state.clear();
+    let restarts = 0;
+    let breakerMsgs = [];
+    const mk = (now) => observeChunk(KEY, SIGNATURE, {
+      now, recovering: false,
+      onRestart: () => { restarts++; },
+      onBreaker: (m) => { breakerMsgs.push(m); },
+    });
+
+    // Four detections each spaced > 60s apart (defeating cooldown) but inside
+    // the 15-min window.
+    const step = COOLDOWN_MS + 1000;
+    mk(step);          // restart 1
+    mk(step * 2);      // restart 2
+    mk(step * 3);      // restart 3
+    const r4 = mk(step * 4); // suppressed by breaker
+
+    assert(restarts === 3, "exactly 3 auto-restarts before the breaker trips");
+    assert(r4 === "breaker", "4th detection is suppressed by the circuit breaker");
+    assert(breakerMsgs.length === 1, "breaker emits the manual-attention message exactly once");
+    assert(breakerMsgs[0] === breakerMessage("dev"), "breaker message names the agent and the pause");
+
+    // Further detections stay suppressed and do NOT re-emit the message.
+    const r5 = mk(step * 5);
+    assert(r5 === "breaker" && breakerMsgs.length === 1, "breaker stays tripped without re-spamming the message");
+  }
+
+  // --- Test 6: a throwing callback cannot propagate out of the detector ---
+  {
+    _state.clear();
+    let threw = false;
+    let result;
+    try {
+      result = observeChunk(KEY, SIGNATURE, {
+        now: 1000, recovering: false,
+        onRestart: () => { throw new Error("boom"); },
+      });
+    } catch {
+      threw = true;
+    }
+    assert(!threw, "detector swallows a throwing callback (PTY pipeline stays intact)");
+    assert(result === "restart", "detection decision is still reported despite the callback throw");
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
Closes #797.

## What
Cheap, low-risk safety net for the Opus 4.8 thinking-block API 400 that permanently bricks a `claude` agent (every subsequent turn 400s instantly while QuadWork still shows it "online"). The deeper fix (turn-aware PTY injection) is explicitly out of scope.

## How
- **Detection** — observe-only inside the existing `term.onData` handler (`server/index.js`). Matches the conservative signature (chunk contains both `cannot be modified` AND `thinking`). Wrapped in its own `try/catch`; the chunk is never consumed or altered, so the PTY → xterm pipeline is untouched.
- **Recovery** — extracted the manual restart route body into a shared `restartAgentSession(key, { reason })` helper (identical effect). Both the route and the detector call it. The detector fires-and-forgets, never `await`s inside `onData`.
- **Guards** (`server/self-heal.js`, pure/testable):
  - 60s **cooldown** (also absorbs the burst of repeated 400 lines from one wedge)
  - **re-entrancy** flag (`session._autoRecovering`) set before stop, cleared after spawn
  - **circuit breaker**: ≤3 auto-restarts per agent per 15 min, then pauses and emits a visible `… auto-recovery paused, manual attention needed` system message once
- **Observability** — `[self-heal]` console logs + `… auto-restarted (recovered from thinking-block API error)` system message in chat.

## Safety
Purely additive: file-chat engine, MCP shim, loop guard, scheduled trigger, bridges, the PTY→xterm stream, `spawnAgentPty`/`stopAgentSession` internals, the watchdog, and agent model resolution are all untouched. The manual restart route keeps identical external behavior (now delegates to the shared helper).

## Tests
`server/self-heal.test.js` (16 assertions, all pass):
- signature matches the real 400 line; never matches prose containing "thinking" or "cannot be modified" alone
- detection restarts once; a second chunk within 60s is suppressed by cooldown
- re-entrancy guard suppresses while a restart is in flight
- 4 detections spaced to defeat cooldown → exactly 3 restarts, 4th tripped by breaker, message emitted exactly once
- a throwing callback cannot propagate out of the detector

`npm run build` passes; full existing server test suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)