### PR TITLE
[#825] Reset self-heal breaker on manual agent stop/restart

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -514,6 +514,8 @@ async function spawnAgentPty(project, agent, opts = {}) {
           onRestart: () => {
             session._autoRecovering = true;
             console.log(`[self-heal] ${key}: thinking-block 400 detected — restarting session`);
+            // #825: NO clearSelfHeal here — the breaker window must persist
+            // across auto-restarts so repeated trips can pause auto-recovery.
             restartAgentSession(key, { reason: "thinking-block-400" })
               .then((result) => {
                 if (result && result.ok) {
@@ -557,7 +559,16 @@ async function spawnAgentPty(project, agent, opts = {}) {
   }
 }
 
-async function stopAgentSession(key) {
+async function stopAgentSession(key, { clearSelfHeal = false } = {}) {
+  // #825 (#797 follow-up): a MANUAL stop/restart/reset must reset the per-agent
+  // self-heal circuit-breaker window, so a fresh operator-driven session isn't
+  // suppressed by a stale "paused" state from a prior trip. This is gated:
+  // the auto-restart path (restartAgentSession with reason "thinking-block-400")
+  // leaves clearSelfHeal=false, because clearing on every auto-restart would
+  // reset countInWindow each time and defeat the #797 breaker entirely. Cleared
+  // before the session lookup so a manual stop resets the window even when no
+  // live session remains (e.g. the agent already exited).
+  if (clearSelfHeal) selfHeal.clearState(key);
   const session = agentSessions.get(key);
   if (!session) {
     agentSessions.set(key, { projectId: null, agentId: null, term: null, viewers: new Set(), viewerDims: new Map(), lastDims: null, state: "stopped", error: null });
@@ -628,7 +639,7 @@ app.post("/api/agents/:project/reset", async (req, res) => {
     for (const agentId of allAgentIds) {
       const s = agentSessions.get(`${projectId}/${agentId}`);
       if (s) s._suppressLifecycleMsg = true;
-      await stopAgentSession(`${projectId}/${agentId}`);
+      await stopAgentSession(`${projectId}/${agentId}`, { clearSelfHeal: true }); // #825: manual reset resets the self-heal window
     }
 
     // Respawn all agents with fresh MCP tokens
@@ -667,7 +678,7 @@ app.post("/api/full-reset", async (_req, res) => {
     console.log("[full-reset] stopping all agent sessions...");
     const sessionKeys = [...agentSessions.keys()];
     for (const key of sessionKeys) {
-      await stopAgentSession(key);
+      await stopAgentSession(key, { clearSelfHeal: true }); // #825: manual full-reset resets the self-heal window
     }
 
     console.log("[full-reset] stopping Butler...");
@@ -739,7 +750,7 @@ app.post("/api/agents/:project/:agent/start", async (req, res) => {
 app.post("/api/agents/:project/:agent/stop", async (req, res) => {
   const { project, agent } = req.params;
   const key = `${project}/${agent}`;
-  await stopAgentSession(key);
+  await stopAgentSession(key, { clearSelfHeal: true }); // #825: manual stop resets the self-heal window
   res.json({ ok: true, state: "stopped" });
 });
 
@@ -748,7 +759,7 @@ app.post("/api/agents/:project/:agent/stop", async (req, res) => {
 // #797: shared restart sequence, used by both the manual restart route and
 // the self-heal detector. Exactly the prior route body — no new lifecycle
 // logic. The `reason` is informational (logged by callers).
-async function restartAgentSession(key, { reason } = {}) {
+async function restartAgentSession(key, { reason, clearSelfHeal = false } = {}) {
   const [project, agent] = key.split("/");
   console.log(`[restart] ${key}: restarting session (reason: ${reason || "unspecified"})`);
 
@@ -756,7 +767,9 @@ async function restartAgentSession(key, { reason } = {}) {
   // the fresh register lands at slot 1 instead of head-2.
   const existing = agentSessions.get(key);
   if (existing) existing._suppressLifecycleMsg = true;
-  await stopAgentSession(key);
+  // #825: forward clearSelfHeal — a manual restart resets the breaker window;
+  // the self-heal auto-restart does NOT (preserves the #797 circuit breaker).
+  await stopAgentSession(key, { clearSelfHeal });
 
   return spawnAgentPty(project, agent, { suppressLifecycleMsg: true });
 }
@@ -765,7 +778,7 @@ app.post("/api/agents/:project/:agent/restart", async (req, res) => {
   const { project, agent } = req.params;
   const key = `${project}/${agent}`;
 
-  const result = await restartAgentSession(key, { reason: "manual" });
+  const result = await restartAgentSession(key, { reason: "manual", clearSelfHeal: true }); // #825
   if (result.ok) {
     emitSystemMessage(project, `${agent} restarted`);
     res.json({ ok: true, state: "running", pid: result.pid });

--- a/server/index.selfHealStop.test.js
+++ b/server/index.selfHealStop.test.js
@@ -1,0 +1,48 @@
+// #825 (#797 follow-up): wiring guard for self-heal breaker reset on manual
+// stop. server/index.js binds a port at require time, so it can't be unit-
+// required; this asserts the integration by source inspection (same approach as
+// rate-limit-handling.test.js). The behaviour that clearState actually resets a
+// tripped breaker is covered in self-heal.test.js (Test 7).
+//
+// Plain node:assert script — run with `node server/index.selfHealStop.test.js`.
+
+const fs = require("fs");
+const path = require("path");
+
+const src = fs.readFileSync(path.join(__dirname, "index.js"), "utf-8");
+
+function span(marker, len = 1400) {
+  const s = src.indexOf(marker);
+  return s === -1 ? "" : src.slice(s, s + len);
+}
+
+function run() {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  const stopFn = span("async function stopAgentSession(");
+  const restartFn = span("async function restartAgentSession(");
+
+  // stopAgentSession gates the clear behind a clearSelfHeal flag and calls
+  // selfHeal.clearState(key) — NOT an unconditional clear (which would reset the
+  // #797 breaker on every auto-restart, since restartAgentSession stops first).
+  ok(/stopAgentSession\(key,\s*\{\s*clearSelfHeal\s*=\s*false\s*\}\s*=\s*\{\}\)/.test(stopFn), "stopAgentSession takes { clearSelfHeal = false } (off by default)");
+  ok(/if\s*\(clearSelfHeal\)\s*selfHeal\.clearState\(key\)/.test(stopFn), "stopAgentSession clears self-heal state ONLY when clearSelfHeal is set");
+
+  // restartAgentSession forwards the flag to its internal stop.
+  ok(/restartAgentSession\(key,\s*\{\s*reason,\s*clearSelfHeal\s*=\s*false\s*\}/.test(restartFn), "restartAgentSession takes clearSelfHeal (default false)");
+  ok(/stopAgentSession\(key,\s*\{\s*clearSelfHeal\s*\}\)/.test(restartFn), "restartAgentSession forwards clearSelfHeal to stopAgentSession");
+
+  // The self-heal AUTO-restart must NOT clear (breaker window must persist).
+  ok(/restartAgentSession\(key,\s*\{\s*reason:\s*"thinking-block-400"\s*\}\)/.test(src), "auto-restart (thinking-block-400) does NOT pass clearSelfHeal → breaker preserved");
+
+  // Manual intervention paths DO reset the window.
+  ok(/restartAgentSession\(key,\s*\{\s*reason:\s*"manual",\s*clearSelfHeal:\s*true\s*\}\)/.test(src), "manual restart route passes clearSelfHeal: true");
+  ok(/stopAgentSession\(key,\s*\{\s*clearSelfHeal:\s*true\s*\}\)/.test(src), "manual stop / full-reset passes clearSelfHeal: true");
+  ok(/stopAgentSession\(`\$\{projectId\}\/\$\{agentId\}`,\s*\{\s*clearSelfHeal:\s*true\s*\}\)/.test(src), "project reset loop passes clearSelfHeal: true");
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();

--- a/server/self-heal.test.js
+++ b/server/self-heal.test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const selfHeal = require("./self-heal");
-const { observeChunk, isThinkingBlock400, breakerMessage, _state, COOLDOWN_MS } = selfHeal;
+const { observeChunk, isThinkingBlock400, breakerMessage, clearState, _state, COOLDOWN_MS } = selfHeal;
 
 // The real thinking-block 400 line emitted by claude on Opus 4.8.
 const SIGNATURE =
@@ -112,6 +112,34 @@ function runTests() {
     }
     assert(!threw, "detector swallows a throwing callback (PTY pipeline stays intact)");
     assert(result === "restart", "detection decision is still reported despite the callback throw");
+  }
+
+  // --- Test 7 (#825): clearState resets a tripped breaker, so a manual
+  //     stop+restart re-enables auto-recovery. stopAgentSession(key,
+  //     {clearSelfHeal:true}) calls clearState on every manual stop/restart/
+  //     reset; this asserts the module behaviour that makes that effective. ---
+  {
+    _state.clear();
+    let restarts = 0;
+    let breakerMsgs = [];
+    const mk = (now) => observeChunk(KEY, SIGNATURE, {
+      now, recovering: false,
+      onRestart: () => { restarts++; },
+      onBreaker: (m) => { breakerMsgs.push(m); },
+    });
+    const step = COOLDOWN_MS + 1000;
+    mk(step); mk(step * 2); mk(step * 3);          // 3 restarts → breaker trips
+    assert(restarts === 3 && mk(step * 4) === "breaker", "precondition: breaker tripped after 3 restarts");
+
+    // Operator manually stops the agent → stopAgentSession calls clearState.
+    clearState(KEY);
+    assert(!_state.has(KEY), "clearState drops the per-agent breaker/cooldown state");
+
+    // The fresh manual session's first thinking-block 400 auto-restarts again —
+    // NOT suppressed by the stale tripped window.
+    const after = mk(step * 5);
+    assert(after === "restart" && restarts === 4, "after clearState, auto-recovery works again (window reset, breaker no longer suppressing)");
+    assert(breakerMsgs.length === 1, "the reset did not re-emit the breaker message");
   }
 
   console.log(`\n${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
Closes #825. Follow-up to #797 (PR #815).

## Problem
The self-heal circuit-breaker state (`{ lastAutoRestartAt, countInWindow, ... }` per agent) was never cleared on a manual stop — `selfHeal.clearState(key)` wasn't called from `stopAgentSession`. So if an agent tripped the breaker (3 auto-restarts / 15 min → auto-recovery paused) and the operator then manually **stopped and restarted** it, the stale breaker state suppressed the fresh session's next legitimate auto-restart.

## Fix
`stopAgentSession(key, { clearSelfHeal = false })` now calls `selfHeal.clearState(key)` when the flag is set. It is **gated, not unconditional** — `stopAgentSession` is also the internal stop of `restartAgentSession`, which the self-heal **auto-restart** path uses. An unconditional clear there would reset `countInWindow` on every auto-restart and defeat the #797 breaker. So:

| Path | clearSelfHeal |
|------|---------------|
| manual `/stop` route | ✅ true |
| manual `/restart` route | ✅ true |
| project reset (`/reset`, #417) | ✅ true |
| full-reset (#657) | ✅ true |
| **auto-restart** (`reason: "thinking-block-400"`) | ❌ false (breaker preserved) |

`restartAgentSession` forwards the flag to its internal `stopAgentSession`. Cleared before the session lookup, so a manual stop resets the window even when no live session remains (agent already exited).

## Acceptance criteria
- [x] Manually stopping an agent clears its self-heal cooldown/circuit-breaker state
- [x] After a manual stop+restart, auto-recovery works again even if the breaker had tripped before
- [x] Existing self-heal tests still pass; added a case asserting clearState-on-stop
- [x] `npm run build` passes

## Tests
- `self-heal.test.js` **Test 7** (new): trip the breaker (3 restarts), `clearState`, then assert the next thinking-block 400 **auto-restarts again** (window reset, breaker no longer suppressing) and the breaker message isn't re-emitted — the module behaviour that makes a manual stop+restart re-enable auto-recovery. 20/20.
- `index.selfHealStop.test.js` (new): `server/index.js` binds a port at require time, so it isn't unit-requirable — this is a focused **source-guard** (same approach as the existing `rate-limit-handling` test) asserting the wiring: clear is gated on `clearSelfHeal`, the **auto-restart path does NOT pass it** (breaker preserved), and the four manual paths do. 8/8.
- `node --check` clean; `npm run build` green.

⚠️ Server-only change; no UI pixels. No GitHub checks are configured on this repo. Key design point for review: the clear is intentionally **gated** so it never fires on the self-heal auto-restart (which routes through `stopAgentSession`) — otherwise the #797 breaker would never trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)