### PR TITLE
[#838] Sidebar Active/Inactive switch: shrink one step

### DIFF
--- a/src/components/ActiveSwitch.tsx
+++ b/src/components/ActiveSwitch.tsx
@@ -25,13 +25,13 @@ export default function ActiveSwitch({ active, onToggle, disabled, title }: Acti
         e.stopPropagation();
         if (!disabled) onToggle();
       }}
-      className={`relative inline-flex h-3.5 w-7 shrink-0 items-center border transition-colors duration-150 disabled:opacity-50 ${
+      className={`relative inline-flex h-3 w-6 shrink-0 items-center border transition-colors duration-150 disabled:opacity-50 ${
         active ? "border-accent bg-accent/15" : "border-border bg-transparent hover:border-text-muted"
       }`}
     >
       <span
-        className={`block h-2.5 w-2.5 transition-transform duration-150 ${
-          active ? "translate-x-[14px] bg-accent" : "translate-x-[2px] bg-text-muted"
+        className={`block h-2 w-2 transition-transform duration-150 ${
+          active ? "translate-x-[12px] bg-accent" : "translate-x-[2px] bg-text-muted"
         }`}
       />
     </button>


### PR DESCRIPTION
## Summary
- `src/components/ActiveSwitch.tsx` — track `h-3.5 w-7` → `h-3 w-6` (14×28 → 12×24), knob `h-2.5 w-2.5` → `h-2 w-2` (10×10 → 8×8), and ON `translate-x` recomputed to `12px` so the knob still lands flush against the inner-right edge with the same 2px gap pattern (OFF stays `translate-x-[2px]`).
- Sharp-cornered, `border-accent`/`bg-accent/15` ON, `border-border`/muted-off OFF, `disabled:opacity-50`, and click-stop behavior all unchanged.

## Geometry
- Inner width = outer − 2×border = 24 − 2 = 22px; knob = 8px; with a 2px gap on each end, OFF knob_left=2, ON knob_left = 22 − 8 − 2 = 12. Hence `translate-x-[2px]` / `translate-x-[12px]`.

## Test plan
- [x] `npm run build` → ✓ Compiled successfully
- [x] Visually verified on `next dev` localhost:3000: ON state (QuadWork, QuadPlan with `#00ff88` accent) and OFF state (others, muted) both render flush in the sidebar — screenshot taken locally.
- [x] All 8 project rows align cleanly; switches measure 24×12px in the accessibility tree as expected.

Fixes #838