### PR TITLE
[#836] Unref routes.js module-load pollers + add cross-platform npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start": "node server/",
     "lint": "eslint",
     "server": "node server/",
+    "test": "node server/run-tests.js",
     "prepack": "npm run build",
     "release:patch": "npm version patch && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",
     "release:minor": "npm version minor && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",

--- a/server/routes.js
+++ b/server/routes.js
@@ -93,7 +93,13 @@ async function refreshRateLimit() {
 function startRateLimitPolling() {
   if (_rateLimitTimer) return;
   refreshRateLimit();
+  // #836: .unref() so this interval doesn't alone pin the event loop.
+  // Production keeps the process alive via the Express HTTP listener, so
+  // cadence/auto-start is unchanged; .unref() only lets test imports and
+  // one-off `node -e` invocations exit cleanly (an unref'd `node -e` poller
+  // ran for 11 days in the wild before this was caught).
   _rateLimitTimer = setInterval(refreshRateLimit, RATE_LIMIT_POLL_MS);
+  _rateLimitTimer.unref();
 }
 
 function isRateLimited() {
@@ -1834,9 +1840,13 @@ async function refreshGraphQLCache() {
 let _graphqlPollTimer = null;
 function startGraphQLPolling() {
   if (_graphqlPollTimer) return;
+  // #836: both the warm-up setTimeout and the steady-state setInterval are
+  // .unref()'d so a test/import process can exit. The Express HTTP listener
+  // keeps prod alive on its own; cadence is unchanged.
   // Initial fetch after a short delay (let rate-limit poll run first).
-  setTimeout(() => refreshGraphQLCache(), 2000);
+  setTimeout(() => refreshGraphQLCache(), 2000).unref();
   _graphqlPollTimer = setInterval(refreshGraphQLCache, GRAPHQL_CACHE_TTL);
+  _graphqlPollTimer.unref();
 }
 
 // ─── #810: batch progress sourced from the REST snapshot ──────────────────

--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// #836: cross-platform test runner. Discovers every `*.test.js` file under
+// `server/` via fs.readdirSync recursion (no shell glob — must work on
+// Windows) and runs each one in its own `node <file>` child process. The
+// per-file process isolates any residual module state (#836 root cause: the
+// shared routes.js module pollers used to pin the loop across files in
+// `node --test server/*.test.js`, hanging the whole suite). Aggregate exit
+// code is non-zero if any child fails or times out.
+//
+// Out of scope for #836: the two Jest-style tests under server/__tests__/
+// (bridge-auto-stop-guard, rate-limit-handling) use `describe`/`expect` and
+// can't run under plain node yet. They're explicitly skipped here with a
+// clear log line so a future rewrite is obvious work.
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const SERVER_DIR = __dirname;
+const ROOT = path.resolve(SERVER_DIR, "..");
+const PER_FILE_TIMEOUT_MS = 60_000;
+
+// Skip-list keyed by absolute path so the runner stays Windows-friendly.
+const SKIP = new Set([
+  path.join(SERVER_DIR, "__tests__", "bridge-auto-stop-guard.test.js"),
+  path.join(SERVER_DIR, "__tests__", "rate-limit-handling.test.js"),
+]);
+
+function discover(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...discover(full));
+    else if (entry.isFile() && entry.name.endsWith(".test.js")) out.push(full);
+  }
+  return out;
+}
+
+function runOne(file) {
+  return new Promise((resolve) => {
+    let timedOut = false;
+    const child = spawn(process.execPath, [file], {
+      cwd: ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => { stdout += d.toString(); });
+    child.stderr.on("data", (d) => { stderr += d.toString(); });
+    const killer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, PER_FILE_TIMEOUT_MS);
+    child.on("close", (code, signal) => {
+      clearTimeout(killer);
+      resolve({ file, code, signal, stdout, stderr, timedOut });
+    });
+    child.on("error", (err) => {
+      clearTimeout(killer);
+      resolve({ file, code: -1, signal: null, stdout, stderr: stderr + String(err), timedOut: false });
+    });
+  });
+}
+
+function indent(text, marker) {
+  if (!text) return "";
+  return text.split("\n").map((l) => `  ${marker} ${l}`).join("\n");
+}
+
+(async () => {
+  const allFiles = discover(SERVER_DIR).sort();
+  const runnable = allFiles.filter((f) => !SKIP.has(f));
+  const skipped = allFiles.filter((f) => SKIP.has(f));
+
+  console.log(`\nDiscovered ${allFiles.length} test files (${skipped.length} skipped, ${runnable.length} to run).\n`);
+
+  let passed = 0;
+  let failed = 0;
+  const failures = [];
+
+  for (const file of runnable) {
+    const rel = path.relative(ROOT, file);
+    process.stdout.write(`▶ ${rel} … `);
+    const r = await runOne(file);
+    if (r.timedOut) {
+      console.log(`TIMEOUT (>${PER_FILE_TIMEOUT_MS / 1000}s)`);
+      failed++;
+      failures.push({ file: rel, reason: `timed out after ${PER_FILE_TIMEOUT_MS / 1000}s`, stdout: r.stdout, stderr: r.stderr });
+    } else if (r.code === 0) {
+      console.log("PASS");
+      passed++;
+    } else {
+      console.log(`FAIL (exit ${r.code}${r.signal ? `, signal ${r.signal}` : ""})`);
+      failed++;
+      failures.push({ file: rel, reason: `exit ${r.code}${r.signal ? `, signal ${r.signal}` : ""}`, stdout: r.stdout, stderr: r.stderr });
+    }
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed, ${skipped.length} skipped.`);
+
+  if (skipped.length) {
+    console.log("\nSkipped (Jest-style — out of #836 scope; rewrite separately):");
+    for (const f of skipped) console.log(`  - ${path.relative(ROOT, f)}`);
+  }
+
+  if (failures.length) {
+    console.log("\nFailure details:\n");
+    for (const f of failures) {
+      console.log(`▼ ${f.file} (${f.reason})`);
+      if (f.stdout) console.log(indent(f.stdout.replace(/\n$/, ""), "|"));
+      if (f.stderr) console.log(indent(f.stderr.replace(/\n$/, ""), "!"));
+      console.log("");
+    }
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+})().catch((err) => {
+  console.error("test runner crashed:", err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
Two coupled changes for the test-suite-hang root cause flagged in #836:

1. **`.unref()` the three module-load timers in `server/routes.js`**:
   - `startRateLimitPolling()`'s `setInterval(refreshRateLimit, …)` (line ~96)
   - `startGraphQLPolling()`'s warmup `setTimeout(refreshGraphQLCache, 2000)` (line ~1838)
   - `startGraphQLPolling()`'s steady-state `setInterval(refreshGraphQLCache, …)` (line ~1839)

   Production is **unaffected** — the Express HTTP listener already keeps the process alive, so polling cadence and auto-start at module load are unchanged. `.unref()` only stops these timers from *alone* pinning the event loop, which is what was hanging `node --test` and any one-off `node -e` invocation that touched routes.js.

2. **Add `server/run-tests.js` + `"test": "node server/run-tests.js"`**:
   - Discovers every `*.test.js` under `server/` via `fs.readdirSync` recursion (no shell globs → Windows-clean).
   - Runs each file in its own `node <file>` child process. Per-file isolation also prevents residual module state from re-introducing this bug.
   - 60s per-file timeout safety net.
   - Aggregate exit code: 1 if any file fails or times out, 0 otherwise.
   - The two `__tests__/*.test.js` Jest-style files (`bridge-auto-stop-guard`, `rate-limit-handling`) are documented as skipped — rewriting them is out-of-scope per the issue body.

## Test plan
- [x] `npm test` → 24 passed, 0 failed, 2 skipped (no hang).
- [x] `node --test server/routes.batchProgress.test.js server/routes.parseActiveBatch.test.js` — the two files that used to hang now exit in ~550ms.
- [x] `npm run build` → ✓ Compiled successfully.
- [x] Runner uses `path.join` / `process.execPath` / `child_process.spawn` (no shell, no globs) — cross-platform clean.

Fixes #836