### PR TITLE
[#855] Re-seed worktree AGENTS.md from agent cwd, map legacy keys

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -3019,6 +3019,45 @@ function reseedAgentsMd(existingContent, freshContent) {
   };
 }
 
+// #855: Map legacy agent config keys to the canonical seed-template names.
+// Older projects (and operator-renamed agents) may use keys like
+// `reviewer1` / `reviewer2` / `t1..t3`; the seed templates only exist for
+// the canonical `head/re1/re2/dev` slugs. Any key not in this table is
+// assumed canonical (so future agent slugs work without a code change).
+const LEGACY_AGENT_KEY_TO_CANONICAL = Object.freeze({
+  t1: "head",
+  t2a: "re1",
+  t2b: "re2",
+  t3: "dev",
+  reviewer1: "re1",
+  reviewer2: "re2",
+});
+
+function _canonicalAgentSlug(agentKey) {
+  return LEGACY_AGENT_KEY_TO_CANONICAL[agentKey] || agentKey;
+}
+
+// #855: Resolve the per-agent re-seed targets for a project. Pulls the
+// worktree path from `project.agents[key].cwd` (the source of truth — the
+// agent process itself spawns there) rather than reconstructing
+// `${dirName}-${key}`, so legacy worktree names like `*-reviewer1` are
+// covered. When a project has no `agents` map at all (very old config),
+// falls back to the canonical sibling layout. Pure — no I/O.
+function _resolveReseedTargets(project) {
+  const workingDir = project?.working_dir;
+  if (!workingDir) return [];
+  const dirName = path.basename(workingDir);
+  const parentDir = path.dirname(workingDir);
+  const agentsCfg = project.agents && typeof project.agents === "object" ? project.agents : null;
+  const keys = agentsCfg ? Object.keys(agentsCfg) : ["head", "re1", "re2", "dev"];
+  return keys.map((agentKey) => {
+    const canonical = _canonicalAgentSlug(agentKey);
+    const configuredCwd = agentsCfg?.[agentKey]?.cwd;
+    const wtDir = configuredCwd || path.join(parentDir, `${dirName}-${canonical}`);
+    return { agentKey, canonical, wtDir };
+  });
+}
+
 // Operator-triggered re-seed of a project's worktree AGENTS.md files from
 // the current `templates/seeds/*.AGENTS.md` templates, using the same
 // placeholder substitution as the setup wizard's `seed-files` step. New
@@ -3078,22 +3117,23 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
   }
 
   const dirName = path.basename(workingDir);
-  const parentDir = path.dirname(workingDir);
   const reviewerUser = body.reviewerUser ?? cfg.reviewer_github_user ?? "";
   const reviewerTokenPath = body.reviewerTokenPath || path.join(os.homedir(), ".quadwork", "reviewer-token");
 
-  const agents = ["head", "re1", "re2", "dev"];
+  // #855: walk the project's configured agents (resolved by `cwd`) instead of
+  // reconstructing sibling paths. Legacy keys (`reviewer1` etc.) still pull
+  // the canonical seed template via `_canonicalAgentSlug`.
+  const targets = _resolveReseedTargets(project);
   const reseeded = [];
   const preserved = {};
   const skipped = [];
-  for (const agent of agents) {
-    const wtDir = path.join(parentDir, `${dirName}-${agent}`);
-    if (!fs.existsSync(wtDir)) { skipped.push(`${agent} (no worktree)`); continue; }
-    const seedSrc = path.join(TEMPLATES_DIR, "seeds", `${agent}.AGENTS.md`);
+  for (const { agentKey, canonical, wtDir } of targets) {
+    if (!fs.existsSync(wtDir)) { skipped.push(`${agentKey} (no worktree)`); continue; }
+    const seedSrc = path.join(TEMPLATES_DIR, "seeds", `${canonical}.AGENTS.md`);
     if (!fs.existsSync(seedSrc)) {
       return res.status(500).json({
         ok: false,
-        error: `Missing seed template: templates/seeds/${agent}.AGENTS.md`,
+        error: `Missing seed template: templates/seeds/${canonical}.AGENTS.md`,
       });
     }
     let freshContent = fs.readFileSync(seedSrc, "utf-8");
@@ -3109,9 +3149,9 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
     }
     const merged = reseedAgentsMd(existing, freshContent);
     fs.writeFileSync(agentsMd, merged.content);
-    reseeded.push(`${agent}/AGENTS.md`);
+    reseeded.push(`${agentKey}/AGENTS.md`);
     if (merged.preservedHeadings.length > 0) {
-      preserved[agent] = merged.preservedHeadings;
+      preserved[agentKey] = merged.preservedHeadings;
     }
   }
   return res.json({
@@ -3683,6 +3723,12 @@ module.exports.isBatchActiveFromProgress = isBatchActiveFromProgress;
 // custom-section preservation contract is exercisable without spinning up a
 // real worktree. Pure function; no production callers outside this file.
 module.exports.reseedAgentsMd = reseedAgentsMd;
+// #855: expose the per-agent target resolver + legacy-key map so the legacy
+// config (`reviewer1` / `reviewer2` / `t1..t3`) → canonical-template mapping
+// is exercisable without spinning up a real worktree. Pure helpers; no
+// production callers outside this file.
+module.exports._resolveReseedTargets = _resolveReseedTargets;
+module.exports._canonicalAgentSlug = _canonicalAgentSlug;
 // #839 (re1 follow-up): expose the shared compute path plus the caches it
 // reads so the cache-miss completed-batch case is exercisable end-to-end.
 module.exports.getOrComputeBatchProgress = getOrComputeBatchProgress;

--- a/server/routes.resolveReseedTargets.test.js
+++ b/server/routes.resolveReseedTargets.test.js
@@ -1,0 +1,152 @@
+// #855: _resolveReseedTargets + _canonicalAgentSlug tests. Verifies the
+// re-seed path walks the project's configured agents from `cwd` (rather
+// than reconstructing `${dirName}-${agentKey}`) and maps legacy agent keys
+// to canonical seed-template slugs.
+//
+// Pure helpers — no fs touching, no temp-dir harness needed. Run with
+// `node server/routes.resolveReseedTargets.test.js` (the cross-platform
+// runner from #836 auto-discovers it).
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { _resolveReseedTargets, _canonicalAgentSlug } = require("./routes");
+
+// 1) Canonical key map — legacy reviewer1/reviewer2/t1..t3 → canonical
+//    head/re1/re2/dev. Unknown / already-canonical keys pass through so
+//    future agent slugs don't need a code change.
+{
+  assert.equal(_canonicalAgentSlug("reviewer1"), "re1");
+  assert.equal(_canonicalAgentSlug("reviewer2"), "re2");
+  assert.equal(_canonicalAgentSlug("t1"), "head");
+  assert.equal(_canonicalAgentSlug("t2a"), "re1");
+  assert.equal(_canonicalAgentSlug("t2b"), "re2");
+  assert.equal(_canonicalAgentSlug("t3"), "dev");
+  // Canonical keys → themselves.
+  for (const k of ["head", "re1", "re2", "dev"]) assert.equal(_canonicalAgentSlug(k), k);
+  // Unknown keys → themselves (no surprise rewrite).
+  assert.equal(_canonicalAgentSlug("ops"), "ops");
+}
+
+// 2) Legacy reviewer1/reviewer2 worktrees — the exact #855 regression case.
+//    Resolver must yield each configured agent's `cwd` verbatim AND map it
+//    to the canonical seed-template slug (re1/re2), so the loop writes the
+//    fresh re1/re2 AGENTS.md into the legacy-named worktree dir.
+{
+  const project = {
+    working_dir: "/Users/op/Projects/plotlink",
+    agents: {
+      head: { cwd: "/Users/op/Projects/plotlink-head" },
+      dev:  { cwd: "/Users/op/Projects/plotlink-dev" },
+      re1:  { cwd: "/Users/op/Projects/plotlink-reviewer1" },
+      re2:  { cwd: "/Users/op/Projects/plotlink-reviewer2" },
+    },
+  };
+  const targets = _resolveReseedTargets(project);
+  assert.equal(targets.length, 4);
+  const byKey = Object.fromEntries(targets.map((t) => [t.agentKey, t]));
+
+  assert.deepEqual(byKey.head, {
+    agentKey: "head", canonical: "head", wtDir: "/Users/op/Projects/plotlink-head",
+  });
+  assert.deepEqual(byKey.dev, {
+    agentKey: "dev", canonical: "dev", wtDir: "/Users/op/Projects/plotlink-dev",
+  });
+  // re1's worktree dir keeps its legacy `*-reviewer1` name (from config cwd),
+  // but the seed template is canonical `re1.AGENTS.md`. Same for re2. This is
+  // the exact bug #855 fixes — the old loop computed `plotlink-re1` and so
+  // never wrote into `plotlink-reviewer1`.
+  assert.deepEqual(byKey.re1, {
+    agentKey: "re1", canonical: "re1", wtDir: "/Users/op/Projects/plotlink-reviewer1",
+  });
+  assert.deepEqual(byKey.re2, {
+    agentKey: "re2", canonical: "re2", wtDir: "/Users/op/Projects/plotlink-reviewer2",
+  });
+}
+
+// 3) Legacy AGENT KEYS (`reviewer1`/`reviewer2`/`t1..t3`) — older configs
+//    used these as the actual `project.agents` keys. Resolver must still
+//    map them to canonical seed templates.
+{
+  const project = {
+    working_dir: "/tmp/legacy",
+    agents: {
+      t1:  { cwd: "/tmp/legacy-t1" },
+      t2a: { cwd: "/tmp/legacy-t2a" },
+      t2b: { cwd: "/tmp/legacy-t2b" },
+      t3:  { cwd: "/tmp/legacy-t3" },
+    },
+  };
+  const targets = _resolveReseedTargets(project);
+  const canonicals = Object.fromEntries(targets.map((t) => [t.agentKey, t.canonical]));
+  assert.deepEqual(canonicals, { t1: "head", t2a: "re1", t2b: "re2", t3: "dev" });
+  // Worktree paths preserved verbatim from config (no rewrite to `*-head`).
+  const wts = Object.fromEntries(targets.map((t) => [t.agentKey, t.wtDir]));
+  assert.deepEqual(wts, {
+    t1: "/tmp/legacy-t1", t2a: "/tmp/legacy-t2a",
+    t2b: "/tmp/legacy-t2b", t3: "/tmp/legacy-t3",
+  });
+}
+
+// 4) Mixed legacy + canonical (e.g. operator renamed only the reviewers but
+//    left head/dev as defaults). Each key resolves independently.
+{
+  const project = {
+    working_dir: "/tmp/mix",
+    agents: {
+      head:      { cwd: "/tmp/mix-head" },
+      dev:       { cwd: "/tmp/mix-dev" },
+      reviewer1: { cwd: "/tmp/mix-reviewer1" },
+      reviewer2: { cwd: "/tmp/mix-reviewer2" },
+    },
+  };
+  const targets = _resolveReseedTargets(project);
+  const summary = targets.map((t) => `${t.agentKey}→${t.canonical}@${t.wtDir}`).sort();
+  assert.deepEqual(summary, [
+    "dev→dev@/tmp/mix-dev",
+    "head→head@/tmp/mix-head",
+    "reviewer1→re1@/tmp/mix-reviewer1",
+    "reviewer2→re2@/tmp/mix-reviewer2",
+  ]);
+}
+
+// 5) Fallback when project has NO `agents` map (very old config) — resolver
+//    walks the canonical default list and computes sibling paths so the
+//    behavior matches the pre-#855 default-layout case.
+{
+  const project = { working_dir: "/srv/oldproj" };
+  const targets = _resolveReseedTargets(project);
+  assert.equal(targets.length, 4);
+  assert.deepEqual(targets.map((t) => t.agentKey), ["head", "re1", "re2", "dev"]);
+  assert.deepEqual(targets.map((t) => t.canonical), ["head", "re1", "re2", "dev"]);
+  for (const t of targets) {
+    assert.equal(t.wtDir, path.join("/srv", `oldproj-${t.canonical}`));
+  }
+}
+
+// 6) Agent config without `cwd` — falls back to sibling computation using the
+//    canonical slug (so a legacy key without a stored cwd still lands in a
+//    sensible default, not undefined).
+{
+  const project = {
+    working_dir: "/srv/half",
+    agents: {
+      reviewer1: {},  // no cwd
+      re2: { cwd: "/srv/half-reviewer2" },
+    },
+  };
+  const targets = _resolveReseedTargets(project);
+  const byKey = Object.fromEntries(targets.map((t) => [t.agentKey, t]));
+  assert.equal(byKey.reviewer1.wtDir, path.join("/srv", "half-re1"));
+  assert.equal(byKey.reviewer1.canonical, "re1");
+  assert.equal(byKey.re2.wtDir, "/srv/half-reviewer2");
+}
+
+// 7) Project without `working_dir` → empty target list (the route handler
+//    already 400s before this is called, but the helper must not throw).
+{
+  assert.deepEqual(_resolveReseedTargets({}), []);
+  assert.deepEqual(_resolveReseedTargets({ working_dir: "" }), []);
+  assert.deepEqual(_resolveReseedTargets(null), []);
+}
+
+console.log("routes.resolveReseedTargets.test.js: all assertions passed (7 cases)");


### PR DESCRIPTION
## Summary

- Fixes #855. The #845 re-seed loop reconstructed `${dirName}-${agent}` and only knew canonical slugs, so reviewers living in `*-reviewer1` / `*-reviewer2` (or projects whose agent keys are `t1..t3` / `reviewer1` / `reviewer2`) were silently skipped — the #809 GITHUB.md discovery instructions never reached those AGENTS.md files.
- Re-seed now walks `project.agents` from config and uses each agent's configured `cwd` as the worktree dir (the source of truth — the agent process spawns there). A new `_canonicalAgentSlug` table maps legacy keys (`reviewer1→re1`, `reviewer2→re2`, `t1→head`, `t2a→re1`, `t2b→re2`, `t3→dev`) to the canonical seed template, so `re1.AGENTS.md` / `re2.AGENTS.md` is what actually gets written into a legacy-named worktree.
- Missing worktrees still report as `skipped`, never as a hard error. Fail-closed batch-state gate, placeholder substitution (`{{project_name}}` / `{{reviewer_*}}`), and the merger from #845 are unchanged.

## Acceptance criteria

- [x] Re-seed updates all configured agents' worktrees regardless of directory naming, including legacy `reviewer1` / `reviewer2` worktrees (resolver pulls `cwd` verbatim).
- [x] Re-seeded re1/re2 AGENTS.md reference `GITHUB.md` discovery as the primary method and no longer contain the old positive `gh pr list` discovery instruction (templates were already updated under #809 — this PR makes them reachable for legacy projects).
- [x] Agents with no existing worktree are reported as `skipped`, not treated as hard errors.
- [x] Added `server/routes.resolveReseedTargets.test.js` covering the `*-reviewer1`/`*-reviewer2` cwd case plus `t1..t3` / mixed / fallback / missing-cwd / empty-working-dir.
- [x] `npm run build` passes.

## Test plan

- [x] `node server/routes.resolveReseedTargets.test.js` → 7 cases pass (canonical passthrough, reviewer1/reviewer2 cwd resolution, t1..t3 legacy keys, mixed legacy + canonical, no-agents fallback, missing-cwd, empty working_dir)
- [x] `node server/routes.reseedAgentsMd.test.js` → 8 cases pass (existing merger contract intact)
- [x] `npm test` → 26 passed, 0 failed, 2 skipped
- [x] `npm run build` → ✓ Compiled successfully

Closes #855