### PR TITLE
[#841] Agent Models: add opus / sonnet (latest) aliases

### DIFF
--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -112,6 +112,12 @@ export const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> =
   ],
   claude: [
     { value: "", label: "(CLI default)" },
+    // #841: CLI-documented aliases (`claude --help` → "alias for the latest
+    // model"). Auto-track new Opus/Sonnet releases without needing a QuadWork
+    // update; pinned `claude-opus-4-X` rows below remain for operators who
+    // want a specific version locked in.
+    { value: "opus", label: "opus (latest)" },
+    { value: "sonnet", label: "sonnet (latest)" },
     { value: "claude-opus-4-8", label: "claude-opus-4-8" },
     { value: "claude-opus-4-7", label: "claude-opus-4-7" },
     { value: "claude-opus-4-6", label: "claude-opus-4-6" },


### PR DESCRIPTION
## Summary
- `src/components/AgentModelsWidget.tsx`: add `opus (latest)` and `sonnet (latest)` entries to `MODEL_OPTIONS.claude`, pinned above the explicit `claude-opus-4-X` rows. `claude --help` documents `--model` accepting `opus` / `sonnet` as "alias for the latest model", so a single dropdown entry auto-tracks new releases without needing a QuadWork update (the manual lift #840 just did).
- Existing pinned versions stay for operators who want a specific lock-in.
- No backend change: `server/index.js:391` passes `--model <value>` for claude with no allowlist gate.

## Why this is safe
- Purely additive — existing agents' stored `model` values and the unset-→-CLI-default fallback are untouched, so no live session is affected.
- `opus` / `sonnet` are CLI-documented aliases (verified per the issue body), so the spawn flag is valid.
- Out of scope per the issue: arbitrary free-text entry (no input validation), and codex/gemini aliases (not documented in this scope).

## Test plan
- [x] `npm run build` → ✓ Compiled successfully.
- [x] Diff is a 6-line addition to `MODEL_OPTIONS.claude`; no other paths touched.
- The list flows through `optionsForBackend("claude")` to both the dropdown render and the custom-value preserve check, so persisting `model: "opus"` is straightforward and Restart will spawn `claude --model opus`.

Fixes #841