### PR TITLE
[#826] Idle: live signal beats stale initial read; disable switch while saving

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -136,24 +136,39 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
   // the operator flips the switch elsewhere (no manual reload).
   const [idle, setIdle] = useState(false);
   const idleLoadedRef = useRef(false);
+  // #826: a live idle signal that arrives while the initial /api/config read is
+  // in flight is AUTHORITATIVE — the operator just toggled the switch, so the
+  // (possibly stale) config result must not overwrite it back. Tracked per
+  // mount/project and reset alongside idleLoadedRef.
+  const idleSignalRef = useRef(false);
   useEffect(() => {
     idleLoadedRef.current = false;
+    idleSignalRef.current = false;
     setIdle(false);
   }, [projectId]);
   useEffect(() => {
     if (idleLoadedRef.current) return;
+    // #826: guard against this read resolving after the project changed (a
+    // stale read from the prior project would otherwise set idle here).
+    let cancelled = false;
     fetch("/api/config")
       .then((r) => (r.ok ? r.json() : null))
       .then((cfg) => {
-        if (!cfg) return;
+        if (cancelled || !cfg) return;
+        idleLoadedRef.current = true;
+        // A live signal already set the authoritative value — don't clobber it.
+        if (idleSignalRef.current) return;
         const entry = (cfg.projects || []).find((p: { id: string }) => p.id === projectId);
         setIdle(!!entry?.idle);
-        idleLoadedRef.current = true;
       })
       .catch(() => {});
+    return () => { cancelled = true; };
   }, [projectId]);
   useEffect(() => onIdleChange(({ projectId: pid, idle: next }) => {
-    if (pid === projectId) setIdle(next);
+    if (pid === projectId) {
+      idleSignalRef.current = true;
+      setIdle(next);
+    }
   }), [projectId]);
 
   // Poll agent states

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -283,6 +283,9 @@ export default function SettingsPage() {
   const [butlerStartConfig, setButlerStartConfig] = useState<{ command: string; model: string } | null>(null);
   // #814: pending "Set Inactive?" confirmation (null = no modal).
   const [idleConfirm, setIdleConfirm] = useState<{ id: string; name: string } | null>(null);
+  // #826: project ids with an idle PUT in flight — disable the switch for them
+  // so a queued double-toggle can't race the persist.
+  const [idlePending, setIdlePending] = useState<Set<string>>(new Set());
 
   // Keep the saved snapshot's idle in lockstep with an idle toggle. Idle is
   // persisted immediately (out of band from the batched Save), so without this
@@ -304,7 +307,14 @@ export default function SettingsPage() {
   // Optimistic local flip + immediate persist + revert on failure.
   const applyIdle = useCallback((projectId: string, nextIdle: boolean) => {
     setProjectIdleLocal(projectId, nextIdle);
-    persistProjectIdle(projectId, nextIdle).catch(() => setProjectIdleLocal(projectId, !nextIdle));
+    setIdlePending((prev) => new Set(prev).add(projectId));
+    persistProjectIdle(projectId, nextIdle)
+      .catch(() => setProjectIdleLocal(projectId, !nextIdle))
+      .finally(() => setIdlePending((prev) => {
+        const next = new Set(prev);
+        next.delete(projectId);
+        return next;
+      }));
   }, [setProjectIdleLocal]);
 
   const handleToggleActive = useCallback((project: ProjectConfig) => {
@@ -876,7 +886,7 @@ export default function SettingsPage() {
                   <span className={`text-[10px] uppercase tracking-wider ${project.idle ? "text-text-muted" : "text-accent"}`}>
                     {project.idle ? "Inactive" : "Active"}
                   </span>
-                  <ActiveSwitch active={!project.idle} onToggle={() => handleToggleActive(project)} />
+                  <ActiveSwitch active={!project.idle} onToggle={() => handleToggleActive(project)} disabled={idlePending.has(project.id)} />
                 </div>
               </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -137,9 +137,10 @@ interface ProjectIconProps {
   hasActiveBatch: boolean;
   onContextMenu: (e: React.MouseEvent, projectId: string) => void;
   onToggleActive: (project: Project) => void;
+  togglePending?: boolean;
 }
 
-function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onContextMenu, onToggleActive }: ProjectIconProps) {
+function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onContextMenu, onToggleActive, togglePending }: ProjectIconProps) {
   const [tooltip, setTooltip] = useState<{ top: number } | null>(null);
   const ref = useRef<HTMLAnchorElement>(null);
 
@@ -208,7 +209,7 @@ function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onCo
       }`}
     >
       {link}
-      <ActiveSwitch active={!project.idle} onToggle={() => onToggleActive(project)} />
+      <ActiveSwitch active={!project.idle} onToggle={() => onToggleActive(project)} disabled={togglePending} />
     </div>
   );
 }
@@ -238,13 +239,25 @@ export default function Sidebar() {
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
   // #814: pending "Set Inactive?" confirmation (null = no modal open).
   const [idleConfirm, setIdleConfirm] = useState<{ id: string; name: string } | null>(null);
+  // #826: project ids with an idle PUT in flight — the switch is disabled for
+  // them so a queued double-toggle can't race the persist.
+  const [idlePending, setIdlePending] = useState<Set<string>>(new Set());
 
   // Optimistically flip a project's idle flag, persist, and revert on failure.
   const applyIdle = useCallback((projectId: string, nextIdle: boolean) => {
     setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, idle: nextIdle } : p)));
-    persistProjectIdle(projectId, nextIdle).catch(() => {
-      setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, idle: !nextIdle } : p)));
-    });
+    setIdlePending((prev) => new Set(prev).add(projectId));
+    persistProjectIdle(projectId, nextIdle)
+      .catch(() => {
+        setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, idle: !nextIdle } : p)));
+      })
+      .finally(() => {
+        setIdlePending((prev) => {
+          const next = new Set(prev);
+          next.delete(projectId);
+          return next;
+        });
+      });
   }, []);
 
   // Going Inactive (parking) requires confirmation; resuming is safe.
@@ -510,6 +523,7 @@ export default function Sidebar() {
                 hasActiveBatch={activeBatches.has(project.id)}
                 onContextMenu={handleContextMenu}
                 onToggleActive={handleToggleActive}
+                togglePending={idlePending.has(project.id)}
               />
             ))}
             <div className={`h-px bg-border ${isExpanded ? "" : "w-6"}`} />
@@ -551,6 +565,7 @@ export default function Sidebar() {
                   hasActiveBatch={activeBatches.has(project.id)}
                   onContextMenu={handleContextMenu}
                   onToggleActive={handleToggleActive}
+                  togglePending={idlePending.has(project.id)}
                 />
               ))}
             </div>
@@ -578,6 +593,7 @@ export default function Sidebar() {
             hasActiveBatch={activeBatches.has(project.id)}
             onContextMenu={handleContextMenu}
             onToggleActive={handleToggleActive}
+            togglePending={idlePending.has(project.id)}
           />
         ))}
 


### PR DESCRIPTION
Closes #826. Follow-up to #814 (PR #823).

## Problem (race)
`ProjectDashboard` reads `idle` from `/api/config` on mount (async) AND subscribes to the shared idle signal (`onIdleChange`). They race:
1. Dashboard mounts → `GET /api/config` starts (idle=false).
2. Operator toggles the project Inactive in the sidebar → `onIdleChange` fires → dashboard sets idle=true (correct).
3. The earlier in-flight config read resolves with **stale** data → overwrites idle back to **false** (wrong).

The open dashboard's pollers then desync from the persisted idle state until a manual reload (`ProjectDashboard.tsx:143-157`).

## Fix
The live signal is now **authoritative** over the initial read:
- `idleSignalRef` records that a signal arrived for this project. The config-read resolution still marks `idleLoadedRef` done, but **skips `setIdle`** when a signal already landed — so a stale read can't clobber the operator's toggle.
- Added a `cancelled` cleanup guard so a read resolving **after a project switch** can't set idle for the wrong project (adjacent staleness, free to fix here).

## Minor (same PR, per the ticket)
`ActiveSwitch` already accepts `disabled`, but the callers never set it. `Sidebar` and `SettingsPage` now track an `idlePending` set (added on toggle, cleared in the persist `.finally`) and pass `disabled={pending}` to the switch, so a queued double-toggle can't race the in-flight PUT. Threaded through `ProjectIcon` to all three sidebar render sites; covers both the **park** (confirm modal) and **resume** paths (both route through `applyIdle`).

## Acceptance criteria
- [x] Toggling idle elsewhere while the dashboard is mounting is not overwritten by the initial config read
- [x] The dashboard's pollers reflect the final toggled state without a manual reload (signal authoritative; `cancelled` guard for project switches)
- [x] `ActiveSwitch` blocks repeat clicks while a save is pending (disabled during the PUT, in sidebar + settings, park + resume)
- [x] `npm run build` passes

## Verification
`npm run build` green; no new lint errors (the pre-existing `set-state-in-effect` warnings on the mount/reset effects are unchanged — the `setIdle(false)` reset predates this change, and the new signal/read `setIdle` calls live in async callbacks the rule permits). UI-only; #812 server gating unchanged.

⚠️ This repo has **no frontend test harness** (jest isn't wired; the test suite is server-side `node` scripts), so — as with #823 — the change is verified by build + static review rather than a unit test. A browser eyeball of the disabled switch during a toggle would be a nice-to-have; I can't capture screenshots here (Chromium won't install on this host). No GitHub checks are configured on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)