### PR TITLE
[#802] Back off GraphQL polling on the GraphQL rate-limit bucket

### DIFF
--- a/server/routes.graphqlRateLimit.test.js
+++ b/server/routes.graphqlRateLimit.test.js
@@ -1,0 +1,63 @@
+// #802: GraphQL rate-limit predicate tests. Plain node:assert script — no
+// test runner is wired up. Run with
+// `node server/routes.graphqlRateLimit.test.js`.
+//
+// _graphqlRateLimit / isGraphqlRateLimited / isGraphqlRateLow are re-exported
+// from server/routes.js strictly for this test. The predicates gate the
+// GraphQL background poller and the /api/batch-progress GraphQL query on the
+// SEPARATE GraphQL budget (REST and GraphQL are independent at GitHub).
+
+const assert = require("node:assert/strict");
+const { _graphqlRateLimit, isGraphqlRateLimited, isGraphqlRateLow } = require("./routes");
+
+function setRemaining(n) {
+  _graphqlRateLimit.remaining = n;
+}
+
+// Thresholds mirror the REST side: LOW = 200, CRITICAL = 50.
+
+// 1) Full budget → neither low nor limited.
+{
+  setRemaining(5000);
+  assert.equal(isGraphqlRateLow(), false, "5000 remaining is not low");
+  assert.equal(isGraphqlRateLimited(), false, "5000 remaining is not critical");
+}
+
+// 2) Below LOW (200) but above CRITICAL (50) → low only.
+{
+  setRemaining(150);
+  assert.equal(isGraphqlRateLow(), true, "150 remaining is low");
+  assert.equal(isGraphqlRateLimited(), false, "150 remaining is not yet critical");
+}
+
+// 3) Below CRITICAL (50) → both low and limited (background AND on-demand stop).
+{
+  setRemaining(10);
+  assert.equal(isGraphqlRateLow(), true, "10 remaining is low");
+  assert.equal(isGraphqlRateLimited(), true, "10 remaining is critical");
+}
+
+// 4) Exhausted (0) → both true.
+{
+  setRemaining(0);
+  assert.equal(isGraphqlRateLow(), true, "0 remaining is low");
+  assert.equal(isGraphqlRateLimited(), true, "0 remaining is critical");
+}
+
+// 5) Boundary: exactly at the thresholds (strict < comparison).
+{
+  setRemaining(200);
+  assert.equal(isGraphqlRateLow(), false, "exactly 200 is NOT low (strict <)");
+  setRemaining(50);
+  assert.equal(isGraphqlRateLimited(), false, "exactly 50 is NOT critical (strict <)");
+}
+
+// 6) GraphQL bucket is independent of REST: this object is a distinct bucket,
+//    so draining GraphQL here cannot reflect REST state.
+{
+  setRemaining(0);
+  assert.equal(isGraphqlRateLimited(), true, "GraphQL critical reflects only the GraphQL bucket");
+}
+
+console.log("routes.graphqlRateLimit.test.js: all assertions passed (6 cases)");
+process.exit(0);

--- a/server/routes.js
+++ b/server/routes.js
@@ -40,6 +40,15 @@ const _rateLimit = {
   updatedAt: 0,      // epoch ms when we last fetched
   error: null,       // last fetch error message, if any
 };
+// #802: GitHub tracks REST (core) and GraphQL as SEPARATE budgets, so GraphQL
+// can hit 0 while REST is full. The background GraphQL poller and the
+// batch-progress GraphQL query must back off on THIS bucket, not the REST one.
+const _graphqlRateLimit = {
+  limit: 5000,       // GraphQL is a points/hour budget, not request count
+  remaining: 5000,
+  resetAt: 0,        // epoch ms
+  updatedAt: 0,      // epoch ms when we last fetched
+};
 const RATE_LIMIT_POLL_MS = 60_000;       // refresh every 60s
 const RATE_LIMIT_LOW_THRESHOLD = 200;    // below this → back off
 const RATE_LIMIT_CRITICAL = 50;          // below this → stop all infra gh calls
@@ -47,15 +56,24 @@ let _rateLimitTimer = null;
 
 async function refreshRateLimit() {
   try {
+    // One `gh api rate_limit` call returns every resource bucket; grab both
+    // core (REST) and graphql so each stream can gate on its own budget (#802).
     const { stdout } = await _execFileAsync("gh", [
-      "api", "rate_limit", "--jq", ".resources.core | {limit,remaining,reset}",
+      "api", "rate_limit", "--jq",
+      "{core: (.resources.core | {limit,remaining,reset}), graphql: (.resources.graphql | {limit,remaining,reset})}",
     ], { encoding: "utf-8", timeout: 10000 });
     const data = JSON.parse(stdout);
-    _rateLimit.limit = data.limit;
-    _rateLimit.remaining = data.remaining;
-    _rateLimit.resetAt = data.reset * 1000; // seconds → ms
+    _rateLimit.limit = data.core.limit;
+    _rateLimit.remaining = data.core.remaining;
+    _rateLimit.resetAt = data.core.reset * 1000; // seconds → ms
     _rateLimit.updatedAt = Date.now();
     _rateLimit.error = null;
+    if (data.graphql) {
+      _graphqlRateLimit.limit = data.graphql.limit;
+      _graphqlRateLimit.remaining = data.graphql.remaining;
+      _graphqlRateLimit.resetAt = data.graphql.reset * 1000;
+      _graphqlRateLimit.updatedAt = Date.now();
+    }
   } catch (err) {
     _rateLimit.error = err.message;
     _rateLimit.updatedAt = Date.now();
@@ -73,6 +91,13 @@ function isRateLimited() {
 }
 function isRateLow() {
   return _rateLimit.remaining < RATE_LIMIT_LOW_THRESHOLD;
+}
+// #802: same thresholds, applied to the separate GraphQL budget.
+function isGraphqlRateLimited() {
+  return _graphqlRateLimit.remaining < RATE_LIMIT_CRITICAL;
+}
+function isGraphqlRateLow() {
+  return _graphqlRateLimit.remaining < RATE_LIMIT_LOW_THRESHOLD;
 }
 
 // Adaptive cache TTL: normal 30s, low 120s, critical ∞ (serve stale)
@@ -1120,7 +1145,10 @@ fragment repoFields on Repository {
 // and on demand when a per-project endpoint has no cached data.
 async function refreshGraphQLCache() {
   if (_graphqlRefreshInFlight) return;
-  if (isRateLimited()) return; // don't burn quota when critically low
+  // #802: gate on the GraphQL budget (not REST). The proactive background
+  // poller backs off at the LOW threshold to preserve points for on-demand
+  // requests, which only hard-stop at critical.
+  if (isGraphqlRateLow()) return;
   _graphqlRefreshInFlight = true;
   try {
     const data = await fetchAllProjectsGraphQL();
@@ -1876,6 +1904,12 @@ router.get("/api/batch-progress", async (req, res) => {
   if (isRateLimited() && cached) {
     return res.json({ ...cached.data, _stale: true, _rateLimited: true });
   }
+  // #802: GraphQL budget exhausted (separate from REST) — prefer serving the
+  // existing cache (even stale) over the GraphQL query below. With no cache we
+  // fall through to the REST gh-CLI fallback path (gated on its own bucket).
+  if (isGraphqlRateLimited() && cached) {
+    return res.json({ ...cached.data, _stale: true, _rateLimited: true });
+  }
 
   const repo = getRepo(projectId);
   if (!repo) return res.status(400).json({ error: "No repo configured for project" });
@@ -1926,8 +1960,12 @@ router.get("/api/batch-progress", async (req, res) => {
   // #703: Try batched GraphQL first — one query for all batch items.
   // Falls back to individual gh CLI calls (the #416 parallel approach)
   // if GraphQL fails.
+  // #802: skip GraphQL entirely when the GraphQL budget is critical so we
+  // don't drain it further; null forces the REST gh-CLI fallback below.
   let items;
-  const graphqlData = await fetchBatchProgressGraphQL(repo, issueNumbers);
+  const graphqlData = isGraphqlRateLimited()
+    ? null
+    : await fetchBatchProgressGraphQL(repo, issueNumbers);
   if (graphqlData) {
     items = issueNumbers.map((n) => {
       const issueNode = graphqlData[`issue${n}`];
@@ -2819,3 +2857,8 @@ module.exports.normalizeMentions = normalizeMentions;
 module.exports.getProjectChatMode = getProjectChatMode;
 // #730: PTY dispatch callback setter
 module.exports.setPtyDispatchCallback = setPtyDispatchCallback;
+// #802: expose the GraphQL rate-limit bucket + predicates for unit tests.
+// No production callers outside this file.
+module.exports._graphqlRateLimit = _graphqlRateLimit;
+module.exports.isGraphqlRateLimited = isGraphqlRateLimited;
+module.exports.isGraphqlRateLow = isGraphqlRateLow;


### PR DESCRIPTION
Closes #802.

## Problem
GitHub tracks REST (`core`) and GraphQL rate-limit budgets **separately**, so GraphQL can hit 0 while REST is full (observed in prod: GraphQL 0/5000, REST 5000/5000). But both GraphQL streams backed off on the **REST** bucket, so they kept hammering the exhausted GraphQL budget:
- `refreshGraphQLCache()` (background poller) — `if (isRateLimited()) return;`
- `/api/batch-progress` — called `fetchBatchProgressGraphQL()` regardless of GraphQL budget.

## Fix
- **`refreshRateLimit()`** now fetches and stores `.resources.graphql` alongside `.resources.core` — a single `gh api rate_limit` call returns both buckets (verified the combined `--jq` against the live API).
- Added **`isGraphqlRateLimited()`** / **`isGraphqlRateLow()`** mirroring the REST thresholds (CRITICAL=50, LOW=200) but reading the GraphQL bucket.
- **`refreshGraphQLCache()`** (proactive background poller) backs off at the GraphQL **LOW** threshold, conserving points for on-demand requests.
- **`/api/batch-progress`** hard-stops the GraphQL query at GraphQL **CRITICAL**: serves the existing `_batchProgressCache` (even stale), else falls through to the existing REST gh-CLI fallback (#416) — which is gated on its own REST bucket.
- Resumption is automatic: the 60s rate-limit poll picks up the replenished GraphQL budget after its reset window.

## Acceptance criteria
- [x] `refreshRateLimit()` tracks both `.resources.core` and `.resources.graphql`
- [x] Both `refreshGraphQLCache()` AND the `/api/batch-progress` GraphQL call back off on the GraphQL remaining budget
- [x] GraphQL remaining < critical → no GraphQL queries from either stream; batch-progress serves cached/stale or REST fallback
- [x] Polling/serving resumes automatically after the GraphQL reset window
- [x] REST-side backoff behavior unchanged
- [x] `npm run build` passes

## Must-not-change (verified untouched)
Module-scope auto-start of polling, poll cadence/TTL, batched-query shapes, and REST-side gating (`isRateLimited()` still drives the REST stale-serve and the line-1326 REST fallback gate).

## Tests
New `server/routes.graphqlRateLimit.test.js` (6 cases, all pass): full budget → neither flag; below LOW → low only; below/at CRITICAL → both (strict `<` boundary checks); exhausted → both; bucket independence. `npm run build` green; existing `routes.*` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)