### PR TITLE
[#827] Hardening: NaN-staleness guard, idle GITHUB.md write race, normalizeMentions test

### DIFF
--- a/server/routes.idleGithubWrite.test.js
+++ b/server/routes.idleGithubWrite.test.js
@@ -1,0 +1,66 @@
+// #827 item 2: writeGithubFileFromSnapshot must no-op for an idle project. The
+// caller (syncGithubFilesForRepo) filters idle from a config snapshot taken
+// earlier, so an idle-flip racing a setup-seed/refresh could otherwise still
+// author a parked project's GITHUB.md. The writer now re-checks isProjectIdle
+// (reads config fresh) before touching the filesystem.
+//
+// routes.js holds the shared `fs` module object (const fs = require("fs")), so
+// stubbing fs here controls isProjectIdle's config read AND lets us assert no
+// write is attempted — without touching the real ~/.quadwork.
+//
+// Plain node:assert script — run with `node server/routes.idleGithubWrite.test.js`.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+const real = {
+  readFileSync: fs.readFileSync,
+  writeFileSync: fs.writeFileSync,
+  renameSync: fs.renameSync,
+  mkdirSync: fs.mkdirSync,
+  statSync: fs.statSync,
+};
+
+let cfgJson;
+const fsWrites = [];
+fs.readFileSync = (p, ...rest) => (p === CONFIG_PATH ? cfgJson : real.readFileSync(p, ...rest));
+fs.writeFileSync = (...args) => { fsWrites.push(args[0]); };
+fs.renameSync = (...args) => { fsWrites.push(args[1]); };
+fs.mkdirSync = () => {};
+fs.statSync = () => ({ mode: 0o700, isDirectory: () => true });
+
+const { writeGithubFileFromSnapshot } = require("./routes");
+
+const SNAPSHOT = { issues: [], prs: [], closedIssues: [], mergedPrs: [] };
+
+function run() {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  // 1) Idle project → no FS write at all (early return before authoring).
+  {
+    cfgJson = JSON.stringify({ projects: [{ id: "proj", repo: "o/r", idle: true }] });
+    fsWrites.length = 0;
+    writeGithubFileFromSnapshot("proj", "Proj", "o/r", SNAPSHOT, "ok");
+    ok(fsWrites.length === 0, "idle project → writeGithubFileFromSnapshot writes nothing");
+  }
+
+  // 2) Positive control: a non-idle project DOES proceed to author the file
+  //    (proves the no-op above is the idle guard, not a stubbing artifact).
+  {
+    cfgJson = JSON.stringify({ projects: [{ id: "proj", repo: "o/r", idle: false }] });
+    fsWrites.length = 0;
+    writeGithubFileFromSnapshot("proj", "Proj", "o/r", SNAPSHOT, "ok");
+    ok(fsWrites.some((p) => String(p).endsWith("GITHUB.md")), "active project → authors GITHUB.md (atomic tmp+rename)");
+  }
+
+  // restore
+  Object.assign(fs, real);
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();

--- a/server/routes.js
+++ b/server/routes.js
@@ -1340,8 +1340,11 @@ const GITHUB_FRESH_TTL_MS = 5 * 60_000;
 // Live staleness for /api/github-parsed: stale if the file says so, if we have
 // no generatedAt, or if the snapshot is older than the FIXED window. Pure so
 // the rate-limit edge case (unbounded age) is regression-tested directly.
+// #827: a NaN ageMs (Date.parse of a malformed/corrupted `generatedAt`) must
+// count as stale/unknown — NOT fresh. Without the guard, `NaN > window` is
+// false and staleness would be hidden exactly when the file is suspect.
 function _githubLiveStale(headerStale, ageMs) {
-  return headerStale || ageMs == null || ageMs > GITHUB_FRESH_TTL_MS;
+  return headerStale || ageMs == null || Number.isNaN(ageMs) || ageMs > GITHUB_FRESH_TTL_MS;
 }
 const GITHUB_SECTION_HEADERS = {
   openIssues: "Open Issues",
@@ -1492,6 +1495,11 @@ function _extractNotesBody(text) {
 // preserving its `## Notes`. status drives the freshness meta.
 function writeGithubFileFromSnapshot(projectId, projectName, repo, snapshot, status) {
   try {
+    // #827: re-check idle here (reads config fresh) — syncGithubFilesForRepo
+    // filtered on a config snapshot taken earlier, so an idle-flip concurrent
+    // with a setup-seed/refresh pass could otherwise still write a parked
+    // project's GITHUB.md. Defensive; idle projects must author nothing.
+    if (isProjectIdle(projectId)) return;
     const dir = path.join(CONFIG_DIR, projectId);
     const filePath = path.join(dir, "GITHUB.md");
     // Cold + total failure with nothing cached: leave the seeded template be.
@@ -2414,7 +2422,11 @@ router.get("/api/github-parsed", (req, res) => {
   // no new sync pass), age must stay visible. Compare against a FIXED window,
   // never adaptiveTTL (which is Infinity under critical rate-limit and would
   // hide unbounded staleness exactly when it matters).
-  const ageMs = parsed.generatedAt ? Date.now() - Date.parse(parsed.generatedAt) : null;
+  // #827: a malformed `generatedAt` → Date.parse NaN. Normalize to null so the
+  // response field is a clean "unknown age" (not NaN), and _githubLiveStale
+  // also treats NaN/null as stale rather than hiding staleness on a suspect file.
+  const rawAge = parsed.generatedAt ? Date.now() - Date.parse(parsed.generatedAt) : null;
+  const ageMs = Number.isNaN(rawAge) ? null : rawAge;
   return res.json({
     ...parsed,
     ageMs,
@@ -3430,3 +3442,6 @@ module.exports.gatherClosedPrPages = gatherClosedPrPages;
 module.exports.selectRecentMergedPrs = selectRecentMergedPrs;
 module.exports.pickLinkedPrFromSearch = pickLinkedPrFromSearch;
 module.exports.findLinkedPrByTitle = findLinkedPrByTitle;
+// #827: expose the GITHUB.md writer for the idle-no-op regression test. No
+// production callers outside this file.
+module.exports.writeGithubFileFromSnapshot = writeGithubFileFromSnapshot;

--- a/server/routes.normalizeMentions.test.js
+++ b/server/routes.normalizeMentions.test.js
@@ -57,5 +57,26 @@ const { normalizeMentions } = require("./routes");
   );
 }
 
-console.log("routes.normalizeMentions.test.js: all assertions passed (5 cases)");
+// 6) #827: command-context exclusion — a name immediately after a shell verb
+//    (run/exec/npx/checkout/...) is NOT mentionized. The implementation has
+//    always done this; this closes the #788 test gap so it can't regress.
+{
+  assert.equal(
+    normalizeMentions("npm run dev", "head"),
+    "npm run dev",
+    "`npm run dev` does not turn `dev` into @dev (run-verb context)",
+  );
+  assert.equal(
+    normalizeMentions("git checkout head and ping dev", "re1"),
+    "git checkout head and ping @dev",
+    "checkout-context `head` untouched, but a normal `dev` is still mentionized",
+  );
+  assert.equal(
+    normalizeMentions("path is /head/logs", "re1"),
+    "path is /head/logs",
+    "a name in a path segment (slash-delimited) is not mentionized",
+  );
+}
+
+console.log("routes.normalizeMentions.test.js: all assertions passed (6 cases)");
 process.exit(0);

--- a/server/routes.parseGithub.test.js
+++ b/server/routes.parseGithub.test.js
@@ -137,6 +137,9 @@ function run() {
     ok(_githubLiveStale(false, 1000) === false, "fresh data (age within window) → not stale");
     ok(_githubLiveStale(false, GITHUB_FRESH_TTL_MS + 1) === true, "age beyond the fixed window → stale (the rate-limited case)");
     ok(_githubLiveStale(false, null) === true, "no generatedAt (null age) → stale");
+    // #827: a malformed/corrupted `generatedAt` → Date.parse NaN. Must be
+    // treated as stale/unknown, NOT fresh (NaN > window is false, which hid it).
+    ok(_githubLiveStale(false, NaN) === true, "NaN age (unparseable generatedAt) → stale, not hidden");
     ok(_githubLiveStale(true, 0) === true, "header already stale → stale regardless of age");
     ok(typeof GITHUB_FRESH_TTL_MS === "number" && Number.isFinite(GITHUB_FRESH_TTL_MS), "freshness window is a finite constant (never Infinity)");
   }


### PR DESCRIPTION
Closes #827. Low-severity hardening follow-ups from the #805 epic + #788 (PRs #819, #816). Server-only.

## 1. `/api/github-parsed` staleness masked by malformed `generatedAt` (#819)
`ageMs = Date.now() - Date.parse(parsed.generatedAt)` — a manually-edited/corrupted `GITHUB.md` with a non-date `generatedAt` yields `Date.parse → NaN`, and `_githubLiveStale(.., NaN)` evaluated `NaN > window` = `false` → **staleness hidden exactly when the file is suspect**.
- `_githubLiveStale` now treats `NaN` (and `null`) as **stale/unknown**.
- The route normalizes `NaN → null` so the `ageMs` response field is a clean "unknown age" rather than relying on `JSON.stringify(NaN) → null`.
- Regression in `routes.parseGithub.test.js`: `_githubLiveStale(false, NaN) === true`.

## 2. Idle-project GITHUB.md write race (#819, defensive)
`syncGithubFilesForRepo` filters idle from a config snapshot read earlier, so an idle-flip racing a setup-seed/refresh pass could still author a parked project's file.
- `writeGithubFileFromSnapshot` now re-checks `isProjectIdle(projectId)` (fresh config read) and **no-ops before any FS write**.
- New `routes.idleGithubWrite.test.js`: idle project → no write; active project → authors the file (positive control, via an `fs` stub so the real `~/.quadwork` is untouched).

## 3. Missing test for normalizeMentions command-context exclusion (#816)
The #788 suite covered code spans but not the shell-command-context exclusion. The implementation was already correct (`run|exec|npx|checkout|...` lookbehind); this closes the regression gap.
- Added: `normalizeMentions("npm run dev", "head")` leaves `dev` untouched; checkout-context `head` untouched while a normal `dev` still mentionizes; a path segment `/head/logs` untouched.

## Acceptance criteria
- [x] NaN/unparseable `generatedAt` is treated as stale, not fresh
- [x] `writeGithubFileFromSnapshot` no-ops for an idle project
- [x] normalizeMentions code-context test added
- [x] `npm run build` passes

## Verification
`routes.parseGithub` 44/44, `routes.normalizeMentions` 6 cases, `routes.idleGithubWrite` 2/2, plus `batchProgressSnapshot`/`githubCanonicalShape`/`restMigration828`/`githubListBareArray` all green; `node --check` clean; `npm run build` green.

Note: all three items were implemented (the ticket marked item 2 as deferrable, but it was a 1-line guard + a small test, so included). No GitHub checks are configured on this repo. This is the last item in Batch 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)