### PR TITLE
[#837] gh api list fetches: explicit 32MB maxBuffer

### DIFF
--- a/server/routes.ghApiConditionalMaxBuffer.test.js
+++ b/server/routes.ghApiConditionalMaxBuffer.test.js
@@ -1,0 +1,113 @@
+// #837 regression: ghApiConditional must parse a >1MB closed-PR list page
+// rather than crashing on Node's default 1MB execFile maxBuffer. A measured
+// realproject7/quadwork `pulls?state=closed&per_page=100` -i page was
+// ~1.74MB, which made the call reject with ERR_CHILD_PROCESS_STDIO_MAXBUFFER
+// and silently empty "Recently Merged PRs" + disable the #828/#834 fast-path.
+//
+// Strategy: stub child_process.execFile BEFORE requiring routes.js so the
+// `execFile` reference captured by `util.promisify` is our stub. The stub
+// simulates a >1MB `gh api -i` response and enforces the caller's maxBuffer
+// the same way Node's real execFile does. Then assert ghApiConditional
+// returns status:"ok" with parsed body. Plain node:assert script — run with
+// `node server/routes.ghApiConditionalMaxBuffer.test.js`.
+
+const assert = require("node:assert/strict");
+const util = require("node:util");
+const cp = require("child_process");
+
+const realExecFile = cp.execFile;
+
+// Build a deterministic >1MB JSON body that looks like a closed-PR page so
+// the test stays meaningful against any future shape tightening.
+function buildBigClosedPrPage() {
+  const pr = (n) => ({
+    number: n,
+    title: `PR ${n} ${"x".repeat(900)}`,
+    html_url: `https://github.com/o/r/pull/${n}`,
+    merged_at: n % 2 ? "2026-01-01T00:00:00Z" : null,
+    user: { login: "alice" },
+  });
+  // 1500 PRs at ~1KB each ≈ 1.5MB body, comfortably over the 1MB default.
+  const body = JSON.stringify(Array.from({ length: 1500 }, (_, i) => pr(i + 1)));
+  const headers = [
+    "HTTP/2.0 200 OK",
+    'Etag: "test-etag"',
+    "Content-Type: application/json; charset=utf-8",
+  ].join("\r\n");
+  return `${headers}\r\n\r\n${body}`;
+}
+
+const BIG_PAYLOAD = buildBigClosedPrPage();
+assert.ok(BIG_PAYLOAD.length > 1024 * 1024, "test fixture must exceed 1MB to exercise the bug");
+
+// Tracks what options ghApiConditional actually passed for the closed-PR call.
+let capturedOptions = null;
+
+cp.execFile = function stubExecFile(command, args, options, callback) {
+  // Normalize the 3-arg form (no options) — real execFile does this too.
+  if (typeof options === "function") { callback = options; options = {}; }
+  options = options || {};
+
+  // Only intercept `gh api ...`. Other callers (e.g. rate_limit polling) get
+  // a benign empty stdout so require-time side effects don't crash.
+  if (command === "gh" && Array.isArray(args) && args[0] === "api") {
+    const apiPath = args[1] || "";
+    const isClosedPrPage = /pulls\?state=closed/.test(apiPath);
+    const payload = isClosedPrPage ? BIG_PAYLOAD : "";
+
+    if (isClosedPrPage) capturedOptions = options;
+
+    const maxBuffer = typeof options.maxBuffer === "number" ? options.maxBuffer : 1024 * 1024;
+    if (Buffer.byteLength(payload, "utf8") > maxBuffer) {
+      const err = new Error("stdout maxBuffer exceeded");
+      err.code = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+      process.nextTick(() => callback(err, "", ""));
+      return { kill: () => {} };
+    }
+    process.nextTick(() => callback(null, payload, ""));
+    return { kill: () => {} };
+  }
+
+  return realExecFile.call(cp, command, args, options, callback);
+};
+
+// child_process.execFile carries a custom util.promisify implementation that
+// resolves to `{ stdout, stderr }`. Replacing the function strips that symbol,
+// so without re-attaching one the default promisify would resolve to a bare
+// stdout string and routes.js's `const { stdout } = await ...` would silently
+// destructure `undefined`. Define an equivalent custom impl on the stub.
+cp.execFile[util.promisify.custom] = (command, args, options) => new Promise((resolve, reject) => {
+  cp.execFile(command, args, options, (err, stdout, stderr) => {
+    if (err) reject(err); else resolve({ stdout, stderr });
+  });
+});
+
+const { ghApiConditional, GH_LIST_MAX_BUFFER } = require("./routes");
+
+(async () => {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  // 1) The shared constant must be generous enough that any current closed-PR
+  //    page comfortably fits. The acceptance criterion is >= ~32MB.
+  ok(GH_LIST_MAX_BUFFER >= 32 * 1024 * 1024, `GH_LIST_MAX_BUFFER (${GH_LIST_MAX_BUFFER}) is at least 32MB`);
+
+  // 2) A >1MB closed-PR page is parsed, not collapsed into status:"error".
+  //    This is the exact failure mode from #837.
+  const result = await ghApiConditional("o/r#pulls-closed-test", "repos/o/r/pulls?state=closed&per_page=100");
+  ok(result.status === "ok", `status is "ok" on >1MB page (got ${JSON.stringify(result.status)})`);
+  ok(Array.isArray(result.data) && result.data.length === 1500, `parsed JSON body (got ${Array.isArray(result.data) ? result.data.length : typeof result.data} items)`);
+  ok(result.changed === true, "first call reports changed=true");
+
+  // 3) The caller passed an explicit maxBuffer >= the fixture size — proving
+  //    the fix is wired through to the actual call (not just present on the
+  //    exported constant).
+  ok(capturedOptions && typeof capturedOptions.maxBuffer === "number", "ghApiConditional passed an explicit maxBuffer option");
+  ok(capturedOptions && capturedOptions.maxBuffer >= BIG_PAYLOAD.length, `passed maxBuffer (${capturedOptions && capturedOptions.maxBuffer}) covers the >1MB page (${BIG_PAYLOAD.length} bytes)`);
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})().catch((err) => {
+  console.error("test crashed:", err);
+  process.exit(1);
+});

--- a/server/routes.js
+++ b/server/routes.js
@@ -26,6 +26,16 @@ const ENV_PATH = path.join(CONFIG_DIR, ".env");
 const TEMPLATES_DIR = path.join(__dirname, "..", "templates");
 const REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 
+// #837: `gh api` list fetches (closed-PR pages with `-i`, GraphQL repo
+// snapshot, batch progress) can exceed Node's default 1MB execFile maxBuffer.
+// A real `pulls?state=closed&per_page=100` -i page measured ~1.74MB on
+// realproject7/quadwork, which made ghApiConditional reject with
+// ERR_CHILD_PROCESS_STDIO_MAXBUFFER → "Recently Merged PRs" stayed empty AND
+// the #828/#834 queued-from-snapshot fast-path was forced off because
+// closedPagesComplete couldn't ever become true. 32MB is well above today's
+// page sizes and still well under node's hard 2GB cap.
+const GH_LIST_MAX_BUFFER = 32 * 1024 * 1024;
+
 function isLocalhost(ip) {
   return ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
 }
@@ -1024,7 +1034,7 @@ async function ghApiConditional(etagKey, apiPath) {
   const args = ["api", apiPath, "-i"];
   if (prev && prev.etag) args.push("-H", `If-None-Match: ${prev.etag}`);
   try {
-    const { stdout } = await _execFileAsync("gh", args, { encoding: "utf-8", timeout: 15000 });
+    const { stdout } = await _execFileAsync("gh", args, { encoding: "utf-8", timeout: 15000, maxBuffer: GH_LIST_MAX_BUFFER });
     const { headerBlock, body } = _parseGhInclude(stdout);
     const etag = _extractEtag(headerBlock);
     let data = null;
@@ -1688,7 +1698,7 @@ fragment repoFields on Repository {
   try {
     const { stdout } = await _execFileAsync("gh", [
       "api", "graphql", "-f", `query=${query}`,
-    ], { encoding: "utf-8", timeout: 15000 });
+    ], { encoding: "utf-8", timeout: 15000, maxBuffer: GH_LIST_MAX_BUFFER });
     const data = JSON.parse(stdout).data;
     if (!data) return null;
 
@@ -2261,7 +2271,7 @@ function parseActiveBatch(queueText) {
 // errors into the "not found" branch, making the new failure-row
 // fallback unreachable for genuine command failures (t2a review).
 async function ghJsonExecAsync(args) {
-  const { stdout } = await _execFileAsync("gh", args, { encoding: "utf-8", timeout: 10000 });
+  const { stdout } = await _execFileAsync("gh", args, { encoding: "utf-8", timeout: 10000, maxBuffer: GH_LIST_MAX_BUFFER });
   return JSON.parse(stdout);
 }
 
@@ -3463,6 +3473,10 @@ module.exports.isGraphqlRateLow = isGraphqlRateLow;
 // entry point (#807's file writer consumes the assembled snapshot).
 module.exports.githubStateFetcher = githubStateFetcher;
 module.exports._coalesce = _coalesce;
+// #837: expose ghApiConditional + the shared list-fetch maxBuffer constant for
+// the >1MB closed-PR page regression test.
+module.exports.ghApiConditional = ghApiConditional;
+module.exports.GH_LIST_MAX_BUFFER = GH_LIST_MAX_BUFFER;
 module.exports.restIssueToCanonical = restIssueToCanonical;
 module.exports.restClosedIssueToCanonical = restClosedIssueToCanonical;
 module.exports.restMergedPrToCanonical = restMergedPrToCanonical;


### PR DESCRIPTION
## Summary
- Adds explicit `maxBuffer: 32MB` (shared `GH_LIST_MAX_BUFFER`) to the three large-list `gh api` execs in `server/routes.js`: `ghApiConditional` (closed-PR pages with `-i`), the GraphQL emergency-fallback fetch, and `ghJsonExecAsync` (batch progress).
- Restores "Recently Merged PRs" and the #828/#834 queued-from-snapshot fast-path: without the bump, Node's default 1MB `execFile` buffer overflowed on a ~1.74MB closed-PR page → `ghApiConditional` returned `status:"error"` → `closedPagesComplete` stayed false forever.
- Adds `server/routes.ghApiConditionalMaxBuffer.test.js` — stubs `child_process.execFile` (with matching `util.promisify.custom` so routes' `{ stdout }` destructure works), simulates a 1.5MB `pulls?state=closed` response, and asserts `ghApiConditional` returns `status:"ok"` with the parsed body and the captured options carry an explicit `maxBuffer` that covers the page.

## Test plan
- [x] `node server/routes.ghApiConditionalMaxBuffer.test.js` → 6/6 PASS (new regression test)
- [x] `node server/routes.coalesce.test.js` → 8/8 PASS (no regression on adjacent code)
- [x] `node server/routes.restMigration828.test.js` → 36/36 PASS
- [x] `node server/routes.batchProgressSnapshot.test.js` → 45/45 PASS
- [x] `npm run build` → ✓ Compiled successfully

Fixes #837