### PR TITLE
[#840] Add Opus 4.8 (claude-opus-4-8) to the Agent Models dropdown

### DIFF
--- a/src/components/AgentModelsWidget.tsx
+++ b/src/components/AgentModelsWidget.tsx
@@ -112,6 +112,7 @@ export const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> =
   ],
   claude: [
     { value: "", label: "(CLI default)" },
+    { value: "claude-opus-4-8", label: "claude-opus-4-8" },
     { value: "claude-opus-4-7", label: "claude-opus-4-7" },
     { value: "claude-opus-4-6", label: "claude-opus-4-6" },
     { value: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },


### PR DESCRIPTION
Closes #840.

## Problem
`MODEL_OPTIONS.claude` in `src/components/AgentModelsWidget.tsx` topped out at `claude-opus-4-7`, so `claude` agents (dev/re2) couldn't be set to the now-available Opus 4.8 (`claude-opus-4-8`) from the Agent Models widget.

## Fix
Add `{ value: "claude-opus-4-8", label: "claude-opus-4-8" }` at the top of the `claude` list (mirrors how #510 added 4.7). One-line config change.

`server/index.js` already pushes `--model <slug>` for the claude CLI base when `agentCfg.model` is set, so selecting it persists `model: "claude-opus-4-8"` and the agent spawns with `--model claude-opus-4-8` — no backend change needed.

## Acceptance criteria
- [x] `claude-opus-4-8` selectable in the Agent Models widget (and Settings) for claude agents
- [x] Selecting it persists `model: "claude-opus-4-8"` → agent spawns with `--model claude-opus-4-8`
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)