### PR TITLE
[#845] Re-seed worktree AGENTS.md from current templates

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -3043,16 +3043,38 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
   if (!workingDir) return res.status(400).json({ ok: false, error: "Project has no working_dir" });
 
   if (!force) {
+    // re1 review on #845: fail CLOSED when batch state can't be computed.
+    // Falling through to a re-seed when the gate is uncertain re-introduces
+    // the exact mid-batch rewrite the gate exists to prevent. Three cases
+    // route to the same "unknown" 503 (operator can retry or pass force:true):
+    //  1. getOrComputeBatchProgress throws (network/IO)
+    //  2. getOrComputeBatchProgress returns null (no repo / no progress data)
+    //  3. isBatchActiveFromProgress returns null (no items payload)
+    let active;
     try {
       const progress = await getOrComputeBatchProgress(projectId);
-      if (isBatchActiveFromProgress(progress)) {
-        return res.status(409).json({
-          ok: false,
-          error: "Batch is active — re-seed deferred to avoid mid-batch instruction drift. Pass force:true to override; new seed content only takes effect on next agent restart.",
-          batchActive: true,
-        });
-      }
-    } catch { /* progress unavailable → fall through and re-seed */ }
+      active = isBatchActiveFromProgress(progress);
+    } catch {
+      return res.status(503).json({
+        ok: false,
+        error: "Could not verify batch state — aborting to avoid a mid-batch re-seed. Retry, or pass force:true to override.",
+        batchUnknown: true,
+      });
+    }
+    if (active === null) {
+      return res.status(503).json({
+        ok: false,
+        error: "Batch state unknown (no progress data) — aborting to avoid a mid-batch re-seed. Retry, or pass force:true to override.",
+        batchUnknown: true,
+      });
+    }
+    if (active) {
+      return res.status(409).json({
+        ok: false,
+        error: "Batch is active — re-seed deferred to avoid mid-batch instruction drift. Pass force:true to override; new seed content only takes effect on next agent restart.",
+        batchActive: true,
+      });
+    }
   }
 
   const dirName = path.basename(workingDir);

--- a/server/routes.js
+++ b/server/routes.js
@@ -2961,6 +2961,146 @@ router.post("/api/setup", (req, res) => {
   }
 });
 
+// ─── Re-seed agents from current templates (#845) ──────────────────────────
+
+// Split an AGENTS.md into the leading "intro" text (above the first H2) plus
+// one block per `## H2` heading. Lines that begin with `## ` (exactly two
+// hashes + whitespace) start a new block; H1 / H3+ stay inside the current
+// block so subsections nested under an H2 are not orphaned.
+function _splitAgentsMdSections(text) {
+  const blocks = [];
+  let intro = [];
+  let current = null;
+  for (const line of String(text || "").split("\n")) {
+    const m = line.match(/^##\s+(.+?)\s*$/);
+    if (m) {
+      if (current) blocks.push(current);
+      current = { heading: m[1], body: "" };
+    } else if (current) {
+      current.body += (current.body ? "\n" : "") + line;
+    } else {
+      intro.push(line);
+    }
+  }
+  if (current) blocks.push(current);
+  return { intro: intro.join("\n"), blocks };
+}
+
+// Merge a fresh seed template with operator-added sections from the existing
+// worktree AGENTS.md. The fresh template wins for any H2 heading it defines
+// (so canonical role/workflow/communication sections always reflect current
+// rules), and any H2 block in the existing file whose heading is NOT in the
+// template is appended at the end under a marker comment. Heading comparison
+// is case-insensitive and whitespace-normalized.
+//
+// Returns { content, preservedHeadings }. If the existing content is empty
+// or has no custom sections, returns the fresh template verbatim.
+function reseedAgentsMd(existingContent, freshContent) {
+  if (!existingContent || !existingContent.trim()) {
+    return { content: freshContent, preservedHeadings: [] };
+  }
+  const norm = (s) => s.toLowerCase().replace(/\s+/g, " ").trim();
+  const fresh = _splitAgentsMdSections(freshContent);
+  const existing = _splitAgentsMdSections(existingContent);
+  const freshHeadings = new Set(fresh.blocks.map((b) => norm(b.heading)));
+  const preserved = existing.blocks.filter((b) => !freshHeadings.has(norm(b.heading)));
+  if (preserved.length === 0) {
+    return { content: freshContent, preservedHeadings: [] };
+  }
+  const trailer =
+    "\n\n<!-- Operator notes preserved from prior AGENTS.md (#845) -->\n\n" +
+    preserved
+      .map((b) => `## ${b.heading}\n${b.body}`.replace(/\s+$/, ""))
+      .join("\n\n");
+  const base = freshContent.replace(/\s+$/, "");
+  return {
+    content: base + trailer + "\n",
+    preservedHeadings: preserved.map((b) => b.heading),
+  };
+}
+
+// Operator-triggered re-seed of a project's worktree AGENTS.md files from
+// the current `templates/seeds/*.AGENTS.md` templates, using the same
+// placeholder substitution as the setup wizard's `seed-files` step. New
+// seed content (e.g. the #809 GITHUB.md discovery instructions) takes
+// effect on the NEXT agent restart — this endpoint only rewrites the file.
+//
+// Guard: refuses to run while the project's batch is active, so a re-seed
+// can't drop new instructions on agents in the middle of a task. Pass
+// `{ force: true }` to override (operator escape hatch — the file is only
+// re-read on next spawn, so even a forced re-seed is harmless to a live
+// session, but the guard makes the safe path obvious).
+router.post("/api/projects/:project/reseed-agents", async (req, res) => {
+  const projectId = req.params.project;
+  const body = req.body || {};
+  const force = body.force === true;
+  let cfg;
+  try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); }
+  catch { return res.status(500).json({ ok: false, error: "Failed to read config" }); }
+  const project = cfg.projects?.find((p) => p.id === projectId);
+  if (!project) return res.status(404).json({ ok: false, error: "Project not found" });
+  const workingDir = project.working_dir;
+  if (!workingDir) return res.status(400).json({ ok: false, error: "Project has no working_dir" });
+
+  if (!force) {
+    try {
+      const progress = await getOrComputeBatchProgress(projectId);
+      if (isBatchActiveFromProgress(progress)) {
+        return res.status(409).json({
+          ok: false,
+          error: "Batch is active — re-seed deferred to avoid mid-batch instruction drift. Pass force:true to override; new seed content only takes effect on next agent restart.",
+          batchActive: true,
+        });
+      }
+    } catch { /* progress unavailable → fall through and re-seed */ }
+  }
+
+  const dirName = path.basename(workingDir);
+  const parentDir = path.dirname(workingDir);
+  const reviewerUser = body.reviewerUser ?? cfg.reviewer_github_user ?? "";
+  const reviewerTokenPath = body.reviewerTokenPath || path.join(os.homedir(), ".quadwork", "reviewer-token");
+
+  const agents = ["head", "re1", "re2", "dev"];
+  const reseeded = [];
+  const preserved = {};
+  const skipped = [];
+  for (const agent of agents) {
+    const wtDir = path.join(parentDir, `${dirName}-${agent}`);
+    if (!fs.existsSync(wtDir)) { skipped.push(`${agent} (no worktree)`); continue; }
+    const seedSrc = path.join(TEMPLATES_DIR, "seeds", `${agent}.AGENTS.md`);
+    if (!fs.existsSync(seedSrc)) {
+      return res.status(500).json({
+        ok: false,
+        error: `Missing seed template: templates/seeds/${agent}.AGENTS.md`,
+      });
+    }
+    let freshContent = fs.readFileSync(seedSrc, "utf-8");
+    freshContent = freshContent
+      .replace(/\{\{reviewer_github_user\}\}/g, reviewerUser)
+      .replace(/\{\{reviewer_token_path\}\}/g, reviewerTokenPath)
+      .replace(/\{\{project_name\}\}/g, dirName);
+
+    const agentsMd = path.join(wtDir, "AGENTS.md");
+    let existing = "";
+    if (fs.existsSync(agentsMd)) {
+      try { existing = fs.readFileSync(agentsMd, "utf-8"); } catch { existing = ""; }
+    }
+    const merged = reseedAgentsMd(existing, freshContent);
+    fs.writeFileSync(agentsMd, merged.content);
+    reseeded.push(`${agent}/AGENTS.md`);
+    if (merged.preservedHeadings.length > 0) {
+      preserved[agent] = merged.preservedHeadings;
+    }
+  }
+  return res.json({
+    ok: true,
+    reseeded,
+    skipped,
+    preserved,
+    note: "Re-seeded files take effect on next agent restart.",
+  });
+});
+
 // ─── Rename ────────────────────────────────────────────────────────────────
 
 function replaceInFile(filePath, oldStr, newStr) {
@@ -3517,6 +3657,10 @@ module.exports.ghApiConditional = ghApiConditional;
 module.exports.GH_LIST_MAX_BUFFER = GH_LIST_MAX_BUFFER;
 // #839: expose the completion-aware sidebar-heartbeat helper for unit tests.
 module.exports.isBatchActiveFromProgress = isBatchActiveFromProgress;
+// #845: expose the AGENTS.md re-seed merger so the placeholder substitution +
+// custom-section preservation contract is exercisable without spinning up a
+// real worktree. Pure function; no production callers outside this file.
+module.exports.reseedAgentsMd = reseedAgentsMd;
 // #839 (re1 follow-up): expose the shared compute path plus the caches it
 // reads so the cache-miss completed-batch case is exercisable end-to-end.
 module.exports.getOrComputeBatchProgress = getOrComputeBatchProgress;

--- a/server/routes.reseedAgentsMd.test.js
+++ b/server/routes.reseedAgentsMd.test.js
@@ -1,0 +1,176 @@
+// #845: reseedAgentsMd merger tests. Plain node:assert script — no test
+// runner is wired up. Run with `node server/routes.reseedAgentsMd.test.js`.
+//
+// reseedAgentsMd is re-exported from server/routes.js for this test only;
+// it has no production callers outside routes.js. The function is pure
+// (in-memory strings only) so it does not need a temp-fs harness.
+
+const assert = require("node:assert/strict");
+const { reseedAgentsMd } = require("./routes");
+
+const FRESH = `# Dev — Full-Stack Builder
+
+## Role
+Implement features.
+
+## Workflow
+1. Read assignment.
+2. Open PR.
+
+## Communication
+Use chat_send.
+`;
+
+// 1) Empty / missing existing content → fresh template verbatim, no trailer.
+{
+  const out = reseedAgentsMd("", FRESH);
+  assert.equal(out.content, FRESH, "empty existing → fresh verbatim");
+  assert.deepEqual(out.preservedHeadings, [], "no preserved headings");
+
+  const out2 = reseedAgentsMd("   \n\n", FRESH);
+  assert.equal(out2.content, FRESH, "whitespace-only existing → fresh verbatim");
+
+  const out3 = reseedAgentsMd(null, FRESH);
+  assert.equal(out3.content, FRESH, "null existing → fresh verbatim");
+}
+
+// 2) Existing with ONLY canonical headings (same as template) → fresh
+//    template wins, stale content discarded, nothing preserved. This is
+//    the #845 root case: agents launch with current rules, not the stale
+//    pre-#809 instructions.
+{
+  const stale = `# Dev — Old Title
+
+## Role
+OUTDATED role text that must be replaced.
+
+## Workflow
+Old workflow.
+
+## Communication
+Stale communication rules referencing gh pr list.
+`;
+  const out = reseedAgentsMd(stale, FRESH);
+  assert.equal(out.content, FRESH, "all-canonical existing → fresh wins, no trailer");
+  assert.deepEqual(out.preservedHeadings, []);
+  assert.ok(!out.content.includes("OUTDATED"), "stale body discarded");
+  assert.ok(!out.content.includes("gh pr list"), "stale communication discarded");
+}
+
+// 3) Existing with a `## Notes` operator section → preserved at the end
+//    under the marker comment, canonical sections still come from fresh.
+{
+  const existing = `# Dev — Old Title
+
+## Role
+OLD role.
+
+## Notes
+- Local dev: run npm run dev before pushing.
+- This project uses a custom GH token at ~/.local/token.
+`;
+  const out = reseedAgentsMd(existing, FRESH);
+  assert.ok(out.content.startsWith("# Dev — Full-Stack Builder"), "fresh title at top");
+  assert.ok(!out.content.includes("OLD role"), "stale Role body discarded");
+  assert.ok(out.content.includes("<!-- Operator notes preserved from prior AGENTS.md (#845) -->"), "trailer marker present");
+  assert.ok(out.content.includes("## Notes"), "Notes heading preserved");
+  assert.ok(out.content.includes("Local dev: run npm run dev"), "Notes body preserved");
+  assert.ok(out.content.includes("custom GH token"), "Notes body preserved (line 2)");
+  assert.deepEqual(out.preservedHeadings, ["Notes"]);
+}
+
+// 4) Multiple custom sections preserved in original order; canonical
+//    sections in fresh are not duplicated.
+{
+  const existing = `# Dev
+
+## Role
+old
+
+## Project-Specific Quirks
+This repo has an unusual build chain.
+
+## Notes
+- Don't touch the migrations folder without asking.
+
+## Workflow
+old workflow
+`;
+  const out = reseedAgentsMd(existing, FRESH);
+  assert.deepEqual(out.preservedHeadings, ["Project-Specific Quirks", "Notes"], "order preserved");
+  assert.ok(out.content.includes("## Project-Specific Quirks"));
+  assert.ok(out.content.includes("unusual build chain"));
+  assert.ok(out.content.includes("## Notes"));
+  assert.ok(out.content.includes("migrations folder"));
+  // Canonical Role and Workflow appear EXACTLY once each (from fresh).
+  const roleMatches = out.content.match(/^## Role\b/gm) || [];
+  const workflowMatches = out.content.match(/^## Workflow\b/gm) || [];
+  assert.equal(roleMatches.length, 1, "## Role appears exactly once");
+  assert.equal(workflowMatches.length, 1, "## Workflow appears exactly once");
+}
+
+// 5) Heading match is case-insensitive and whitespace-normalized — a
+//    stale "## role" or "##  Role  " block is NOT preserved as custom.
+{
+  const existing = `# Dev
+
+## role
+mixed case heading
+
+##  Workflow
+trailing spaces
+
+## CustomBoxOnly
+keep me
+`;
+  const out = reseedAgentsMd(existing, FRESH);
+  assert.deepEqual(out.preservedHeadings, ["CustomBoxOnly"], "only the genuinely-custom heading is preserved");
+  assert.ok(!out.content.includes("mixed case heading"));
+  assert.ok(!out.content.includes("trailing spaces"));
+  assert.ok(out.content.includes("keep me"));
+}
+
+// 6) H3+ subsections inside a custom H2 stay nested under their parent
+//    (no orphaning). They must NOT be treated as their own H2 blocks.
+{
+  const existing = [
+    "# Dev",
+    "",
+    "## Notes",
+    "",
+    "### Local setup",
+    "Run `npm install` first.",
+    "",
+    "### Common pitfalls",
+    "The build cache lies — `rm -rf .next` when in doubt.",
+    "",
+  ].join("\n");
+  const out = reseedAgentsMd(existing, FRESH);
+  assert.deepEqual(out.preservedHeadings, ["Notes"]);
+  assert.ok(out.content.includes("### Local setup"), "H3 subsection survives under its parent");
+  assert.ok(out.content.includes("### Common pitfalls"));
+  assert.ok(out.content.includes("npm install"));
+  assert.ok(out.content.includes("rm -rf .next"));
+}
+
+// 7) Fresh template's trailing whitespace is normalized so the trailer
+//    attaches cleanly (no triple blank lines).
+{
+  const freshWithTrailing = FRESH + "\n\n\n";
+  const existing = `## Notes\n- a note\n`;
+  const out = reseedAgentsMd(existing, freshWithTrailing);
+  assert.ok(!/\n\n\n\n/.test(out.content), "no run of >2 consecutive blank lines");
+  assert.ok(out.content.endsWith("\n"), "ends with single newline");
+}
+
+// 8) Placeholder substitution is the caller's job (the endpoint substitutes
+//    {{project_name}} / {{reviewer_*}} BEFORE calling the merger). Verify
+//    the merger does not touch placeholders so an operator can preserve
+//    legitimate literal {{...}} text in a custom section.
+{
+  const existing = "## Notes\nWe document our placeholder convention as `{{project_name}}` for examples.\n";
+  const out = reseedAgentsMd(existing, FRESH);
+  assert.ok(out.content.includes("`{{project_name}}`"), "merger leaves placeholders untouched in custom sections");
+}
+
+console.log("routes.reseedAgentsMd.test.js: all assertions passed (8 cases)");

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -25,6 +25,11 @@ const COPY = {
       confirmFullReset: "Reset all projects?",
       fullResetResult: (projects: number, agents: number, ms: number) => `Full reset — ${projects} project${projects !== 1 ? "s" : ""}, ${agents} agent${agents !== 1 ? "s" : ""} (${(ms / 1000).toFixed(1)}s)`,
       fullResetFailed: "Full reset failed",
+      reseed: "Re-seed AGENTS.md",
+      confirmReseed: "Overwrite worktree AGENTS.md?",
+      reseedResult: (n: number) => `Re-seeded ${n} AGENTS.md file${n !== 1 ? "s" : ""} — restart agents to apply`,
+      reseedBlocked: "Batch active — re-seed deferred (restart agents to apply on next batch)",
+      reseedFailed: "Re-seed failed",
       interrupt: "Interrupt",
       interruptAll: "All agents",
       interrupted: (name: string) => `Interrupted ${name}`,
@@ -71,6 +76,11 @@ const COPY = {
       confirmFullReset: "모든 프로젝트를 리셋할까요?",
       fullResetResult: (projects: number, agents: number, ms: number) => `전체 리셋 완료 — ${projects}개 프로젝트, ${agents}개 에이전트 (${(ms / 1000).toFixed(1)}초)`,
       fullResetFailed: "전체 리셋 실패",
+      reseed: "AGENTS.md 재시드",
+      confirmReseed: "워크트리 AGENTS.md를 덮어쓸까요?",
+      reseedResult: (n: number) => `AGENTS.md ${n}개 재시드 완료 — 적용하려면 에이전트를 재시작하세요`,
+      reseedBlocked: "배치 실행 중 — 재시드 보류 (다음 배치 전에 에이전트를 재시작하세요)",
+      reseedFailed: "재시드 실패",
       interrupt: "중단",
       interruptAll: "모든 에이전트",
       interrupted: (name: string) => `${name} 중단됨`,
@@ -116,6 +126,7 @@ function ServerSection({ projectId }: { projectId: string }) {
   const [loading, setLoading] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [confirmFullReset, setConfirmFullReset] = useState(false);
+  const [confirmReseed, setConfirmReseed] = useState(false);
   const [showInterrupt, setShowInterrupt] = useState(false);
   const [agentStates, setAgentStates] = useState<Record<string, string>>({});
   const interruptRef = useRef<HTMLDivElement>(null);
@@ -183,6 +194,12 @@ function ServerSection({ projectId }: { projectId: string }) {
     return () => clearTimeout(timer);
   }, [confirmFullReset]);
 
+  useEffect(() => {
+    if (!confirmReseed) return;
+    const timer = setTimeout(() => setConfirmReseed(false), 4000);
+    return () => clearTimeout(timer);
+  }, [confirmReseed]);
+
   const handleFullReset = async () => {
     if (!confirmFullReset) {
       setConfirmFullReset(true);
@@ -221,6 +238,35 @@ function ServerSection({ projectId }: { projectId: string }) {
     clearFeedback();
   };
 
+  // #845: re-seed worktree AGENTS.md from the current templates without
+  // recreating the project. The server refuses to run mid-batch (HTTP 409
+  // with batchActive flag); the operator can still force via "Re-seed"
+  // again after batch completes. New content only takes effect on the
+  // next agent restart — feedback message tells the operator to restart.
+  const handleReseed = async () => {
+    if (!confirmReseed) { setConfirmReseed(true); return; }
+    setConfirmReseed(false);
+    setLoading("reseed");
+    try {
+      const r = await fetch(
+        `/api/projects/${encodeURIComponent(projectId)}/reseed-agents`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }
+      );
+      const d = await r.json();
+      if (d.ok) {
+        setFeedback(t.reseedResult((d.reseeded || []).length));
+      } else if (d.batchActive) {
+        setFeedback(t.reseedBlocked);
+      } else {
+        setFeedback(d.error || t.reseedFailed);
+      }
+    } catch {
+      setFeedback(t.reseedFailed);
+    }
+    setLoading(null);
+    clearFeedback();
+  };
+
   return (
     <div className="flex flex-col gap-1">
       <div className="text-[10px] text-text-muted uppercase tracking-wider font-semibold">
@@ -244,6 +290,18 @@ function ServerSection({ projectId }: { projectId: string }) {
           }`}
         >
           {loading === "fullReset" ? "..." : confirmFullReset ? t.confirmFullReset : t.fullReset}
+        </button>
+        <button
+          onClick={handleReseed}
+          disabled={!!loading}
+          title={t.reseed}
+          className={`px-1.5 py-0.5 text-[10px] border transition-colors disabled:opacity-50 ${
+            confirmReseed
+              ? "text-error border-error/60 bg-error/10 hover:bg-error/20"
+              : "text-text-muted border-border hover:text-accent hover:border-accent/40"
+          }`}
+        >
+          {loading === "reseed" ? "..." : confirmReseed ? t.confirmReseed : t.reseed}
         </button>
         <div className="relative" ref={interruptRef}>
           <button

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -29,6 +29,7 @@ const COPY = {
       confirmReseed: "Overwrite worktree AGENTS.md?",
       reseedResult: (n: number) => `Re-seeded ${n} AGENTS.md file${n !== 1 ? "s" : ""} — restart agents to apply`,
       reseedBlocked: "Batch active — re-seed deferred (restart agents to apply on next batch)",
+      reseedUnknown: "Batch state unknown — re-seed aborted; retry in a moment",
       reseedFailed: "Re-seed failed",
       interrupt: "Interrupt",
       interruptAll: "All agents",
@@ -80,6 +81,7 @@ const COPY = {
       confirmReseed: "워크트리 AGENTS.md를 덮어쓸까요?",
       reseedResult: (n: number) => `AGENTS.md ${n}개 재시드 완료 — 적용하려면 에이전트를 재시작하세요`,
       reseedBlocked: "배치 실행 중 — 재시드 보류 (다음 배치 전에 에이전트를 재시작하세요)",
+      reseedUnknown: "배치 상태 확인 불가 — 재시드 중단됨; 잠시 후 다시 시도하세요",
       reseedFailed: "재시드 실패",
       interrupt: "중단",
       interruptAll: "모든 에이전트",
@@ -257,6 +259,8 @@ function ServerSection({ projectId }: { projectId: string }) {
         setFeedback(t.reseedResult((d.reseeded || []).length));
       } else if (d.batchActive) {
         setFeedback(t.reseedBlocked);
+      } else if (d.batchUnknown) {
+        setFeedback(t.reseedUnknown);
       } else {
         setFeedback(d.error || t.reseedFailed);
       }


### PR DESCRIPTION
## Summary
- New `POST /api/projects/:id/reseed-agents` rewrites each worktree `AGENTS.md` from `templates/seeds/*.AGENTS.md` with the existing placeholder substitution (`{{project_name}}`, `{{reviewer_github_user}}`, `{{reviewer_token_path}}`). Refuses to run while the project's batch is active (HTTP 409 + `batchActive: true`); operator can override with `{ force: true }`.
- Pure `reseedAgentsMd(existing, fresh)` merger: fresh template wins for any H2 heading it defines; H2 blocks in the existing file whose heading is NOT in the template (e.g. operator `## Notes`) are appended at the end under a marker comment. Case-insensitive heading match. H3+ subsections stay nested under their parent H2.
- "Re-seed AGENTS.md" button in ControlBar's Server section (en + ko) with the same two-click confirm pattern as Full Reset. Distinct feedback line when the server blocks because a batch is active.
- Re-seeded content only takes effect on next agent restart — feedback message tells the operator to restart agents.

## Acceptance criteria
- [x] Existing project worktree `AGENTS.md` files can be brought up to current templates without project recreation (button + endpoint).
- [x] Does not run mid-batch — server returns `409 { batchActive: true }`; UI surfaces "Batch active — re-seed deferred" instead of error.
- [x] Reviewer identity/token placeholders preserved (`{{reviewer_github_user}}` from global config, token path defaults to `~/.quadwork/reviewer-token`).
- [x] Human-edited notes preserved — any H2 heading not in the template is appended at the end under `<!-- Operator notes preserved from prior AGENTS.md (#845) -->`.
- [x] After re-seed, agents discover via `GITHUB.md` (no instruction to use `gh pr list` for board discovery; the `gh pr list` references that remain are the new `## GitHub State (discovery)` anti-instructions telling agents NOT to use it).
- [x] `npm run build` passes.

## Test plan
- [x] `node server/routes.reseedAgentsMd.test.js` → 8 cases pass (empty existing, all-canonical existing, single Notes preservation, multi-section preservation in order, case-insensitive matching, H3 nesting, trailing whitespace normalization, placeholder pass-through).
- [x] `npm test` → 25 passed, 0 failed, 2 skipped.
- [x] `npm run build` → ✓ compiled.
- [x] End-to-end smoke: created 4 temp worktree dirs with a `## Notes` operator section + stale `## Role` content, ran the merger with real `templates/seeds/*.AGENTS.md`, confirmed all 4 files were reseeded, `## Notes` preserved verbatim, placeholders substituted, dev/AGENTS.md now references `GITHUB.md` for board discovery.

Fixes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)