### PR TITLE
[#788] normalizeMentions skips the sender's own name

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -286,16 +286,20 @@ router.get("/api/chat", (req, res) => {
 // Bare "head", "dev", "re1", "re2" become "@head", "@dev", "@re1", "@re2".
 // Already-prefixed mentions are not double-prefixed; suffixed names like
 // "head-2" or "re1-3" are left untouched.
+// #788: `skipName` is the sender's own agent name — it is never converted, so
+// an agent writing "head received the batch" doesn't self-mention. Pass a
+// falsy skipName (user / bridge senders) to normalize every name.
 const MENTION_AGENT_NAMES = ["head", "dev", "re1", "re2"];
-function normalizeMentions(text) {
+function normalizeMentions(text, skipName) {
   if (typeof text !== "string" || !text) return text || "";
+  const names = skipName ? MENTION_AGENT_NAMES.filter((n) => n !== skipName) : MENTION_AGENT_NAMES;
   const preserved = [];
   const ph = "\x00CODE\x00";
   let safe = text.replace(/```[\s\S]*?```|`[^`]+`/g, (m) => {
     preserved.push(m);
     return ph;
   });
-  safe = MENTION_AGENT_NAMES.reduce(
+  safe = names.reduce(
     (t, name) =>
       t.replace(new RegExp(`(?<![@\\w])\\b${name}\\b(?![\\w-])`, "gi"), (match, offset, str) => {
         const before = str.slice(Math.max(0, offset - 20), offset);
@@ -718,17 +722,21 @@ router.post("/api/chat", (req, res) => {
   const shimToken = req.headers["x-chat-token"];
   const bridgeSender = req.headers["x-bridge-sender"];
   let sender = "user";
+  // #788: only an authenticated agent (shim) sender skips its own name; user
+  // and bridge messages normalize every name.
+  let selfMentionSkip = null;
   if (shimSender && shimToken) {
     if (!fileChat.validateShimToken(projectId, shimSender, shimToken)) {
       return res.status(403).json({ error: "Invalid shim token" });
     }
     sender = shimSender;
+    selfMentionSkip = shimSender;
   } else if (bridgeSender && isLocalhost(req.ip)) {
     sender = bridgeSender;
   }
   const msg = fileChat.appendMessage(projectId, {
     sender,
-    text: normalizeMentions(text),
+    text: normalizeMentions(text, selfMentionSkip),
     channel: req.body?.channel || "general",
     type: "message",
   });

--- a/server/routes.normalizeMentions.test.js
+++ b/server/routes.normalizeMentions.test.js
@@ -1,0 +1,61 @@
+// #788: normalizeMentions(text, skipName) tests. Plain node:assert script —
+// no test runner is wired up. Run with
+// `node server/routes.normalizeMentions.test.js`.
+//
+// normalizeMentions is re-exported from server/routes.js (#693).
+
+const assert = require("node:assert/strict");
+const { normalizeMentions } = require("./routes");
+
+// 1) #788: an agent's own name is NOT converted to a self-mention.
+{
+  assert.equal(
+    normalizeMentions("head received the batch request", "head"),
+    "head received the batch request",
+    "sender's own bare name is left untouched",
+  );
+}
+
+// 2) #788: OTHER agent names are still converted when a sender is skipped.
+{
+  assert.equal(
+    normalizeMentions("dev will notify head and re1", "dev"),
+    "dev will notify @head and @re1",
+    "non-sender names still normalize; only the sender is skipped",
+  );
+}
+
+// 3) No skipName (user / bridge sender) → every name normalizes, including head.
+{
+  assert.equal(
+    normalizeMentions("head and dev please review", null),
+    "@head and @dev please review",
+    "user/bridge messages normalize all names",
+  );
+  assert.equal(
+    normalizeMentions("head and dev please review"),
+    "@head and @dev please review",
+    "omitted skipName behaves like the legacy single-arg call",
+  );
+}
+
+// 4) Already-prefixed mentions are not doubled, even for the sender.
+{
+  assert.equal(
+    normalizeMentions("@head done; pinging dev", "head"),
+    "@head done; pinging @dev",
+    "existing @mention preserved; other name still normalized",
+  );
+}
+
+// 5) Code spans are still preserved (skipName path keeps the guard).
+{
+  assert.equal(
+    normalizeMentions("ran `git checkout head` then told dev", "re1"),
+    "ran `git checkout head` then told @dev",
+    "names inside code spans are not touched",
+  );
+}
+
+console.log("routes.normalizeMentions.test.js: all assertions passed (5 cases)");
+process.exit(0);


### PR DESCRIPTION
Closes #788.

## Problem
`normalizeMentions()` (`server/routes.js`) converts bare agent names to @mentions for every `/api/chat` message regardless of sender — including the sender's own name. So when the head agent writes `head received the batch request`, it renders as `@head received the batch request`, making head look like it's tagging itself.

## Fix
- `normalizeMentions(text, skipName)` — when `skipName` is set, that name is filtered out of the conversion list (`MENTION_AGENT_NAMES.filter(n => n !== skipName)`); other names still normalize. A falsy `skipName` keeps the legacy "normalize everything" behavior.
- At the `/api/chat` call site, only an **authenticated shim (agent) sender** passes its own name as `skipName`. User and bridge senders pass `null`, so their messages still normalize all names per the AC.

## Acceptance criteria
- [x] Agent messages do not get their own name converted to @mention
- [x] Other agent names in the message are still converted (e.g. dev writing "notify head" → "notify @head")
- [x] User and bridge messages still normalize all names
- [x] `npm run build` passes

## Tests
New `server/routes.normalizeMentions.test.js` (5 cases, all pass):
- sender's own bare name left untouched
- non-sender names still normalize while sender is skipped
- no skipName (user/bridge) and the omitted-arg legacy call both normalize all
- existing `@mention` not doubled; code-span guard still preserved

`npm run build` green; existing `routes.*` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)