### PR TITLE
[#809] Seeds: agent discovery reads GITHUB.md instead of gh pr/issue list

### DIFF
--- a/templates/seeds/butler.CLAUDE.md
+++ b/templates/seeds/butler.CLAUDE.md
@@ -49,6 +49,8 @@ Butler is the cross-project operator assistant:
 
 Read `~/.quadwork/config.json` for project IDs, repos, and working directories. Access any repo via `gh -R owner/repo`. Know worktree layout: `<working_dir>-{head,dev,re1,re2}`.
 
+**Board discovery via GITHUB.md.** To see a project's issue/PR board state, read the server-authored per-project file `~/.quadwork/<project>/GITHUB.md` (or `GET http://127.0.0.1:8400/api/github-parsed?project=<project>`) instead of `gh pr list`/`gh issue list`. **Writes and correctness-critical reads stay direct, live `gh`:** `gh issue create`/`gh issue edit`, `gh release create`, and PR-review reads (`gh pr view`, `git diff`). **By-number / live fallback:** when acting on a specific number, use a single-object `gh` call directly; if GITHUB.md is absent or stale (`_stale` / older than ~2 cycles), do one direct `gh` read — never conclude "no work" from a stale or empty file.
+
 **Critical: project context isolation.** Butler manages multiple projects simultaneously. To prevent mixing contexts:
 - Always specify `-R owner/repo` when running `gh` commands — never rely on cwd
 - When discussing a project, state the project name at the start of each response

--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -50,6 +50,18 @@ The project's task queue lives at the absolute path:
 
 Head owns this file — do not edit it. Read it when you need context on the batch you're working in or want to see what's coming next.
 
+## GitHub State (discovery)
+For board context — what issues/PRs exist and their state — read the server-authored file instead of running `gh pr list`/`gh issue list`:
+
+```
+~/.quadwork/{{project_name}}/GITHUB.md
+```
+
+(or `GET http://127.0.0.1:8400/api/github-parsed?project={{project_name}}` for JSON). The server regenerates it from live GitHub each poll cycle.
+
+- Reading the **assigned issue** stays a live, by-number call: `gh issue view <n>` (the file is for context, not the source of truth for the issue you're implementing).
+- **By-number / live fallback:** Head assigns by issue number in chat — act on it directly; never gate its existence on the file. If the assigned issue is missing from GITHUB.md, or the file is stale (`_stale` true / older than ~2 cycles), just `gh issue view <n>` — **never conclude "no work" from a stale or empty file.**
+
 ## Role
 - Implement features, fix bugs, and refactor code as assigned by Head
 - Create feature branches, write code, and open PRs

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -48,10 +48,25 @@ When checking for mentions addressed to you, match your **base role name** regar
 - Final guard on all merges — verify RE1/RE2 approval exists before merging
 
 ## Allowed Actions
-- `gh issue create`, `gh issue edit`, `gh issue list`, `gh issue view`
-- `gh pr merge` (only after RE1/RE2 approval)
-- `gh pr list`, `gh pr view`, `gh pr checks`
+- `gh issue create`, `gh issue edit`, `gh issue view` (live, by number)
+- `gh pr merge` (only after RE1/RE2 approval + the live approval re-read below)
+- `gh pr view`, `gh pr checks` (live, by number)
+- `gh pr list` / `gh issue list` — **fallback only**, when GITHUB.md is absent or stale (see GitHub State below)
 - Read any file in the workspace
+
+## GitHub State (discovery)
+Discover the board — which issues/PRs exist, their state, and review status — by reading the server-authored file, NOT `gh pr list`/`gh issue list`:
+
+```
+~/.quadwork/{{project_name}}/GITHUB.md
+```
+
+(or `GET http://127.0.0.1:8400/api/github-parsed?project={{project_name}}` for the same data as JSON). The server regenerates it from live GitHub state every poll cycle.
+
+**Discovery is never authoritative for an action:**
+- **Before EVERY merge**, re-confirm approvals with a live read — `gh pr view <n> --json reviewDecision,reviews` — AND keep the chat-derived two-reviewer gate (read chat for both RE1 and RE2 approval messages for the current commit). Both are required. Never merge off the file's `## Review Detail` (it is ADVISORY only). Branch protection is the server-side backstop.
+- **Before `gh issue create`**, run a live duplicate-issue check (`gh issue list`/search for the same scope) — never create off the file.
+- **By-number / live fallback:** when handed a specific number, act on it directly via a single-object `gh` call — never gate its existence on the file. If expected work is missing from GITHUB.md, or the file is stale (`_stale` true / older than ~2 cycles), do a targeted `gh pr view <n>` / `gh issue view <n>` (or one `gh pr list`) — **never conclude "no work" from a stale or empty file.**
 
 ## Forbidden Actions
 - **NO coding** — do not create, edit, or write code files
@@ -76,7 +91,7 @@ This is an **absolute path** — read it with the full path, never a relative on
 
 ### Operator → Head flow
 When the operator asks you in chat to start a task or batch:
-1. Create the GitHub issue(s) if they don't already exist (`gh issue create` with scope, acceptance, and `agent/*` labels).
+1. Create the GitHub issue(s) if they don't already exist — run a **live** duplicate check first (`gh issue list`/search; do not rely on GITHUB.md), then `gh issue create` with scope, acceptance, and `agent/*` labels.
 2. Append the task(s) under the **Backlog** section of `OVERNIGHT-QUEUE.md`, or move them into **Active Batch** if the operator says they're ready to run.
 
    **Batch numbering.** Each new batch you put into Active Batch gets the next sequential number. Read every `**Batch:** N` line in the file (Active Batch + Done) and use `max(N) + 1`. If no batches exist yet, start at `1`. Stamp the Active Batch section with:
@@ -116,8 +131,8 @@ When the operator asks you in chat to start a task or batch:
 ## Workflow
 1. Receive task request (from the operator in chat, or as the next item in `OVERNIGHT-QUEUE.md`) → create GitHub issue if needed.
 2. @dev to assign implementation — then **wait silently**. Do NOT route to reviewers; Dev handles that.
-3. Wait for Dev to confirm reviewers approved. Before merging, verify by reading the chat history for **both** RE1 and RE2 approval messages for this PR. Do NOT rely solely on Dev's claim.
-4. Merge: `gh pr merge <number> --merge`
+3. Wait for Dev to confirm reviewers approved. Before merging, verify by reading the chat history for **both** RE1 and RE2 approval messages for this PR's current commit. Do NOT rely solely on Dev's claim, and do NOT rely on GITHUB.md's `## Review Detail` (advisory only).
+4. **Immediately before merging, re-confirm approvals live**: `gh pr view <number> --json reviewDecision,reviews` (in addition to the chat two-reviewer gate in step 3). Then merge: `gh pr merge <number> --merge`.
 5. Update `OVERNIGHT-QUEUE.md` (move the item from Active Batch to Done) and update the issue status.
 
 ## Communication

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -51,6 +51,19 @@ The project's task queue lives at the absolute path:
 
 Head owns this file — do not edit it. Read it when you need context on the batch the PR under review belongs to.
 
+## GitHub State (discovery)
+Discover **which open PRs are yours to review** — those you were @mentioned on — by reading the server-authored file instead of `gh pr list`/`gh issue list`:
+
+```
+~/.quadwork/{{project_name}}/GITHUB.md
+```
+
+(or `GET http://127.0.0.1:8400/api/github-parsed?project={{project_name}}` for JSON — `## Open PRs` lists open PRs). The server regenerates it from live GitHub each poll cycle.
+
+**The review itself is ALWAYS live — never review off the file:**
+- Read the code with live `gh pr diff <n>` / `gh pr view <n>`, and CI with live `gh pr checks <n>`. **Never APPROVE off cached CI or cached code** — the file's status can lag.
+- **By-number fallback:** you are bound to a PR by a chat @mention carrying its number — act on that number directly; never gate its existence on the file. If the @mentioned PR is missing from GITHUB.md, or the file is stale (`_stale` true / older than ~2 cycles), just `gh pr view <n>` / `gh pr diff <n>` — **never conclude "nothing to review" from a stale or empty file.**
+
 ## Role
 - Review pull requests for correctness, design, and code quality
 - Post structured PR reviews via `gh pr review`
@@ -58,9 +71,10 @@ Head owns this file — do not edit it. Read it when you need context on the bat
 - You have VETO authority on design decisions
 
 ## Allowed Actions
-- `gh pr view`, `gh pr diff`, `gh pr checks`
+- `gh pr view`, `gh pr diff`, `gh pr checks` — **always live** (review off live code + CI, never cached)
 - `gh pr review --approve`, `gh pr review --request-changes`, `gh pr review --comment`
-- `gh issue view`, `gh issue list`
+- `gh issue view` (live, by number)
+- `gh issue list` — **fallback only**, when GITHUB.md is absent or stale (see GitHub State above)
 - Read any file in the workspace
 
 ## GitHub Authentication
@@ -118,7 +132,7 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 
 ## Workflow
 1. Receive review request from Dev with PR number
-2. Read the PR: `gh pr view <number>`, `gh pr diff <number>`
+2. Read the PR live: `gh pr view <number>`, `gh pr diff <number>`, and CI via `gh pr checks <number>` — review off live code + CI, never GITHUB.md's cached status
 3. Read related issue: `gh issue view <number>`
 4. Review code against checklist
 5. Post review: `gh pr review <number> --approve/--request-changes --body "..."`

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -51,6 +51,19 @@ The project's task queue lives at the absolute path:
 
 Head owns this file — do not edit it. Read it when you need context on the batch the PR under review belongs to.
 
+## GitHub State (discovery)
+Discover **which open PRs are yours to review** — those you were @mentioned on — by reading the server-authored file instead of `gh pr list`/`gh issue list`:
+
+```
+~/.quadwork/{{project_name}}/GITHUB.md
+```
+
+(or `GET http://127.0.0.1:8400/api/github-parsed?project={{project_name}}` for JSON — `## Open PRs` lists open PRs). The server regenerates it from live GitHub each poll cycle.
+
+**The review itself is ALWAYS live — never review off the file:**
+- Read the code with live `gh pr diff <n>` / `gh pr view <n>`, and CI with live `gh pr checks <n>`. **Never APPROVE off cached CI or cached code** — the file's status can lag.
+- **By-number fallback:** you are bound to a PR by a chat @mention carrying its number — act on that number directly; never gate its existence on the file. If the @mentioned PR is missing from GITHUB.md, or the file is stale (`_stale` true / older than ~2 cycles), just `gh pr view <n>` / `gh pr diff <n>` — **never conclude "nothing to review" from a stale or empty file.**
+
 ## Role
 - Review pull requests for correctness, design, and code quality
 - Post structured PR reviews via `gh pr review`
@@ -58,9 +71,10 @@ Head owns this file — do not edit it. Read it when you need context on the bat
 - You have VETO authority on design decisions
 
 ## Allowed Actions
-- `gh pr view`, `gh pr diff`, `gh pr checks`
+- `gh pr view`, `gh pr diff`, `gh pr checks` — **always live** (review off live code + CI, never cached)
 - `gh pr review --approve`, `gh pr review --request-changes`, `gh pr review --comment`
-- `gh issue view`, `gh issue list`
+- `gh issue view` (live, by number)
+- `gh issue list` — **fallback only**, when GITHUB.md is absent or stale (see GitHub State above)
 - Read any file in the workspace
 
 ## GitHub Authentication
@@ -118,7 +132,7 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 
 ## Workflow
 1. Receive review request from Dev with PR number
-2. Read the PR: `gh pr view <number>`, `gh pr diff <number>`
+2. Read the PR live: `gh pr view <number>`, `gh pr diff <number>`, and CI via `gh pr checks <number>` — review off live code + CI, never GITHUB.md's cached status
 3. Read related issue: `gh issue view <number>`
 4. Review code against checklist
 5. Post review: `gh pr review <number> --approve/--request-changes --body "..."`


### PR DESCRIPTION
Closes #809. Part of #805 (step 4) — behavioral cutover (prompt-level).

## What
Edit the 5 seed prompts so steady-state **discovery** reads `GITHUB.md` / `GET /api/github-parsed` instead of `gh pr list` / `gh issue list`. **All writes and correctness-critical reads stay direct, LIVE `gh`.**

| Agent | Discovery → file | Stays direct, LIVE `gh` |
|---|---|---|
| HEAD | board via GITHUB.md | `gh pr merge`; **mandatory `gh pr view --json reviewDecision,reviews` re-read immediately before merge**; live duplicate-issue check; `gh issue create/edit` |
| DEV | board context via GITHUB.md | `gh pr create`, `gh issue view <n>` |
| RE1/RE2 | `## Open PRs` for @mentioned PRs | `gh pr review`, `gh pr diff`/`view`, **`gh pr checks` (never APPROVE off cached CI)** |
| BUTLER | per-project GITHUB.md | `gh issue create/edit`, `gh release create` |

## Hard requirements (folded in as rules, not caveats)
- **HEAD keeps the chat-derived two-reviewer gate AND re-confirms approvals via a live `gh pr view` immediately before every `gh pr merge`.** `## Review Detail` is advisory only; branch protection is the server-side backstop.
- **By-number / live fallback:** when @mentioned with a number, act on it directly via a single-object `gh` call — never gate existence on the file. When expected work is **missing from the file, or the file is stale (`_stale` / >2 cycles)**, do a targeted `gh pr view <n>` / `gh issue view <n>` — **never conclude "no work."**
- **Reviewers' code (`gh pr diff`/`view`) and CI (`gh pr checks`) are always live** — never a stale-code or stale-CI verdict.
- HEAD's pre-create **duplicate-issue check** is live.

## Acceptance criteria
- [x] Steady-state prompt discovery reads GITHUB.md / `/api/github-parsed` instead of `gh pr list`
- [x] HEAD re-confirms approvals via a live `gh pr view` immediately before every merge; chat two-reviewer gate retained
- [x] Reviewers' CI (`gh pr checks`) and diffs always live; HEAD's duplicate-issue pre-check live
- [x] By-number/live fallback for @mentioned, missing, or stale-file work — never "no work" off a stale/empty file
- [x] Enforcement is prompt-level (no "0 discovery calls" claim — a `gh` shim would be needed, out of scope)
- [x] `npm run build` passes

## Notes
- Prompt/seed text only — no code paths touched.
- **Rollout is operational, not in this PR:** per the ticket, re-seed + restart each team at a **batch boundary** (never mid-batch) so agents don't run in mixed state. This PR only updates the templates that a re-seed copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)