### PR TITLE
[#846] ActiveSwitch ON knob offset undershoots (translate-x-[12px] → [14px])

### DIFF
--- a/src/components/ActiveSwitch.tsx
+++ b/src/components/ActiveSwitch.tsx
@@ -31,7 +31,7 @@ export default function ActiveSwitch({ active, onToggle, disabled, title }: Acti
     >
       <span
         className={`block h-2 w-2 transition-transform duration-150 ${
-          active ? "translate-x-[12px] bg-accent" : "translate-x-[2px] bg-text-muted"
+          active ? "translate-x-[14px] bg-accent" : "translate-x-[2px] bg-text-muted"
         }`}
       />
     </button>


### PR DESCRIPTION
Closes #846. Follow-up to #838 (PR #843).

## Problem
#838 shrank the sidebar Active/Inactive switch to a `h-3 w-6` (24px) track + `h-2 w-2` (8px) knob, with the OFF knob at `translate-x-[2px]` (2px from the left). But the ON-state offset was `translate-x-[12px]`, leaving ~4px of gap on the right vs 2px on the left — so the knob wasn't flush at the right end (failing #838's "flush at both ends" criterion).

## Fix
`src/components/ActiveSwitch.tsx:34` — ON offset `translate-x-[12px]` → `translate-x-[14px]`. For symmetry with the 2px OFF inset: `24 (track) − 8 (knob) − 2 (right inset) = 14px`.

## Acceptance criteria
- [x] Knob sits flush (≈2px) at BOTH ON and OFF ends
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)