### PR TITLE
[#834] queued-from-snapshot: prove no closed/merged linked PR, not just no open PR

### DIFF
--- a/server/routes.batchProgressSnapshot.test.js
+++ b/server/routes.batchProgressSnapshot.test.js
@@ -90,26 +90,48 @@ function run() {
     ok(progressFromSnapshot(snapshot, 6) === null, "closed issue in snapshot, no in-window PR → null (by-number confirms merged-vs-closed)");
   }
 
-  // ── #828 P1: queued classified from the snapshot ONLY when the open-PR
-  //    window is provably complete (openPrsWindowComplete) — and NEVER when it
-  //    may be truncated. No GraphQL/network in either case. ──
+  // ── #828 P1 / #834: queued classified from the snapshot ONLY when BOTH the
+  //    open-PR window AND the closed-PR window are provably complete, and the
+  //    issue isn't linked by any scanned closed PR. No GraphQL/network. ──
   {
-    const complete = { ...snapshot, openPrsWindowComplete: true };
+    // closedPrIssueNums = [5,7] (the [#N] of the scanned closed/merged PRs).
+    const complete = { ...snapshot, openPrsWindowComplete: true, closedPrsWindowComplete: true, closedPrIssueNums: [5, 7] };
     const r1 = progressFromSnapshot(complete, 1);
-    ok(r1 && r1.status === "queued" && r1.progress === 0, "window complete + OPEN issue + no matching PR → queued/0 (no by-number fetch)");
+    ok(r1 && r1.status === "queued" && r1.progress === 0, "both windows complete + OPEN issue + no linked PR → queued/0 (no by-number fetch)");
     ok(r1 && r1.issue_number === 1 && r1.title === "queued one", "queued row carries the snapshot issue's number + title");
-    // Truncated/unknown window must NOT guess queued — falls through to null.
-    ok(progressFromSnapshot({ ...snapshot, openPrsWindowComplete: false }, 1) === null, "window NOT complete → null even for an OPEN no-PR issue (by-number fallback)");
+    // Open-PR window not complete → never queued.
+    ok(progressFromSnapshot({ ...snapshot, openPrsWindowComplete: false }, 1) === null, "open-PR window NOT complete → null even for an OPEN no-PR issue (by-number fallback)");
     // A matching in-window PR still wins over the queued shortcut.
     ok(progressFromSnapshot(complete, 2).status === "in_review", "window complete but a matching open PR exists → in_review (PR proof wins)");
-    // merged-but-open edge: matching merged PR in-window + issue OPEN → still
-    // null (NOT queued) so by-number resolves the merged-vs-in_review state.
-    ok(progressFromSnapshot(complete, 7) === null, "window complete + merged PR in-window but issue OPEN → null (merged-but-open edge, not queued)");
-    // CLOSED issue with no in-window PR → null even when window complete
-    // (open-PR completeness says nothing about merged-out-of-window).
-    ok(progressFromSnapshot(complete, 6) === null, "window complete + CLOSED issue + no in-window PR → null (closed-no-PR vs merged-out-of-window needs by-number)");
-    // Issue absent from the snapshot entirely → null regardless of the flag.
-    ok(progressFromSnapshot(complete, 999) === null, "window complete but issue absent from snapshot → null (by-number fallback)");
+    // #834: issue 7 has a linked merged PR ([#7] ∈ closedPrIssueNums) and is
+    // OPEN → NOT queued (by-number resolves the merged-vs-in_review state).
+    ok(progressFromSnapshot(complete, 7) === null, "OPEN issue with a linked closed/merged PR → null (not queued), via closedPrIssueNums");
+    // CLOSED issue with no in-window PR → null (openIssue absent).
+    ok(progressFromSnapshot(complete, 6) === null, "CLOSED issue + no in-window PR → null (closed-no-PR vs merged needs by-number)");
+    // Issue absent from the snapshot entirely → null regardless of the flags.
+    ok(progressFromSnapshot(complete, 999) === null, "issue absent from snapshot → null (by-number fallback)");
+  }
+
+  // ── #834 headline: an OPEN issue whose linked [#N] PR merged/closed OUTSIDE
+  //    the recent-5 merged display window must NOT be shown queued. The merged
+  //    slice (snapshot.mergedPrs) wouldn't contain it, but closedPrIssueNums —
+  //    parsed from ALL scanned closed pages — does, so we fall back. ──
+  {
+    const base = {
+      issues: [{ number: 8, title: "open, PR merged out of window", state: "OPEN", url: "u8" }],
+      prs: [],
+      closedIssues: [],
+      mergedPrs: [], // PR for #8 merged but PAST the recent-5 display window
+      openPrsWindowComplete: true,
+      closedPrsWindowComplete: true,
+      closedPrIssueNums: [8], // but [#8] WAS seen on a scanned closed page
+    };
+    ok(progressFromSnapshot(base, 8) === null, "OPEN issue + [#8] PR merged OUT of the recent window → null (NOT queued — by-number resolves; the #834 bug)");
+    // Small repo, genuinely no linked PR anywhere → fast-path queued, no network.
+    ok(progressFromSnapshot({ ...base, closedPrIssueNums: [] }, 8).status === "queued", "OPEN issue + no linked PR anywhere (both windows complete) → queued, no network");
+    // Early-stop / cap-hit-while-full: closed-PR window NOT proven complete →
+    // never queued, even though the (partial) closedPrIssueNums lacks the issue.
+    ok(progressFromSnapshot({ ...base, closedPrsWindowComplete: false, closedPrIssueNums: [] }, 8) === null, "closed-PR window NOT complete (early-stop/cap) → null (by-number fallback), never queued");
   }
 
   // ── cache miss → null (caller does targeted by-number fetch) ──

--- a/server/routes.js
+++ b/server/routes.js
@@ -1222,6 +1222,39 @@ function selectRecentMergedPrs(pages) {
     .map(restMergedPrToCanonical);
 }
 
+// #834: whether the closed-PR pagination reached the ACTUAL end of the list —
+// the ONLY proof that no further closed/merged PR exists beyond what we scanned.
+// True iff the LAST fetched page came back reliably (not an "error") AND had
+// < 100 items (a genuine final page; a full 100 means more may exist). This is
+// deliberately stricter than "the loop stopped": stopping early because the
+// display need was met (≥5 merged) or hitting MERGED_PAGE_CAP while pages were
+// still full does NOT prove completeness — those leave a full (===100) last
+// page, so this returns false and the caller falls back to by-number. A 304
+// carries the unchanged real data, so a short (<100) 304 page is a genuine end
+// too; only "error" pages (possibly stale/null data) can't prove it. Pure.
+function closedPagesComplete(pages) {
+  const last = pages[pages.length - 1];
+  return !!last && last.status !== "error" && Array.isArray(last.data) && last.data.length < 100;
+}
+
+// #834: issue numbers linked by the team's `[#N]` PR-title convention across
+// ALL fetched closed-PR pages (not just the 5 displayed merged). Lets
+// progressFromSnapshot prove an OPEN issue has no closed/merged linked PR —
+// even one merged/closed outside the recent-5 window — before classifying it
+// queued. Pure → unit-testable.
+function closedPrIssueNumsFromPages(pages) {
+  const re = /^\s*\[#(\d{1,7})\]/;
+  const nums = [];
+  for (const r of pages) {
+    const arr = Array.isArray(r && r.data) ? r.data : [];
+    for (const p of arr) {
+      const m = ((p && p.title) || "").match(re);
+      if (m) nums.push(parseInt(m[1], 10));
+    }
+  }
+  return nums;
+}
+
 async function githubStateFetcher(repo) {
   const [owner, name] = (repo || "").split("/");
   if (!owner || !name) return { status: "error", data: null };
@@ -1269,6 +1302,13 @@ async function githubStateFetcher(repo) {
   // without a by-number fetch; if exactly 50 came back the window may be
   // truncated and it must NOT guess.
   const openPrsWindowComplete = Array.isArray(openPullsR.data) && openPullsR.data.length < 50;
+  // #834: queued-from-snapshot also requires proving NO closed/merged linked PR
+  // exists. closedPrsWindowComplete = the closed-PR pagination reached an actual
+  // <100 end (not just stopped early); closedPrIssueNums = every [#N] across ALL
+  // scanned closed pages, so a PR merged/closed outside the recent-5 window
+  // still blocks a false "queued". Both are consumed by progressFromSnapshot.
+  const closedPrsWindowComplete = closedPagesComplete(closedPullPages);
+  const closedPrIssueNums = closedPrIssueNumsFromPages(closedPullPages);
 
   const openPullsRaw = Array.isArray(openPullsR.data) ? openPullsR.data : [];
   const prs = await _mapLimited(openPullsRaw, GH_MAX_CONCURRENT, async (p) => {
@@ -1290,7 +1330,7 @@ async function githubStateFetcher(repo) {
 
   return {
     status: changed > 0 ? "ok" : "unchanged",
-    data: { issues, prs, closedIssues, mergedPrs, openPrsWindowComplete },
+    data: { issues, prs, closedIssues, mergedPrs, openPrsWindowComplete, closedPrsWindowComplete, closedPrIssueNums },
   };
 }
 
@@ -1806,13 +1846,15 @@ function countApprovedRoles(reviews) {
 // Compute issue `n`'s progress row from the snapshot (no network). Links
 // issue↔PR by the team's `[#<issue>]` PR-title convention. Returns a row when
 // the snapshot can PROVE the state: a matching in-window PR (in_review/approved/
-// ready/merged), or — #828 P1 — a queued OPEN issue when the open-PR window is
-// provably complete (openPrsWindowComplete: <50 open PRs returned, so a
-// no-match means there genuinely is no open PR). Returns null otherwise (issue
-// absent, window possibly truncated, CLOSED-with-no-in-window-PR, or merged-
-// but-open), because a partial window can't prove the absence of a linked PR —
-// the caller then does the authoritative by-number REST fetch
-// (progressForItemRest). Bucket mapping is identical to progressForItemRest.
+// ready/merged), or — #828 P1 / #834 — a queued OPEN issue when BOTH windows are
+// provably complete: openPrsWindowComplete (<50 open PRs → no open PR exists)
+// AND closedPrsWindowComplete (the closed-PR pagination reached an actual <100
+// end) with the issue absent from closedPrIssueNums (every [#N] across ALL
+// scanned closed pages, so a PR merged/closed even OUTSIDE the recent-5 window
+// is accounted for). Returns null otherwise (either window unproven, issue
+// absent, CLOSED-with-no-in-window-PR, merged-but-open, or a linked closed/
+// merged PR exists) — a partial window can't prove absence of a linked PR, so
+// the caller does the authoritative by-number REST fetch (progressForItemRest).
 function progressFromSnapshot(snapshot, n) {
   if (!snapshot) return null;
   const titleRe = new RegExp(`^\\s*\\[#${n}\\]`);
@@ -1836,18 +1878,25 @@ function progressFromSnapshot(snapshot, n) {
     if (approvals === 1) return { issue_number: n, title, url: openPr.url, pr_number: openPr.number, status: "approved1", progress: 50, label: `PR #${openPr.number} · 1 approval` };
     return { issue_number: n, title, url: openPr.url, pr_number: openPr.number, status: "in_review", progress: 20, label: `PR #${openPr.number} · waiting on review` };
   }
-  // No matching PR in the board window. #828 P1: classify queued from the
-  // snapshot ONLY when the open-PR window is provably complete (we saw <50 open
-  // PRs → ALL of them). An OPEN issue with no matching open PR and no matching
-  // merged PR in-window is then genuinely queued — return the row here, NO
-  // GraphQL/network. A CLOSED issue (closed-no-PR vs merged-out-of-window) or a
-  // merged-but-open edge stays null so the by-number REST fetch resolves it; if
-  // the window may be truncated (≥50 open PRs) we never guess.
-  if (snapshot.openPrsWindowComplete && openIssue && !mergedPr) {
+  // No matching open/in-window-merged PR. #828 P1 / #834: classify queued from
+  // the snapshot ONLY when absence of BOTH an open AND a closed/merged linked PR
+  // is proven — openPrsWindowComplete (no open PR) AND closedPrsWindowComplete
+  // (the closed-PR window genuinely ended) AND `n` not in closedPrIssueNums
+  // (no [#N] across ANY scanned closed page, incl. merges past the recent-5
+  // display window). Then an OPEN issue is genuinely queued — NO network. Any
+  // gap (either window unproven, or a linked closed/merged PR exists) → null,
+  // and the by-number REST fetch resolves it authoritatively.
+  if (
+    snapshot.openPrsWindowComplete &&
+    snapshot.closedPrsWindowComplete &&
+    openIssue &&
+    !openPr &&
+    !(snapshot.closedPrIssueNums || []).includes(n)
+  ) {
     return buildNoPrRow({ number: n, title: openIssue.title, state: "OPEN", url: openIssue.url });
   }
-  // Can't prove the issue has no linked PR (window truncated / issue absent) —
-  // return null and let the by-number REST fetch resolve it authoritatively.
+  // Can't prove the issue has no linked PR (a window unproven / issue absent /
+  // linked closed PR) — return null; the by-number REST fetch resolves it.
   return null;
 }
 
@@ -3440,6 +3489,10 @@ module.exports._rateLimit = _rateLimit;
 // picker for unit tests. No production callers outside this file.
 module.exports.gatherClosedPrPages = gatherClosedPrPages;
 module.exports.selectRecentMergedPrs = selectRecentMergedPrs;
+// #834: closed-PR window completeness + linked-issue extraction, for the
+// queued-from-snapshot fix. No production callers outside this file.
+module.exports.closedPagesComplete = closedPagesComplete;
+module.exports.closedPrIssueNumsFromPages = closedPrIssueNumsFromPages;
 module.exports.pickLinkedPrFromSearch = pickLinkedPrFromSearch;
 module.exports.findLinkedPrByTitle = findLinkedPrByTitle;
 // #827: expose the GITHUB.md writer for the idle-no-op regression test. No

--- a/server/routes.restMigration828.test.js
+++ b/server/routes.restMigration828.test.js
@@ -17,6 +17,8 @@ const {
   findLinkedPrByTitle,
   gatherClosedPrPages,
   selectRecentMergedPrs,
+  closedPagesComplete,
+  closedPrIssueNumsFromPages,
 } = require("./routes");
 
 const page = (data) => ({ status: "ok", data });
@@ -116,6 +118,33 @@ async function run() {
     // recently-closed-unmerged PRs on page 1 don't bury real merges on page 2.
     ok(!merged.some((m) => m.number === 2), "an older merge is correctly excluded once 5 fresher merges exist on a later page");
     ok(merged.every((m) => m.mergedAt), "every selected row carries mergedAt");
+  }
+
+  // ── #834: closedPagesComplete — the closed-PR window is PROVEN complete only
+  //    when the LAST fetched page came back reliably AND had < 100 items. ──
+  {
+    const full = Array.from({ length: 100 }, (_, i) => unmergedPr(i + 1));
+    const short = [unmergedPr(1), unmergedPr(2)];
+    ok(closedPagesComplete([page(short)]) === true, "single short (<100) ok page → complete (genuine end)");
+    ok(closedPagesComplete([page(full)]) === false, "single full (===100) ok page → NOT complete (more may exist)");
+    ok(closedPagesComplete([page(full), page(short)]) === true, "last page short → complete regardless of earlier full pages");
+    ok(closedPagesComplete([page(full), page(full)]) === false, "cap-hit/early-stop with a full LAST page → NOT complete");
+    ok(closedPagesComplete([{ status: "error", data: null }]) === false, "error last page → NOT complete (can't prove the end)");
+    ok(closedPagesComplete([page(full), { status: "error", data: short }]) === false, "error last page even with short stale data → NOT complete");
+    // A 304 carries the unchanged real data — a short 304 page is a genuine end.
+    ok(closedPagesComplete([{ status: "unchanged", data: short }]) === true, "304 (unchanged) short page → complete (its data is the real, unchanged tail)");
+    ok(closedPagesComplete([{ status: "unchanged", data: full }]) === false, "304 full page → NOT complete");
+  }
+
+  // ── #834: closedPrIssueNumsFromPages — every [#N] linked issue across ALL
+  //    scanned closed pages (strict, start-anchored), not just the displayed 5. ──
+  {
+    const p1 = page([{ title: "[#5] merged a" }, { title: "[#7] closed b" }, { title: "no link here" }]);
+    const p2 = page([{ title: "[#8] merged out-of-window" }, { title: "Fix [#9] mid-title (rejected)" }]);
+    const nums = closedPrIssueNumsFromPages([p1, p2]);
+    ok(nums.includes(5) && nums.includes(7) && nums.includes(8), "collects [#N] across all pages (incl. beyond the displayed 5)");
+    ok(!nums.includes(9), "mid-title [#9] (not start-anchored) is NOT collected");
+    ok(closedPrIssueNumsFromPages([{ status: "error", data: null }]).length === 0, "error/no-data page contributes nothing");
   }
 
   // ── P1/P3 acceptance guard: ZERO `gh issue view` / `gh pr view` (GraphQL)


### PR DESCRIPTION
Closes #834. Follow-up to #828 (PR #830), from RE1 review — fixes the non-blocking edge RE2 flagged on #830.

## Problem
`progressFromSnapshot` classified an issue **queued** on `openPrsWindowComplete && openIssue && !mergedPr`. `openPrsWindowComplete` only proves there's no **open** PR; `snapshot.mergedPrs` is the recent-5 slice (`selectRecentMergedPrs`). So an OPEN issue whose linked `[#N]` PR merged/closed **outside that recent-5 window** was wrongly shown queued. Bounded impact (display-only: auto-stop errs toward not-stopping, HEAD re-checks live before merge) but the panel label is wrong and the trigger can run longer than needed.

## Fix
Conclude queued from the snapshot **only when absence of BOTH an open AND a closed/merged linked PR is proven**; otherwise the REST/Search by-number fallback (no GraphQL).

1. **`closedPagesComplete(pages)` → `closedPrsWindowComplete`.** True **only** when the closed-PR pagination reached an *actual* end: the **last** fetched page came back reliably (not `"error"`) **and** had `< 100` items. Deliberately stricter than "the loop stopped" — early-display-stop (≥5 merged) or cap-hit-while-full leave a full (`===100`) last page → **false**, so the caller falls back. A short (`<100`) **304** page is a genuine end (its data is the unchanged real tail); only `"error"` pages can't prove it. This avoids repeating the same false-proof bug under a new flag.
2. **`closedPrIssueNumsFromPages(pages)` → `closedPrIssueNums`.** Every `[#N]` (start-anchored) linked issue across **ALL** scanned closed pages, not just the displayed 5.
3. **queued-from-snapshot now requires** `openPrsWindowComplete && closedPrsWindowComplete && openIssue && !openPr && !closedPrIssueNums.includes(n)`; otherwise `null` → authoritative by-number REST/Search fallback (no GraphQL introduced).

## Acceptance criteria
- [x] An OPEN issue with a linked `[#N]` PR merged/closed **outside** the recent window is NOT shown queued
- [x] `closedPrsWindowComplete` is true **only** when the last closed-PR page had `< 100` items; false for early-display-stop, cap-hit-while-full, error, or 304-without-known-complete (a short 304 *is* a known-complete tail; a full 304 → false)
- [x] queued requires `openPrsWindowComplete && closedPrsWindowComplete && !closedPrIssueNums.includes(n)`
- [x] When `closedPrsWindowComplete` is false → REST/Search by-number fallback, **no GraphQL**
- [x] **Test: early-stop** — enough merged for display but a full final page within the cap; OPEN issue with no open PR → `null`/fallback, NOT queued
- [x] Test: open issue + out-of-window merged `[#N]` → not queued; small-repo full-window → fast-path queued, no network
- [x] `npm run build` passes

## Tests
- `batchProgressSnapshot` (45/45): out-of-window merged `[#8]` → null (the headline bug); small-repo full-window no-PR → queued (no network); early-stop (`closedPrsWindowComplete:false`) → null; the existing fixture updated to carry the two new flags + `closedPrIssueNums`, and issue 7 (linked merged PR) now → null via `closedPrIssueNums`.
- `restMigration828` (36/36): `closedPagesComplete` (short/full/error/304 last-page incl. cap-hit-while-full) and `closedPrIssueNumsFromPages` (cross-page, start-anchored rejects mid-title `[#N]`, no-data page).
- Full server suite green; `node --check` clean; `npm run build` green.

⚠️ Server-only; no UI pixels. No GitHub checks configured on this repo. Note on the 304 nuance: a short 304 page's data is the unchanged real tail (per-page ETag, sort=updated desc — new closed PRs would shift page 1 and break the ETag), so it genuinely proves the end; only a *full* 304 page or an `error` page leaves completeness unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)