### PR TITLE
[#814] Move Idle control to sidebar as an Active/Inactive switch (+ Settings status)

### DIFF
--- a/src/components/ActiveSwitch.tsx
+++ b/src/components/ActiveSwitch.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+// #814: compact Active/Inactive switch. ON (accent #00ff88) = Active
+// (idle:false), OFF (muted) = Inactive/parked (idle:true) — the switch shows
+// `active = !project.idle`. Sharp-cornered, monospace aesthetic — deliberately
+// NOT the rounded iOS-blue style. Stops click propagation so it works inside a
+// clickable nav row.
+interface ActiveSwitchProps {
+  active: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+  title?: string;
+}
+
+export default function ActiveSwitch({ active, onToggle, disabled, title }: ActiveSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={active}
+      disabled={disabled}
+      title={title || (active ? "Active — click to set Inactive (park)" : "Inactive — click to set Active (resume)")}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!disabled) onToggle();
+      }}
+      className={`relative inline-flex h-3.5 w-7 shrink-0 items-center border transition-colors duration-150 disabled:opacity-50 ${
+        active ? "border-accent bg-accent/15" : "border-border bg-transparent hover:border-text-muted"
+      }`}
+    >
+      <span
+        className={`block h-2.5 w-2.5 transition-transform duration-150 ${
+          active ? "translate-x-[14px] bg-accent" : "translate-x-[2px] bg-text-muted"
+        }`}
+      />
+    </button>
+  );
+}

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+// #814: small reusable confirmation modal (dark / sharp-corners / monospace).
+// Used for the "Set Inactive?" confirmation in the sidebar and settings.
+interface ConfirmModalProps {
+  title: string;
+  body: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmModal({
+  title,
+  body,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  // Esc cancels.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onCancel(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70"
+      onClick={onCancel}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="mx-4 max-w-sm border border-border bg-bg-surface p-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-2 text-[13px] font-semibold text-text">{title}</h2>
+        <p className="mb-4 text-[11px] leading-relaxed text-text-muted">{body}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="border border-border px-3 py-1 text-[11px] text-text-muted transition-colors hover:text-text"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="border border-accent bg-accent/10 px-3 py-1 text-[11px] font-semibold text-accent transition-colors hover:bg-accent/20"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -9,6 +9,7 @@ import ControlBar from "./ControlBar";
 import AgentTerminalsGrid from "./AgentTerminalsGrid";
 import OperatorFeaturesPanel from "./OperatorFeaturesPanel";
 import { useLocale } from "@/components/LocaleProvider";
+import { onIdleChange } from "@/lib/idle";
 
 const MIN_SIZE = 150; // px
 const DIVIDER = 4; // px
@@ -129,8 +130,11 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
   // (project.idle). When idle, the server suspends all GitHub polling /
   // triggers / bridge auto-lifecycle for this project, and the dashboard
   // stops its own batch-progress pollers. Agent terminals stay viewable.
+  // #814: the Active/Inactive control moved to the sidebar / settings. The
+  // dashboard no longer owns the toggle — it loads idle from config on mount
+  // and reacts to the shared idle signal so its pollers start/stop live when
+  // the operator flips the switch elsewhere (no manual reload).
   const [idle, setIdle] = useState(false);
-  const [idleError, setIdleError] = useState(false);
   const idleLoadedRef = useRef(false);
   useEffect(() => {
     idleLoadedRef.current = false;
@@ -143,60 +147,14 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
       .then((cfg) => {
         if (!cfg) return;
         const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
-        if (entry?.idle) setIdle(true);
+        setIdle(!!entry?.idle);
         idleLoadedRef.current = true;
       })
       .catch(() => {});
   }, [projectId]);
-  const toggleIdle = useCallback(() => {
-    const next = !idle;
-    // Optimistic flip so polling responds instantly.
-    setIdle(next);
-    setIdleError(false);
-    // Persist to config. The server's syncTriggers hook fires on this PUT
-    // and clears any running trigger for a now-idle project (#812), so no
-    // separate stop call is needed. If persistence fails, REVERT the local
-    // flag so the dashboard's polling state can't desync from the server.
-    (async () => {
-      try {
-        const r = await fetch("/api/config");
-        if (!r.ok) throw new Error("config read failed");
-        const cfg = await r.json();
-        const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
-        if (!entry) throw new Error("project not found in config");
-        entry.idle = next;
-        const put = await fetch("/api/config", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(cfg),
-        });
-        if (!put.ok) throw new Error("config write failed");
-      } catch {
-        setIdle(!next); // revert — keep UI in sync with the unchanged server state
-        setIdleError(true);
-      }
-    })();
-  }, [idle, projectId]);
-  const idleToggle = useMemo(() => (
-    <button
-      type="button"
-      onClick={toggleIdle}
-      title={idleError
-        ? "Failed to save idle state — reverted. Click to retry."
-        : idle
-          ? "Project is idle — GitHub polling, triggers & bridges are paused. Click to resume."
-          : "Idle this project — pause all GitHub polling, triggers & bridge auto-lifecycle. Click to park."}
-      className={`px-1.5 py-0.5 text-[10px] border transition-colors ${
-        idleError
-          ? "border-error/60 text-error hover:bg-error/10"
-          : idle
-            ? "border-accent/50 text-accent bg-accent/10 hover:bg-accent/20"
-            : "border-border text-text-muted hover:text-text hover:border-accent"
-      }`}
-    >
-      {idleError ? "Idle !" : idle ? "Idle ●" : "Idle ○"}
-    </button>
-  ), [idle, idleError, toggleIdle]);
+  useEffect(() => onIdleChange(({ projectId: pid, idle: next }) => {
+    if (pid === projectId) setIdle(next);
+  }), [projectId]);
 
   // Poll agent states
   useEffect(() => {
@@ -346,9 +304,7 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
             <InfoTooltip>
               {t.githubTooltip}
             </InfoTooltip>
-          }>
-            {idleToggle}
-          </PanelHeader>
+          } />
           <div className="flex-1 min-h-0">
             <GitHubPanel projectId={projectId} idle={idle} />
           </div>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -4,6 +4,9 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { useLocale } from "@/components/LocaleProvider";
 import { MODEL_OPTIONS, optionsForBackend } from "./AgentModelsWidget";
+import ActiveSwitch from "./ActiveSwitch";
+import ConfirmModal from "./ConfirmModal";
+import { persistProjectIdle, onIdleChange, idleConfirmTitle, IDLE_CONFIRM_BODY } from "@/lib/idle";
 
 interface AgentConfig {
   display_name: string;
@@ -24,6 +27,7 @@ interface ProjectConfig {
   working_dir: string;
   agents: Record<string, AgentConfig>;
   archived?: boolean;
+  idle?: boolean;
 }
 
 interface ButlerConfig {
@@ -277,6 +281,39 @@ export default function SettingsPage() {
   const [saved, setSaved] = useState(false);
   const savedConfigRef = useRef<string>("");
   const [butlerStartConfig, setButlerStartConfig] = useState<{ command: string; model: string } | null>(null);
+  // #814: pending "Set Inactive?" confirmation (null = no modal).
+  const [idleConfirm, setIdleConfirm] = useState<{ id: string; name: string } | null>(null);
+
+  // Keep the saved snapshot's idle in lockstep with an idle toggle. Idle is
+  // persisted immediately (out of band from the batched Save), so without this
+  // it would falsely register as an unsaved change (isDirty) and a later Save
+  // could clobber an idle change made in the sidebar.
+  const syncSavedIdle = useCallback((projectId: string, idle: boolean) => {
+    try {
+      const saved = JSON.parse(savedConfigRef.current);
+      const sp = (saved.projects || []).find((p: { id: string }) => p.id === projectId);
+      if (sp) { sp.idle = idle; savedConfigRef.current = JSON.stringify(saved); }
+    } catch { /* no saved snapshot yet */ }
+  }, []);
+
+  const setProjectIdleLocal = useCallback((projectId: string, idle: boolean) => {
+    setConfig((prev) => (prev ? { ...prev, projects: prev.projects.map((p) => (p.id === projectId ? { ...p, idle } : p)) } : prev));
+    syncSavedIdle(projectId, idle);
+  }, [syncSavedIdle]);
+
+  // Optimistic local flip + immediate persist + revert on failure.
+  const applyIdle = useCallback((projectId: string, nextIdle: boolean) => {
+    setProjectIdleLocal(projectId, nextIdle);
+    persistProjectIdle(projectId, nextIdle).catch(() => setProjectIdleLocal(projectId, !nextIdle));
+  }, [setProjectIdleLocal]);
+
+  const handleToggleActive = useCallback((project: ProjectConfig) => {
+    if (!project.idle) setIdleConfirm({ id: project.id, name: project.name });
+    else applyIdle(project.id, false);
+  }, [applyIdle]);
+
+  // Re-sync when idle is changed elsewhere (sidebar, dashboard).
+  useEffect(() => onIdleChange(({ projectId, idle }) => setProjectIdleLocal(projectId, idle)), [setProjectIdleLocal]);
   // #212: drop the per-project accordion. AGENTS.md edit toggles
   // still need a per-key flag, so we keep `expanded` but no longer
   // gate the project body on it — every project is open by default.
@@ -833,6 +870,14 @@ export default function SettingsPage() {
               {/* Header — #212: no accordion, body always visible */}
               <div className="flex items-center justify-between px-3 py-2">
                 <span className="text-[12px] text-text font-semibold">{project.name}</span>
+                {/* #814: per-project Active/Inactive status + switch (same source
+                    of truth + confirmation as the sidebar). */}
+                <div className="flex items-center gap-2">
+                  <span className={`text-[10px] uppercase tracking-wider ${project.idle ? "text-text-muted" : "text-accent"}`}>
+                    {project.idle ? "Inactive" : "Active"}
+                  </span>
+                  <ActiveSwitch active={!project.idle} onToggle={() => handleToggleActive(project)} />
+                </div>
               </div>
 
               {(
@@ -1073,6 +1118,16 @@ export default function SettingsPage() {
             {saving ? t.saving : t.save}
           </button>
         </div>
+      )}
+
+      {idleConfirm && (
+        <ConfirmModal
+          title={idleConfirmTitle(idleConfirm.name)}
+          body={IDLE_CONFIRM_BODY}
+          confirmLabel="Set Inactive"
+          onConfirm={() => { applyIdle(idleConfirm.id, true); setIdleConfirm(null); }}
+          onCancel={() => setIdleConfirm(null)}
+        />
       )}
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,9 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import ActiveSwitch from "./ActiveSwitch";
+import ConfirmModal from "./ConfirmModal";
+import { persistProjectIdle, onIdleChange, idleConfirmTitle, IDLE_CONFIRM_BODY } from "@/lib/idle";
 
 function HamburgerIcon() {
   return (
@@ -23,6 +26,7 @@ function CloseXIcon() {
 interface Project {
   id: string;
   name: string;
+  idle?: boolean;
 }
 
 interface SidebarGroup {
@@ -132,60 +136,80 @@ interface ProjectIconProps {
   pinned: boolean;
   hasActiveBatch: boolean;
   onContextMenu: (e: React.MouseEvent, projectId: string) => void;
+  onToggleActive: (project: Project) => void;
 }
 
-function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onContextMenu }: ProjectIconProps) {
+function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onContextMenu, onToggleActive }: ProjectIconProps) {
   const [tooltip, setTooltip] = useState<{ top: number } | null>(null);
   const ref = useRef<HTMLAnchorElement>(null);
 
-  return (
-    <>
-      <Link
-        ref={ref}
-        href={`/project/${project.id}`}
-        className={`flex items-center gap-2 ${expanded ? "w-full px-2" : ""} rounded-sm transition-colors ${
-          !expanded ? "" : isActive ? "bg-[#1a1a1a]" : "hover:bg-[#1a1a1a]"
-        }`}
-        onMouseEnter={() => {
-          if (expanded) return;
-          const rect = ref.current?.getBoundingClientRect();
-          if (rect) setTooltip({ top: rect.top + rect.height / 2 });
-        }}
-        onMouseLeave={() => setTooltip(null)}
-        onContextMenu={(e) => onContextMenu(e, project.id)}
-      >
-        <div className="relative shrink-0">
-          <div
-            className={`w-10 h-10 flex items-center justify-center rounded-full text-[11px] font-semibold uppercase tracking-tight transition-colors ${
-              isActive
-                ? "border-2 border-accent text-accent"
-                : "border border-border text-text-muted hover:text-text"
-            } ${hasActiveBatch ? "animate-pulse-ring" : ""}`}
-          >
-            {project.name.slice(0, 2) || "?"}
-          </div>
-          {pinned && !expanded && (
-            <div className="absolute -top-1 -right-1 text-accent">
-              <PinIcon size={8} />
-            </div>
-          )}
-        </div>
-        {expanded && (
-          <span className={`text-xs truncate flex items-center gap-1 ${isActive ? "text-accent" : "text-text-muted"}`}>
-            {project.name}
-            {pinned && <PinIcon size={10} />}
-          </span>
-        )}
-      </Link>
-      {!expanded && tooltip && (
+  const link = (
+    <Link
+      ref={ref}
+      href={`/project/${project.id}`}
+      className={`flex items-center gap-2 ${expanded ? "flex-1 min-w-0" : ""} rounded-sm transition-colors`}
+      onMouseEnter={() => {
+        if (expanded) return;
+        const rect = ref.current?.getBoundingClientRect();
+        if (rect) setTooltip({ top: rect.top + rect.height / 2 });
+      }}
+      onMouseLeave={() => setTooltip(null)}
+      onContextMenu={(e) => onContextMenu(e, project.id)}
+    >
+      <div className="relative shrink-0">
         <div
-          className="fixed px-2 py-1 bg-bg-surface border border-border text-text text-xs whitespace-nowrap pointer-events-none z-50"
-          style={{ left: 72, top: tooltip.top, transform: "translateY(-50%)" }}
+          className={`w-10 h-10 flex items-center justify-center rounded-full text-[11px] font-semibold uppercase tracking-tight transition-colors ${
+            isActive
+              ? "border-2 border-accent text-accent"
+              : "border border-border text-text-muted hover:text-text"
+          } ${hasActiveBatch ? "animate-pulse-ring" : ""}`}
         >
-          {pinned && "📌 "}{project.name}
+          {project.name.slice(0, 2) || "?"}
         </div>
+        {pinned && !expanded && (
+          <div className="absolute -top-1 -right-1 text-accent">
+            <PinIcon size={8} />
+          </div>
+        )}
+      </div>
+      {expanded && (
+        <span className={`text-xs truncate flex items-center gap-1 ${isActive ? "text-accent" : "text-text-muted"}`}>
+          {project.name}
+          {pinned && <PinIcon size={10} />}
+        </span>
       )}
-    </>
+    </Link>
+  );
+
+  // Collapsed (icon-only) rail: just the link + hover tooltip — no switch room.
+  if (!expanded) {
+    return (
+      <>
+        {link}
+        {tooltip && (
+          <div
+            className="fixed px-2 py-1 bg-bg-surface border border-border text-text text-xs whitespace-nowrap pointer-events-none z-50"
+            style={{ left: 72, top: tooltip.top, transform: "translateY(-50%)" }}
+          >
+            {pinned && "📌 "}{project.name}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  // Expanded: nav row with the Active/Inactive switch on the right. The switch
+  // is a sibling of the Link (not nested) and stops propagation, so toggling
+  // never navigates.
+  return (
+    <div
+      className={`flex items-center w-full px-2 rounded-sm transition-colors ${
+        isActive ? "bg-[#1a1a1a]" : "hover:bg-[#1a1a1a]"
+      }`}
+    >
+      {link}
+      <ActiveSwitch active={!project.idle} onToggle={() => onToggleActive(project)} />
+    </div>
   );
 }
 
@@ -212,6 +236,30 @@ export default function Sidebar() {
   const [version, setVersion] = useState<string>("");
   const configRef = useRef<Record<string, unknown> | null>(null);
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
+  // #814: pending "Set Inactive?" confirmation (null = no modal open).
+  const [idleConfirm, setIdleConfirm] = useState<{ id: string; name: string } | null>(null);
+
+  // Optimistically flip a project's idle flag, persist, and revert on failure.
+  const applyIdle = useCallback((projectId: string, nextIdle: boolean) => {
+    setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, idle: nextIdle } : p)));
+    persistProjectIdle(projectId, nextIdle).catch(() => {
+      setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, idle: !nextIdle } : p)));
+    });
+  }, []);
+
+  // Going Inactive (parking) requires confirmation; resuming is safe.
+  const handleToggleActive = useCallback((project: Project) => {
+    if (!project.idle) {
+      setIdleConfirm({ id: project.id, name: project.name });
+    } else {
+      applyIdle(project.id, false);
+    }
+  }, [applyIdle]);
+
+  // Re-sync when idle is changed elsewhere (settings, dashboard, other tab view).
+  useEffect(() => onIdleChange(({ projectId, idle }) => {
+    setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, idle } : p)));
+  }), []);
 
   // Close mobile overlay on navigation
   useEffect(() => {
@@ -461,6 +509,7 @@ export default function Sidebar() {
                 pinned
                 hasActiveBatch={activeBatches.has(project.id)}
                 onContextMenu={handleContextMenu}
+                onToggleActive={handleToggleActive}
               />
             ))}
             <div className={`h-px bg-border ${isExpanded ? "" : "w-6"}`} />
@@ -501,6 +550,7 @@ export default function Sidebar() {
                   pinned={false}
                   hasActiveBatch={activeBatches.has(project.id)}
                   onContextMenu={handleContextMenu}
+                  onToggleActive={handleToggleActive}
                 />
               ))}
             </div>
@@ -527,6 +577,7 @@ export default function Sidebar() {
             pinned={false}
             hasActiveBatch={activeBatches.has(project.id)}
             onContextMenu={handleContextMenu}
+            onToggleActive={handleToggleActive}
           />
         ))}
 
@@ -666,6 +717,16 @@ export default function Sidebar() {
         <div className={`text-[10px] text-text-muted/40 ${isExpanded ? "px-3" : "text-center"} pt-2`}>
           v{version}
         </div>
+      )}
+
+      {idleConfirm && (
+        <ConfirmModal
+          title={idleConfirmTitle(idleConfirm.name)}
+          body={IDLE_CONFIRM_BODY}
+          confirmLabel="Set Inactive"
+          onConfirm={() => { applyIdle(idleConfirm.id, true); setIdleConfirm(null); }}
+          onCancel={() => setIdleConfirm(null)}
+        />
       )}
     </>
   );

--- a/src/lib/idle.ts
+++ b/src/lib/idle.ts
@@ -1,0 +1,50 @@
+// #814: shared per-project Active/Inactive (idle) state. The source of truth is
+// `project.idle` in config (#812). Toggling persists via PUT /api/config — the
+// server's syncTriggers hook stops a now-idle project's trigger — and broadcasts
+// a lightweight in-tab signal so every open view (the dashboard's pollers, the
+// sidebar switch, the settings switch) re-syncs without a manual reload.
+
+export const IDLE_EVENT = "quadwork:idle-changed";
+
+export interface IdleChangeDetail {
+  projectId: string;
+  idle: boolean;
+}
+
+export function emitIdleChange(projectId: string, idle: boolean): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<IdleChangeDetail>(IDLE_EVENT, { detail: { projectId, idle } }));
+}
+
+// Subscribe to idle changes. Returns an unsubscribe fn (use directly in useEffect).
+export function onIdleChange(handler: (detail: IdleChangeDetail) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const listener = (e: Event) => handler((e as CustomEvent<IdleChangeDetail>).detail);
+  window.addEventListener(IDLE_EVENT, listener);
+  return () => window.removeEventListener(IDLE_EVENT, listener);
+}
+
+// Persist a project's idle flag: re-read the latest config, flip ONLY this
+// project's flag (preserving everything else), write it back. Throws on failure
+// so callers can revert their optimistic UI. Broadcasts on success.
+export async function persistProjectIdle(projectId: string, idle: boolean): Promise<void> {
+  const r = await fetch("/api/config");
+  if (!r.ok) throw new Error("config read failed");
+  const cfg = await r.json();
+  const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
+  if (!entry) throw new Error("project not found in config");
+  entry.idle = idle;
+  const put = await fetch("/api/config", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(cfg),
+  });
+  if (!put.ok) throw new Error("config write failed");
+  emitIdleChange(projectId, idle);
+}
+
+// Confirmation copy shown only when setting a project Inactive (parking it).
+// Resuming (→ Active) is safe and needs no confirmation.
+export const idleConfirmTitle = (name: string) => `Set "${name}" to Inactive?`;
+export const IDLE_CONFIRM_BODY =
+  "This pauses everything for this project: GitHub polling, the GitHub board & batch progress, scheduled triggers, and bridge auto-lifecycle. Agents stay running but won't be pulsed; the dashboard shows last-known data until you set it Active again.";


### PR DESCRIPTION
Closes #814. Follow-up to #812 (per-project Idle). UI-only — server gating unchanged.

## What
Reframes per-project Idle as an **Active/Inactive** switch (operators shouldn't reason about "idle") and moves it from the GitHub-panel header into the sidebar, plus the Settings page.

## How
- **`src/lib/idle.ts`** (new, shared source of truth):
  - `persistProjectIdle(id, idle)` — re-reads config, flips only that project's `idle`, PUTs (the server `syncTriggers` hook stops a now-idle project's trigger, #812); throws so callers can revert.
  - **Lightweight signal** `quadwork:idle-changed` (`emitIdleChange`/`onIdleChange`) — the ticket's sanctioned "re-read on a lightweight signal" so every open view re-syncs without a reload.
  - Confirmation copy.
- **`ActiveSwitch`** (new) — compact, sharp-cornered, accent `#00ff88` ON / muted OFF; shows `!project.idle`. Deliberately **not** the rounded iOS-blue style. Stops click propagation so it works inside a clickable nav row.
- **`ConfirmModal`** (new) — small dark/sharp modal, reused by sidebar + settings (Esc/overlay cancels).
- **Sidebar** — each expanded project row gets the switch on the right (sibling of the nav Link). Turning a project **OFF → Inactive** shows the confirmation modal explaining what idle pauses; turning **ON → resume** needs no confirmation. Optimistic + revert-on-failure; listens for the signal.
- **ProjectDashboard** — removed the `Idle ○/●` header button; it now loads idle on mount and **reacts to the signal so its pollers start/stop live** when toggled in the sidebar/settings (no manual reload). The BatchProgressPanel paused/idle empty state is kept.
- **SettingsPage** — per-project **Active/Inactive status + the same switch + confirmation**, persisted immediately; keeps the batched-Save snapshot's `idle` in lockstep (`syncSavedIdle`) so an idle toggle isn't flagged dirty or clobbered by a later Save.

## Acceptance criteria
- [x] Each sidebar project item has an Active/Inactive switch on the right; ON = active (default), OFF = idle
- [x] Turning OFF shows a confirmation popup explaining idle; turning ON does not
- [x] Switch persists `project.idle` and reverts on save failure
- [x] Old GitHub-panel-header idle button removed
- [x] Settings page shows per-project Active/Idle status with the same toggle + confirmation (same source of truth, stays consistent)
- [x] Toggling in the sidebar immediately starts/stops the open dashboard's polling (signal → dashboard updates `idle` → the 8 #812 poller guards react)
- [x] Server gating from #812 unchanged (UI-only)
- [x] `npm run build` passes

## Verification note
`npm run build` is green (TypeScript strict + ESLint clean); `/` (sidebar) and `/settings` render 200 in `next dev` against the live backend, `/api/config` proxies. I could **not** capture browser screenshots — Playwright/Chromium won't install on this host's OS (ubuntu 26.04 unsupported) — so the switch/modal visuals were built to the design tokens + DESIGN-GUIDE rather than pixel-verified. Reviewers with a browser may want to eyeball the switch sizing/contrast and the confirm-modal layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)