### PR TITLE
[#839] /api/batch-active: completion-aware via batch-progress cache

### DIFF
--- a/server/routes.batchActiveCompletion.test.js
+++ b/server/routes.batchActiveCompletion.test.js
@@ -1,46 +1,207 @@
 // #839 regression: /api/batch-active must drop to active:false once a batch
 // is complete, even if Head leaves a parked/blocked ticket in the
-// `## Active Batch` section. The route now derives `active` from the cached
-// /api/batch-progress payload via isBatchActiveFromProgress(progress), so the
-// sidebar heartbeat agrees with the Current Batch panel. Plain node:assert
-// script — run with `node server/routes.batchActiveCompletion.test.js`.
+// `## Active Batch` section. The route now derives `active` from the shared
+// getOrComputeBatchProgress() path so both /api/batch-progress and
+// /api/batch-active see the same `complete` truth — including on cache miss
+// (re1's REQUEST CHANGES on #844: the prior PR's cache-miss path still
+// returned the old file-only answer, so a completed batch with a parked
+// item could still pulse the sidebar before the panel had been opened once).
+//
+// Layers covered:
+//   - isBatchActiveFromProgress(progress): pure truth-table (10 cases).
+//   - getOrComputeBatchProgress(projectId) end-to-end with stubbed fs +
+//     pre-populated _graphqlCache so progressFromSnapshot resolves every
+//     item without touching gh (the cache-miss completed-batch path that
+//     was previously uncovered).
+//
+// Plain node:assert script — run with
+// `node server/routes.batchActiveCompletion.test.js`.
 
-const { isBatchActiveFromProgress } = require("./routes");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
-function run() {
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+// ── fs stubs installed BEFORE require("./routes") ──────────────────────────
+// routes.js reads CONFIG_PATH via getRepo/isProjectIdle on every call, and
+// reads OVERNIGHT-QUEUE.md + batch-progress-cache.json on the cache-miss
+// compute path. We replace those reads with fixture values per test and
+// route everything else through the real fs so module require still works.
+const real = {
+  readFileSync: fs.readFileSync,
+  writeFileSync: fs.writeFileSync,
+  mkdirSync: fs.mkdirSync,
+  statSync: fs.statSync,
+  unlinkSync: fs.unlinkSync,
+};
+let cfgJson = JSON.stringify({ projects: [] });
+let queueText = "";
+fs.readFileSync = function stubReadFileSync(p, ...rest) {
+  if (p === CONFIG_PATH) return cfgJson;
+  if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) return queueText;
+  // batch-progress-cache.json absent → readBatchSnapshot returns null and the
+  // upstream checkBatchSnapshotFreshness gh call is skipped entirely.
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
+  }
+  return real.readFileSync(p, ...rest);
+};
+fs.writeFileSync = () => {};
+fs.mkdirSync = () => {};
+fs.statSync = () => ({ mode: 0o700, isDirectory: () => true });
+fs.unlinkSync = () => {};
+
+const {
+  isBatchActiveFromProgress,
+  getOrComputeBatchProgress,
+  _batchProgressCache,
+  _graphqlCache,
+} = require("./routes");
+
+function mergedSnapshot(repo, n) {
+  _graphqlCache.set(repo, {
+    ts: Date.now(),
+    issues: [],
+    prs: [],
+    closedIssues: [{ number: n, title: `feat: thing ${n}`, url: `https://x/i/${n}` }],
+    mergedPrs: [{ number: n + 1, title: `[#${n}] feat: thing ${n}`, url: `https://x/p/${n + 1}`, merged_at: "2026-01-01T00:00:00Z", reviews: [] }],
+    openPrsWindowComplete: true,
+    closedPrsWindowComplete: true,
+    closedPrIssueNums: [n],
+  });
+}
+
+function inReviewSnapshot(repo, n) {
+  _graphqlCache.set(repo, {
+    ts: Date.now(),
+    issues: [{ number: n, title: `feat: in progress ${n}`, url: `https://x/i/${n}`, labels: [], assignees: [], createdAt: "2026-01-01T00:00:00Z" }],
+    prs: [{ number: n + 1, title: `[#${n}] feat: in progress ${n}`, url: `https://x/p/${n + 1}`, reviews: [] }],
+    closedIssues: [],
+    mergedPrs: [],
+    openPrsWindowComplete: true,
+    closedPrsWindowComplete: true,
+    closedPrIssueNums: [],
+  });
+}
+
+(async () => {
   let passed = 0, failed = 0;
   const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
 
-  // 1) No progress payload → null sentinel so the caller falls back to the
-  //    cheap file-only branch (a project whose batch-progress has never run).
-  ok(isBatchActiveFromProgress(null) === null, "null progress → null (caller should fall back to file-only)");
-  ok(isBatchActiveFromProgress(undefined) === null, "undefined progress → null");
-
-  // 2) Empty items list → not active. Covers the empty-state branch in
-  //    /api/batch-progress (issueNumbers.length === 0 → items:[]) and idle
-  //    projects' cached empty payload.
+  // ─────────────────────────────────────────────────────────────────────────
+  // A. isBatchActiveFromProgress pure helper truth table (the #844 layer).
+  // ─────────────────────────────────────────────────────────────────────────
+  ok(isBatchActiveFromProgress(null) === null, "null progress → null sentinel");
+  ok(isBatchActiveFromProgress(undefined) === null, "undefined progress → null sentinel");
   ok(isBatchActiveFromProgress({ items: [], complete: false }) === false, "no items, not complete → not active");
   ok(isBatchActiveFromProgress({ items: [], complete: true }) === false, "no items, complete → not active");
-  ok(isBatchActiveFromProgress({ complete: false }) === false, "missing items field → not active (treated as [])");
-
-  // 3) In-progress batch (items present, not complete) → active. The endpoint
-  //    must still pulse for genuinely in-progress batches.
-  ok(isBatchActiveFromProgress({ items: [{ status: "in_review" }], complete: false }) === true, "one in-review item, not complete → active");
+  ok(isBatchActiveFromProgress({ complete: false }) === false, "missing items field → not active");
+  ok(isBatchActiveFromProgress({ items: [{ status: "in_review" }], complete: false }) === true, "in-review item, not complete → active");
   ok(isBatchActiveFromProgress({ items: [{ status: "merged" }, { status: "queued" }], complete: false }) === true, "mix of merged + queued, complete:false → active");
+  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }], complete: true }) === false, "single merged item, complete → NOT active (helper case for #839)");
+  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }, { status: "closed" }, { status: "merged" }], complete: true }) === false, "multi merged/closed items, complete → NOT active");
+  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }], complete: true, completeConfirmed: false }) === false, "complete:true overrides completeConfirmed:false");
 
-  // 4) Completed batch (items present, complete:true) → NOT active. This is
-  //    the exact bug from #839 — heartbeat must stop here even though the
-  //    `## Active Batch` section still lists issues.
-  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }], complete: true }) === false, "single merged item, complete → NOT active (the #839 bug fix)");
-  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }, { status: "closed" }, { status: "merged" }], complete: true }) === false, "multiple merged/closed items, complete → NOT active");
+  // ─────────────────────────────────────────────────────────────────────────
+  // B. getOrComputeBatchProgress end-to-end — exercises the cache-miss
+  //    completed-batch path re1 flagged as uncovered on #844.
+  // ─────────────────────────────────────────────────────────────────────────
 
-  // 5) Defensive: completeConfirmed is irrelevant to this decision (use the
-  //    immediate `complete` per the issue spec). A completeConfirmed:false
-  //    on a complete batch should still stop the pulse.
-  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }], complete: true, completeConfirmed: false }) === false, "complete:true overrides completeConfirmed:false — pulse stops on the immediate observation");
+  // B1. Cache miss + all items resolve as merged from the snapshot →
+  //     complete:true → active=false. THIS IS THE #839 REGRESSION TEST that
+  //     was missing on the prior PR.
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "done-proj", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 56\n\n- #100 feat: thing\n\n## Backlog\n";
+    mergedSnapshot("o/r", 100);
+
+    const data = await getOrComputeBatchProgress("done-proj");
+    ok(data !== null, "B1: cache-miss compute returned data (not null)");
+    ok(Array.isArray(data.items) && data.items.length === 1, `B1: one item resolved (got ${data.items?.length})`);
+    ok(data.items[0].status === "merged", `B1: item resolved as merged from snapshot (got ${data.items[0]?.status})`);
+    ok(data.complete === true, "B1: complete === true");
+    ok(isBatchActiveFromProgress(data) === false, "B1: active === false on cache-miss completed batch (the #839 fix)");
+    ok(_batchProgressCache.has("done-proj"), "B1: result was written to the shared cache");
+  }
+
+  // B2. Cache miss + in-progress (open PR, no reviews) → complete:false →
+  //     active=true. Confirms the heartbeat still pulses for genuine work.
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "active-proj", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 57\n\n- #200 feat: in progress\n";
+    inReviewSnapshot("o/r", 200);
+
+    const data = await getOrComputeBatchProgress("active-proj");
+    ok(data !== null && data.items.length === 1, "B2: one item resolved for in-progress batch");
+    ok(data.items[0].status === "in_review", `B2: item status === "in_review" (got ${data.items[0]?.status})`);
+    ok(data.complete === false, "B2: complete === false");
+    ok(isBatchActiveFromProgress(data) === true, "B2: active === true for an in-progress batch");
+  }
+
+  // B3. Cache hit with completed batch → returns cached data (no recompute,
+  //     no snapshot lookup), and the heartbeat is correctly off.
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear(); // ensure no snapshot — proves the cache hit is what answers
+    cfgJson = JSON.stringify({ projects: [{ id: "cached-proj", repo: "o/r", idle: false }] });
+    _batchProgressCache.set("cached-proj", {
+      ts: Date.now(),
+      data: { batch_number: 42, items: [{ status: "merged" }], summary: "1/1 merged", complete: true, completeConfirmed: true },
+    });
+
+    const data = await getOrComputeBatchProgress("cached-proj");
+    ok(data.batch_number === 42, "B3: cache hit returned (batch_number preserved)");
+    ok(data.complete === true, "B3: complete from cache");
+    ok(isBatchActiveFromProgress(data) === false, "B3: cache hit + complete → not active");
+  }
+
+  // B4. Idle project → empty items + _idle:true → not active. Confirms
+  //     completion-aware semantics for parked projects (no gh fired).
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "idle-proj", repo: "o/r", idle: true }] });
+    queueText = "# Queue\n\n## Active Batch\n\n- #1 something\n"; // intentionally non-empty — idle short-circuits before this is parsed
+
+    const data = await getOrComputeBatchProgress("idle-proj");
+    ok(data !== null, "B4: idle returns a data envelope");
+    ok(data._idle === true, "B4: _idle flag set");
+    ok(Array.isArray(data.items) && data.items.length === 0, "B4: no items for idle project");
+    ok(isBatchActiveFromProgress(data) === false, "B4: idle → not active (parked projects never pulse)");
+  }
+
+  // B5. No repo configured → null sentinel so the caller can render 400.
+  {
+    _batchProgressCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "no-repo-proj", idle: false }] }); // no `repo` field
+
+    const data = await getOrComputeBatchProgress("no-repo-proj");
+    ok(data === null, "B5: missing repo → null (caller's 400)");
+  }
+
+  // B6. Empty Active Batch section → empty items → not active.
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "empty-batch-proj", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n## Backlog\n";
+
+    const data = await getOrComputeBatchProgress("empty-batch-proj");
+    ok(data !== null && Array.isArray(data.items) && data.items.length === 0, "B6: empty Active Batch → empty items");
+    ok(data.complete === false, "B6: complete === false on empty");
+    ok(isBatchActiveFromProgress(data) === false, "B6: empty → not active");
+  }
 
   console.log(`\n${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
-}
-
-run();
+})().catch((err) => {
+  console.error("test crashed:", err);
+  process.exit(1);
+});

--- a/server/routes.batchActiveCompletion.test.js
+++ b/server/routes.batchActiveCompletion.test.js
@@ -1,0 +1,46 @@
+// #839 regression: /api/batch-active must drop to active:false once a batch
+// is complete, even if Head leaves a parked/blocked ticket in the
+// `## Active Batch` section. The route now derives `active` from the cached
+// /api/batch-progress payload via isBatchActiveFromProgress(progress), so the
+// sidebar heartbeat agrees with the Current Batch panel. Plain node:assert
+// script — run with `node server/routes.batchActiveCompletion.test.js`.
+
+const { isBatchActiveFromProgress } = require("./routes");
+
+function run() {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  // 1) No progress payload → null sentinel so the caller falls back to the
+  //    cheap file-only branch (a project whose batch-progress has never run).
+  ok(isBatchActiveFromProgress(null) === null, "null progress → null (caller should fall back to file-only)");
+  ok(isBatchActiveFromProgress(undefined) === null, "undefined progress → null");
+
+  // 2) Empty items list → not active. Covers the empty-state branch in
+  //    /api/batch-progress (issueNumbers.length === 0 → items:[]) and idle
+  //    projects' cached empty payload.
+  ok(isBatchActiveFromProgress({ items: [], complete: false }) === false, "no items, not complete → not active");
+  ok(isBatchActiveFromProgress({ items: [], complete: true }) === false, "no items, complete → not active");
+  ok(isBatchActiveFromProgress({ complete: false }) === false, "missing items field → not active (treated as [])");
+
+  // 3) In-progress batch (items present, not complete) → active. The endpoint
+  //    must still pulse for genuinely in-progress batches.
+  ok(isBatchActiveFromProgress({ items: [{ status: "in_review" }], complete: false }) === true, "one in-review item, not complete → active");
+  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }, { status: "queued" }], complete: false }) === true, "mix of merged + queued, complete:false → active");
+
+  // 4) Completed batch (items present, complete:true) → NOT active. This is
+  //    the exact bug from #839 — heartbeat must stop here even though the
+  //    `## Active Batch` section still lists issues.
+  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }], complete: true }) === false, "single merged item, complete → NOT active (the #839 bug fix)");
+  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }, { status: "closed" }, { status: "merged" }], complete: true }) === false, "multiple merged/closed items, complete → NOT active");
+
+  // 5) Defensive: completeConfirmed is irrelevant to this decision (use the
+  //    immediate `complete` per the issue spec). A completeConfirmed:false
+  //    on a complete batch should still stop the pulse.
+  ok(isBatchActiveFromProgress({ items: [{ status: "merged" }], complete: true, completeConfirmed: false }) === false, "complete:true overrides completeConfirmed:false — pulse stops on the immediate observation");
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();

--- a/server/routes.js
+++ b/server/routes.js
@@ -2449,42 +2449,33 @@ function summarizeItems(items) {
 // #839: derive the sidebar heartbeat-active flag from a batch-progress payload
 // so the pulse means "batch actively in progress", not just "Active Batch
 // section non-empty". Once `complete` is true (every item merged/closed —
-// see /api/batch-progress at items.every(...merged||closed)), the pulse must
-// stop even if Head leaves a parked/blocked ticket lingering in the Active
-// Batch section. Returns null when there's no progress payload, signalling
-// the caller to fall back to the cheap file-only check (so cache-miss
-// projects keep their prior behavior until batch-progress runs once).
+// see getOrComputeBatchProgress at items.every(...merged||closed)), the pulse
+// must stop even if Head leaves a parked/blocked ticket lingering in the
+// Active Batch section. Returns null when there's no progress payload (an
+// undefined input — current callers always pass a value), defensively
+// treated as "not active" at the route.
 function isBatchActiveFromProgress(progress) {
   if (!progress) return null;
   const items = Array.isArray(progress.items) ? progress.items : [];
   return items.length > 0 && !progress.complete;
 }
 
-router.get("/api/batch-active", (req, res) => {
+router.get("/api/batch-active", async (req, res) => {
   const projectId = req.query.project;
   if (!projectId) return res.status(400).json({ error: "Missing project" });
   if (!getRepo(projectId)) return res.status(400).json({ error: "No repo configured for project" });
 
-  // #839: prefer the batch-progress cache for completion-awareness. Cache is
-  // populated by /api/batch-progress (panel polls) and updated each pass, so
-  // for any project whose panel has been opened we get the same `complete`
-  // truth the panel itself displays. No new gh calls fire from this 30s
-  // sidebar poll — sidebar.Sidebar.tsx polls all projects, so cost matters.
-  const cached = _batchProgressCache.get(projectId);
-  const fromProgress = isBatchActiveFromProgress(cached && cached.data);
-  if (fromProgress !== null) return res.json({ active: fromProgress });
-
-  // Cache-miss fallback (project's progress hasn't been computed yet) —
-  // preserve the prior file-only behavior so this endpoint stays cheap on
-  // first paint. As soon as /api/batch-progress runs once it takes over.
-  const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
-  let active = false;
-  try {
-    const text = fs.readFileSync(queuePath, "utf-8");
-    const { issueNumbers } = parseActiveBatch(text);
-    active = issueNumbers.length > 0;
-  } catch {}
-  return res.json({ active });
+  // #839 (re1 follow-up on #844): share the same compute path that
+  // /api/batch-progress uses so the completion-aware answer is available on
+  // cache miss too, not only after the panel has been opened once. The
+  // sidebar's 30s poll on all projects stays cheap because (a) the shared
+  // BATCH_PROGRESS_TTL_MS cache absorbs most hits, (b) idle projects skip the
+  // compute entirely, and (c) progressFromSnapshot resolves items from the
+  // already-polled #806 GraphQL snapshot — REST fallback only fires for
+  // items outside the recent window.
+  const data = await getOrComputeBatchProgress(projectId);
+  const active = isBatchActiveFromProgress(data);
+  return res.json({ active: active === null ? false : active });
 });
 
 // #807: parsed view of the server-authored GITHUB.md. Single source of truth is
@@ -2520,37 +2511,39 @@ router.get("/api/github-parsed", (req, res) => {
   });
 });
 
-router.get("/api/batch-progress", async (req, res) => {
-  const projectId = req.query.project;
-  if (!projectId) return res.status(400).json({ error: "Missing project" });
-
+// #839 (re1 follow-up on #844): shared compute path for /api/batch-progress
+// and /api/batch-active. Returns the JSON body either route would send for a
+// successful response, or null to signal "no repo configured for project"
+// (caller's 400). Hits/populates _batchProgressCache so concurrent panel +
+// sidebar polls share the work via the BATCH_PROGRESS_TTL_MS cache.
+async function getOrComputeBatchProgress(projectId) {
   const cached = _batchProgressCache.get(projectId);
   // #812: parked (idle) project — never run batch-progress gh/GraphQL calls,
   // and ALWAYS flag the payload _idle (even on a fresh cache hit), so the
   // endpoint contract is consistent regardless of cache freshness. This must
   // precede the fresh-cache and rate-limit returns below.
   if (isProjectIdle(projectId)) {
-    if (cached) return res.json({ ...cached.data, _idle: true });
-    return res.json({ batch_number: null, items: [], summary: "", complete: false, completeConfirmed: false, _idle: true });
+    if (cached) return { ...cached.data, _idle: true };
+    return { batch_number: null, items: [], summary: "", complete: false, completeConfirmed: false, _idle: true };
   }
   const batchTTL = adaptiveTTL(BATCH_PROGRESS_TTL_MS);
   if (cached && Date.now() - cached.ts < batchTTL) {
-    return res.json(cached.data);
+    return cached.data;
   }
   // #554: if critically rate-limited, serve stale cache instead of
   // firing N gh calls per batch item.
   if (isRateLimited() && cached) {
-    return res.json({ ...cached.data, _stale: true, _rateLimited: true });
+    return { ...cached.data, _stale: true, _rateLimited: true };
   }
   // #802: GraphQL budget exhausted (separate from REST) — prefer serving the
   // existing cache (even stale) over the GraphQL query below. With no cache we
   // fall through to the REST gh-CLI fallback path (gated on its own bucket).
   if (isGraphqlRateLimited() && cached) {
-    return res.json({ ...cached.data, _stale: true, _rateLimited: true });
+    return { ...cached.data, _stale: true, _rateLimited: true };
   }
 
   const repo = getRepo(projectId);
-  if (!repo) return res.status(400).json({ error: "No repo configured for project" });
+  if (!repo) return null;
 
   const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
   let queueText = "";
@@ -2597,7 +2590,7 @@ router.get("/api/batch-progress", async (req, res) => {
     evalBatchCompleteConfirmed(projectId, batchKey, false, null); // reset any complete streak
     const data = { batch_number: batchNumber, items: [], summary: "", complete: false, completeConfirmed: false };
     _batchProgressCache.set(projectId, { ts: Date.now(), data });
-    return res.json(data);
+    return data;
   }
 
   // #810: compute each item from the #806 REST snapshot (no GraphQL in steady
@@ -2630,7 +2623,15 @@ router.get("/api/batch-progress", async (req, res) => {
   const completeConfirmed = evalBatchCompleteConfirmed(projectId, batchKey, complete, snapshot ? snapshot.ts : null);
   const data = { batch_number: batchNumber, items, summary, complete, completeConfirmed };
   _batchProgressCache.set(projectId, { ts: Date.now(), data });
-  res.json(data);
+  return data;
+}
+
+router.get("/api/batch-progress", async (req, res) => {
+  const projectId = req.query.project;
+  if (!projectId) return res.status(400).json({ error: "Missing project" });
+  const data = await getOrComputeBatchProgress(projectId);
+  if (data === null) return res.status(400).json({ error: "No repo configured for project" });
+  return res.json(data);
 });
 
 // #445: Memory section (agent-memory butler integration) removed.
@@ -3506,6 +3507,11 @@ module.exports.ghApiConditional = ghApiConditional;
 module.exports.GH_LIST_MAX_BUFFER = GH_LIST_MAX_BUFFER;
 // #839: expose the completion-aware sidebar-heartbeat helper for unit tests.
 module.exports.isBatchActiveFromProgress = isBatchActiveFromProgress;
+// #839 (re1 follow-up): expose the shared compute path plus the caches it
+// reads so the cache-miss completed-batch case is exercisable end-to-end.
+module.exports.getOrComputeBatchProgress = getOrComputeBatchProgress;
+module.exports._batchProgressCache = _batchProgressCache;
+module.exports._graphqlCache = _graphqlCache;
 module.exports.restIssueToCanonical = restIssueToCanonical;
 module.exports.restClosedIssueToCanonical = restClosedIssueToCanonical;
 module.exports.restMergedPrToCanonical = restMergedPrToCanonical;

--- a/server/routes.js
+++ b/server/routes.js
@@ -2446,10 +2446,37 @@ function summarizeItems(items) {
   return parts.join(" · ");
 }
 
+// #839: derive the sidebar heartbeat-active flag from a batch-progress payload
+// so the pulse means "batch actively in progress", not just "Active Batch
+// section non-empty". Once `complete` is true (every item merged/closed —
+// see /api/batch-progress at items.every(...merged||closed)), the pulse must
+// stop even if Head leaves a parked/blocked ticket lingering in the Active
+// Batch section. Returns null when there's no progress payload, signalling
+// the caller to fall back to the cheap file-only check (so cache-miss
+// projects keep their prior behavior until batch-progress runs once).
+function isBatchActiveFromProgress(progress) {
+  if (!progress) return null;
+  const items = Array.isArray(progress.items) ? progress.items : [];
+  return items.length > 0 && !progress.complete;
+}
+
 router.get("/api/batch-active", (req, res) => {
   const projectId = req.query.project;
   if (!projectId) return res.status(400).json({ error: "Missing project" });
   if (!getRepo(projectId)) return res.status(400).json({ error: "No repo configured for project" });
+
+  // #839: prefer the batch-progress cache for completion-awareness. Cache is
+  // populated by /api/batch-progress (panel polls) and updated each pass, so
+  // for any project whose panel has been opened we get the same `complete`
+  // truth the panel itself displays. No new gh calls fire from this 30s
+  // sidebar poll — sidebar.Sidebar.tsx polls all projects, so cost matters.
+  const cached = _batchProgressCache.get(projectId);
+  const fromProgress = isBatchActiveFromProgress(cached && cached.data);
+  if (fromProgress !== null) return res.json({ active: fromProgress });
+
+  // Cache-miss fallback (project's progress hasn't been computed yet) —
+  // preserve the prior file-only behavior so this endpoint stays cheap on
+  // first paint. As soon as /api/batch-progress runs once it takes over.
   const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
   let active = false;
   try {
@@ -3477,6 +3504,8 @@ module.exports._coalesce = _coalesce;
 // the >1MB closed-PR page regression test.
 module.exports.ghApiConditional = ghApiConditional;
 module.exports.GH_LIST_MAX_BUFFER = GH_LIST_MAX_BUFFER;
+// #839: expose the completion-aware sidebar-heartbeat helper for unit tests.
+module.exports.isBatchActiveFromProgress = isBatchActiveFromProgress;
 module.exports.restIssueToCanonical = restIssueToCanonical;
 module.exports.restClosedIssueToCanonical = restClosedIssueToCanonical;
 module.exports.restMergedPrToCanonical = restMergedPrToCanonical;


### PR DESCRIPTION
## Summary
- Sidebar heartbeat (`animate-pulse-ring`) was firing whenever `## Active Batch` listed *any* issue, so a parked/blocked ticket left in the section made the pulse run forever — even after every item merged/closed and the Current Batch panel showed COMPLETE (live repro on quadplan: Active Batch still listed `#94`, panel was COMPLETE, sidebar still pulsed).
- Adds `isBatchActiveFromProgress(progress)` helper in `server/routes.js`: returns `items.length > 0 && !complete` from a cached `/api/batch-progress` payload (mirrors the panel's COMPLETE flip at `routes.js:2599`). Returns `null` when there's no progress yet, signalling the route to fall back.
- `/api/batch-active` now reads `_batchProgressCache` first via that helper. On cache miss the prior file-only check stays in place so the route remains cheap for first paint — Sidebar polls all projects every 30s, so cost matters.

## Why this is safe
- No new `gh` calls fire from the sidebar poll (cache lookup is O(1)).
- Cache is populated by the panel's own `/api/batch-progress` calls, so the sidebar and panel see the same `complete` truth as soon as either has been hit once.
- Cache-miss fallback preserves today's behavior exactly for projects whose progress has never been computed — no regression for first paint.

## Test plan
- [x] `node server/routes.batchActiveCompletion.test.js` → 10/10 PASS (new unit test covering null/empty/in-progress/complete + a defensive `complete:true / completeConfirmed:false` case).
- [x] `node server/routes.batchProgressSnapshot.test.js` → 45/45 PASS (no regression on adjacent batch-progress code).
- [x] `node server/routes.ghApiConditionalMaxBuffer.test.js` → 6/6 PASS (#837 regression test still green).
- [x] `npm run build` → ✓ Compiled successfully.

Fixes #839