### PR TITLE
[#840] Agent Models: add claude-opus-4-8

### DIFF
--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -112,6 +112,7 @@ export const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> =
   ],
   claude: [
     { value: "", label: "(CLI default)" },
+    { value: "claude-opus-4-8", label: "claude-opus-4-8" },
     { value: "claude-opus-4-7", label: "claude-opus-4-7" },
     { value: "claude-opus-4-6", label: "claude-opus-4-6" },
     { value: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },


### PR DESCRIPTION
## Summary
- `src/components/AgentModelsWidget.tsx`: pin `claude-opus-4-8` at the top of `MODEL_OPTIONS.claude` (above `claude-opus-4-7`), mirroring the ordering pattern #510 used when 4.7 was added.
- `SettingsPage.tsx` re-uses the same list via `import { MODEL_OPTIONS, optionsForBackend }`, so Settings picks up the new entry with no extra change.
- No backend change: `server/index.js:391` already passes `--model <slug>` for the claude backend whenever the row's `model` is set.

## Test plan
- [x] `npm run build` → ✓ Compiled successfully
- [x] Diff is a single one-line addition; no other code paths touched.
- The list is referenced by `optionsForBackend(row.backend)` for both the dropdown (line 273) and the "custom value preservation" check (line 279), so selecting `claude-opus-4-8` will persist via the existing PUT `/api/project/:id/agent-models/:agent` route and Restart will spawn the agent with `--model claude-opus-4-8`.

Fixes #840