### PR TITLE
[#836] Unref routes.js module-load pollers + add cross-platform 'npm test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "test": "node server/run-tests.js",
     "start": "node server/",
     "lint": "eslint",
     "server": "node server/",

--- a/server/routes.js
+++ b/server/routes.js
@@ -93,7 +93,10 @@ async function refreshRateLimit() {
 function startRateLimitPolling() {
   if (_rateLimitTimer) return;
   refreshRateLimit();
-  _rateLimitTimer = setInterval(refreshRateLimit, RATE_LIMIT_POLL_MS);
+  // #836: .unref() so this module-load poller doesn't alone pin the event
+  // loop — lets a test/import process exit. The Express listener keeps the
+  // real server alive, so polling cadence is unchanged in production.
+  _rateLimitTimer = setInterval(refreshRateLimit, RATE_LIMIT_POLL_MS).unref();
 }
 
 function isRateLimited() {
@@ -1835,8 +1838,11 @@ let _graphqlPollTimer = null;
 function startGraphQLPolling() {
   if (_graphqlPollTimer) return;
   // Initial fetch after a short delay (let rate-limit poll run first).
-  setTimeout(() => refreshGraphQLCache(), 2000);
-  _graphqlPollTimer = setInterval(refreshGraphQLCache, GRAPHQL_CACHE_TTL);
+  // #836: .unref() both timers so an importing process (test / one-off
+  // node -e) can exit — production cadence is unchanged (HTTP listener
+  // keeps the server alive).
+  setTimeout(() => refreshGraphQLCache(), 2000).unref();
+  _graphqlPollTimer = setInterval(refreshGraphQLCache, GRAPHQL_CACHE_TTL).unref();
 }
 
 // ─── #810: batch progress sourced from the REST snapshot ──────────────────

--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+"use strict";
+
+// #836: cross-platform test runner (wired as `npm test`).
+//
+// Discovers every `*.test.js` under server/ via fs recursion — NO shell
+// glob or `find`, so it works identically on Windows, macOS, and Linux —
+// and runs each file in its own child process. Per-file isolation means
+// residual module state (e.g. a required ./routes singleton) can't leak
+// between files, and a single hanging/failing file can't take down the
+// rest of the sweep. Exits non-zero if any file fails or times out.
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const ROOT = __dirname; // server/
+const PER_FILE_TIMEOUT_MS = 60_000;
+
+// Jest-global suites (`describe`/`expect`) — not runnable under plain
+// `node`, and there is no Jest configured. Migrating them to node:assert
+// is explicitly out of scope for #836 (tracked separately). Skip so the
+// sweep stays green. Paths are relative to ROOT, posix-normalized.
+const SKIP = new Set([
+  "__tests__/rate-limit-handling.test.js",
+  "__tests__/bridge-auto-stop-guard.test.js",
+]);
+
+function findTestFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...findTestFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith(".test.js")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const rel = (f) => path.relative(ROOT, f).split(path.sep).join("/");
+
+const files = findTestFiles(ROOT)
+  .filter((f) => !SKIP.has(rel(f)))
+  .sort();
+
+let failed = 0;
+for (const file of files) {
+  const name = rel(file);
+  process.stdout.write(`\n▶ ${name}\n`);
+  const res = spawnSync(process.execPath, [file], {
+    stdio: "inherit",
+    timeout: PER_FILE_TIMEOUT_MS,
+  });
+  if (res.error) {
+    const why =
+      res.error.code === "ETIMEDOUT"
+        ? `TIMEOUT after ${PER_FILE_TIMEOUT_MS}ms`
+        : res.error.message;
+    console.error(`✗ ${why}: ${name}`);
+    failed++;
+  } else if (res.status !== 0) {
+    const sig = res.signal ? `, signal ${res.signal}` : "";
+    console.error(`✗ FAILED (exit ${res.status}${sig}): ${name}`);
+    failed++;
+  }
+}
+
+const total = files.length;
+console.log(
+  `\n${total - failed}/${total} test files passed${failed ? `, ${failed} FAILED` : ""}.`
+);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closes #836.

## Problem
The full server test sweep (`node --test server/*.test.js`) hung after `routes.batchProgress.test.js` / `routes.parseActiveBatch.test.js` printed their pass messages — assertions passed but the process never exited. Cause: `server/routes.js` starts background pollers at module load whose timers were not `.unref()`'d, so any process that `require()`s the module (a test, a stray `node -e`) had its event loop pinned forever. There was also no `npm test` script.

## Fix
**1. `.unref()` the three module-load timers** (`startRateLimitPolling`'s `setInterval(refreshRateLimit)`, and `startGraphQLPolling`'s `setTimeout(refreshGraphQLCache, 2000)` + `setInterval(refreshGraphQLCache)`).
- Production-invisible: the Express HTTP listener keeps the server process alive, so the pollers still fire on the same cadence and auto-start at module load is preserved. `.unref()` only stops them from *alone* pinning the loop — which is exactly what lets a test/import process exit.

**2. Add `server/run-tests.js`, wired as `npm test`** (`"test": "node server/run-tests.js"`).
- Discovers `*.test.js` under `server/` via `fs.readdirSync` recursion — no shell glob / `find`, so it works identically on Windows/macOS/Linux.
- Runs **each file in its own child process** (`spawnSync`) with a per-file timeout; fails the aggregate run on any non-zero exit or timeout. Per-file isolation also prevents residual module state from leaking between files.
- Skips the two Jest-global suites (`__tests__/rate-limit-handling.test.js`, `__tests__/bridge-auto-stop-guard.test.js`) — migrating them to `node:assert` is explicitly out of scope; there is no Jest configured, so they aren't runnable under plain `node`.

## Verification
- `npm test` → **24/24 test files pass, runner exits 0** — no hang on the route-test files.
- `node -e 'require("./server/routes.js")'` now **exits naturally** (previously hung).
- `npm run build` passes.

## Acceptance criteria
- [x] Suite terminates — no hang on the route-test files; all suites pass
- [x] The three `routes.js` module-load timers are `.unref()`'d; production polling cadence/auto-start unchanged
- [x] `npm test` runs the full suite cross-platform (no `find`/shell-glob), each file in its own process, correct aggregate exit code
- [x] `npm run build` passes

## Out of scope (per issue)
- GitHub Actions CI workflow (follow-up once `npm test` is green).
- Rewriting the two Jest-global suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)