### PR TITLE
[#854] Preserve reviewer token path during AGENTS.md re-seed

### DIFF
--- a/server/routes.extractReviewerTokenPath.test.js
+++ b/server/routes.extractReviewerTokenPath.test.js
@@ -1,0 +1,122 @@
+// #854: _extractReviewerTokenPath unit tests. Pure parser — covers the
+// common shell forms an operator might have edited a worktree AGENTS.md
+// into so the re-seed substitution preserves their custom token path
+// instead of clobbering it with the default.
+//
+// Plain node:assert script — auto-discovered by the #836 cross-platform
+// runner. Run directly with `node server/routes.extractReviewerTokenPath.test.js`.
+
+const assert = require("node:assert/strict");
+const { _extractReviewerTokenPath } = require("./routes");
+
+// 1) Canonical seed form — `export GH_TOKEN=$(cat <path>)`. The exact line
+//    `templates/seeds/re1.AGENTS.md` ships with, after substitution.
+{
+  const txt = `## GitHub Authentication\nexport GH_TOKEN=$(cat /Users/cho/.local/reviewer-token)\nNext section...`;
+  assert.equal(_extractReviewerTokenPath(txt), "/Users/cho/.local/reviewer-token");
+}
+
+// 2) No `export` prefix — operator may have stripped it (still a valid shell line).
+{
+  const txt = `GH_TOKEN=$(cat /custom/path)\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/custom/path");
+}
+
+// 3) Outer double-quote wrapping — `"$(cat …)"`. Common operator edit when
+//    they paste a snippet from elsewhere.
+{
+  const txt = `export GH_TOKEN="$(cat /opt/secrets/gh-token)"\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/opt/secrets/gh-token");
+}
+
+// 4) Inner double-quoted path (path with spaces).
+{
+  const txt = `export GH_TOKEN=$(cat "/Users/op/My Tokens/gh.token")\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/Users/op/My Tokens/gh.token");
+}
+
+// 5) Inner single-quoted path.
+{
+  const txt = `GH_TOKEN=$(cat '/srv/tokens/gh-prod')\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/srv/tokens/gh-prod");
+}
+
+// 6) Outer + inner double quotes together.
+{
+  const txt = `export GH_TOKEN="$(cat "/path with spaces/tok")"\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/path with spaces/tok");
+}
+
+// 7) Indented (inside a fenced code block in the existing AGENTS.md).
+{
+  const txt = `\`\`\`bash\n    export GH_TOKEN=$(cat /tab/indented/token)\n\`\`\`\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/tab/indented/token");
+}
+
+// 8) Tabs between tokens — `export\tGH_TOKEN  =\t$(cat …)`.
+{
+  const txt = `export\tGH_TOKEN\t=\t$(cat /tabbed/token)\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/tabbed/token");
+}
+
+// 9) Multiple GH_TOKEN lines — first match wins. (Operators shouldn't have
+//    two, but if they do we don't crash; canonical first-line picks up the
+//    one that's documented/used.)
+{
+  const txt = `export GH_TOKEN=$(cat /first/path)\n# Or alternately:\nGH_TOKEN=$(cat /second/path)\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "/first/path");
+}
+
+// 10) Different `cat` invocation forms inside `$()` — extra whitespace.
+{
+  assert.equal(_extractReviewerTokenPath(`GH_TOKEN=$( cat /spaced )`), "/spaced");
+  assert.equal(_extractReviewerTokenPath(`GH_TOKEN=$(cat  /double-space)`), "/double-space");
+}
+
+// 11) No GH_TOKEN line at all — head/dev seeds. Returns null so the resolver
+//     falls through to cfg / default (the placeholder isn't even present in
+//     those templates anyway).
+{
+  const txt = `# Dev\n\nNo authentication section here.\n`;
+  assert.equal(_extractReviewerTokenPath(txt), null);
+}
+
+// 12) GH_TOKEN set to a literal value (no `$(cat …)`) — we can't preserve a
+//     path that isn't there. Returns null; the substitution falls through
+//     to the default and the operator's literal-value line is preserved as
+//     a custom section by the #845 merger if they keep it under a non-canonical
+//     H2 (here it's inline in the same fresh section, so the fresh template
+//     will replace it — which is acceptable because there's no path to keep).
+{
+  const txt = `export GH_TOKEN=ghp_HARDCODED_LITERAL_TOKEN\n`;
+  assert.equal(_extractReviewerTokenPath(txt), null);
+}
+
+// 13) GH_TOKEN line that references the placeholder verbatim (pre-substitution
+//     content somehow round-tripped). Returns the literal placeholder text —
+//     the resolver caller will pass it back into substitution unchanged, which
+//     is functionally equivalent to using the default for re-seeding purposes.
+//     Documented behavior to keep the extractor a true round-trip.
+{
+  const txt = `export GH_TOKEN=$(cat {{reviewer_token_path}})\n`;
+  assert.equal(_extractReviewerTokenPath(txt), "{{reviewer_token_path}}");
+}
+
+// 14) Empty / null / non-string inputs — never throw, return null.
+{
+  assert.equal(_extractReviewerTokenPath(""), null);
+  assert.equal(_extractReviewerTokenPath(null), null);
+  assert.equal(_extractReviewerTokenPath(undefined), null);
+  assert.equal(_extractReviewerTokenPath(123), null);
+  assert.equal(_extractReviewerTokenPath({}), null);
+}
+
+// 15) Substring `GH_TOKEN` in prose (not on a line of its own setting it) —
+//     no match, returns null. Anchored on line start, so prose like "set
+//     GH_TOKEN somehow" doesn't trigger.
+{
+  const txt = `Run something like \`GH_TOKEN=...\` here.\nNo real setter.\n`;
+  assert.equal(_extractReviewerTokenPath(txt), null);
+}
+
+console.log("routes.extractReviewerTokenPath.test.js: all assertions passed (15 cases)");

--- a/server/routes.js
+++ b/server/routes.js
@@ -3019,6 +3019,42 @@ function reseedAgentsMd(existingContent, freshContent) {
   };
 }
 
+// #854: Extract the reviewer token path from a worktree's existing AGENTS.md
+// so the re-seed substitution preserves a custom path instead of resetting
+// it to the default. The re1/re2 seed renders:
+//
+//     export GH_TOKEN=$(cat <path>)
+//
+// Common operator-edited variations are recognized:
+//   • optional `export ` prefix
+//   • optional outer `"$(cat …)"` double-quote wrapping
+//   • optional inner quoting of the path (single or double quotes)
+//   • whitespace tolerated between tokens
+//
+// Returns the raw extracted path (quotes stripped, whitespace trimmed) or
+// `null` when no GH_TOKEN line is present or the line doesn't use the
+// `$(cat …)` form. Pure — no I/O.
+function _extractReviewerTokenPath(existingContent) {
+  if (!existingContent || typeof existingContent !== "string") return null;
+  // First find a GH_TOKEN line. We anchor on the literal name so an operator
+  // comment about token paths can't accidentally seed a stale path.
+  const lineMatch = existingContent.match(/^[ \t]*(?:export[ \t]+)?GH_TOKEN[ \t]*=.*$/m);
+  if (!lineMatch) return null;
+  // Then pull the path out of `$(cat …)` on that line. Non-greedy capture
+  // stops at the first `)` after `cat`, which is the correct boundary for
+  // any well-formed command substitution.
+  const catMatch = lineMatch[0].match(/\$\(\s*cat\s+(.+?)\s*\)/);
+  if (!catMatch) return null;
+  let raw = catMatch[1].trim();
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    raw = raw.slice(1, -1);
+  }
+  return raw || null;
+}
+
 // #855: Map legacy agent config keys to the canonical seed-template names.
 // Older projects (and operator-renamed agents) may use keys like
 // `reviewer1` / `reviewer2` / `t1..t3`; the seed templates only exist for
@@ -3118,7 +3154,7 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
 
   const dirName = path.basename(workingDir);
   const reviewerUser = body.reviewerUser ?? cfg.reviewer_github_user ?? "";
-  const reviewerTokenPath = body.reviewerTokenPath || path.join(os.homedir(), ".quadwork", "reviewer-token");
+  const defaultReviewerTokenPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
 
   // #855: walk the project's configured agents (resolved by `cwd`) instead of
   // reconstructing sibling paths. Legacy keys (`reviewer1` etc.) still pull
@@ -3136,17 +3172,33 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
         error: `Missing seed template: templates/seeds/${canonical}.AGENTS.md`,
       });
     }
-    let freshContent = fs.readFileSync(seedSrc, "utf-8");
-    freshContent = freshContent
-      .replace(/\{\{reviewer_github_user\}\}/g, reviewerUser)
-      .replace(/\{\{reviewer_token_path\}\}/g, reviewerTokenPath)
-      .replace(/\{\{project_name\}\}/g, dirName);
 
+    // #854: Read the existing AGENTS.md FIRST so the per-agent token path
+    // resolution can see what the operator currently has. Resolution order:
+    //   1. explicit body override (`body.reviewerTokenPath`)
+    //   2. extracted from this worktree's existing AGENTS.md
+    //   3. project/global config (`cfg.reviewer_token_path`)
+    //   4. default `~/.quadwork/reviewer-token`
+    // Head/dev seeds have no GH_TOKEN line, so (2) is `null` for them and
+    // they fall through to the default — the substituted placeholder is
+    // unused in those templates anyway.
     const agentsMd = path.join(wtDir, "AGENTS.md");
     let existing = "";
     if (fs.existsSync(agentsMd)) {
       try { existing = fs.readFileSync(agentsMd, "utf-8"); } catch { existing = ""; }
     }
+    const tokenPath =
+      body.reviewerTokenPath
+      || _extractReviewerTokenPath(existing)
+      || cfg.reviewer_token_path
+      || defaultReviewerTokenPath;
+
+    let freshContent = fs.readFileSync(seedSrc, "utf-8");
+    freshContent = freshContent
+      .replace(/\{\{reviewer_github_user\}\}/g, reviewerUser)
+      .replace(/\{\{reviewer_token_path\}\}/g, tokenPath)
+      .replace(/\{\{project_name\}\}/g, dirName);
+
     const merged = reseedAgentsMd(existing, freshContent);
     fs.writeFileSync(agentsMd, merged.content);
     reseeded.push(`${agentKey}/AGENTS.md`);
@@ -3729,6 +3781,9 @@ module.exports.reseedAgentsMd = reseedAgentsMd;
 // production callers outside this file.
 module.exports._resolveReseedTargets = _resolveReseedTargets;
 module.exports._canonicalAgentSlug = _canonicalAgentSlug;
+// #854: expose the GH_TOKEN path extractor so the parse forms (`export`,
+// double-quoted, inner-quoted, etc.) are exercisable without a temp fs.
+module.exports._extractReviewerTokenPath = _extractReviewerTokenPath;
 // #839 (re1 follow-up): expose the shared compute path plus the caches it
 // reads so the cache-miss completed-batch case is exercisable end-to-end.
 module.exports.getOrComputeBatchProgress = getOrComputeBatchProgress;

--- a/server/routes.reseedTokenPreservation.test.js
+++ b/server/routes.reseedTokenPreservation.test.js
@@ -1,0 +1,257 @@
+// #854 endpoint-level test: the re-seed endpoint must preserve each
+// reviewer's existing token path. Sets up temp worktrees whose re1/re2
+// AGENTS.md contain a custom `GH_TOKEN=$(cat /custom/...)` line, POSTs to
+// /api/projects/:project/reseed-agents (force:true so the batch gate is
+// bypassed), and asserts the rewritten files still reference `/custom/...`
+// while the discovery sections were refreshed from the current seed.
+//
+// Plain node:assert script — auto-discovered by the #836 runner. Run
+// directly with `node server/routes.reseedTokenPreservation.test.js`.
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const http = require("http");
+const crypto = require("crypto");
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+const TEMPLATES_DIR = path.join(__dirname, "..", "templates");
+
+// ── Stub fs.readFileSync for CONFIG_PATH BEFORE requiring routes ──────────
+// routes.js reads CONFIG_PATH on every per-project call. We want our
+// fixture project loaded, not the real ~/.quadwork/config.json, so the
+// test is hermetic on developer machines and CI alike. Everything else
+// (temp AGENTS.md, seed templates) goes through the real fs.
+const realReadFileSync = fs.readFileSync;
+let stubCfgJson = JSON.stringify({ projects: [] });
+fs.readFileSync = function stubReadFileSync(p, ...rest) {
+  if (p === CONFIG_PATH) return stubCfgJson;
+  return realReadFileSync(p, ...rest);
+};
+
+const express = require("express");
+const routes = require("./routes");
+
+// Tiny in-process http server with the real router mounted.
+async function withServer(fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(routes.router || routes); // routes.js exports default = router
+  await new Promise((resolve, reject) => {
+    const server = app.listen(0, "127.0.0.1", async () => {
+      const { port } = server.address();
+      try {
+        await fn(`http://127.0.0.1:${port}`);
+        resolve();
+      } catch (e) {
+        reject(e);
+      } finally {
+        server.close();
+      }
+    });
+  });
+}
+
+function post(url, body) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const data = JSON.stringify(body || {});
+    const req = http.request({
+      hostname: u.hostname,
+      port: u.port,
+      path: u.pathname,
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(data) },
+    }, (res) => {
+      let chunks = "";
+      res.on("data", (c) => chunks += c);
+      res.on("end", () => {
+        try { resolve({ status: res.statusCode, body: JSON.parse(chunks || "{}") }); }
+        catch (e) { reject(new Error(`Non-JSON response (status ${res.statusCode}): ${chunks}`)); }
+      });
+    });
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+function makeTempProject(label, agentsLayout) {
+  // agentsLayout: { agentKey: { cwdName, existingAgentsMd } } — `existingAgentsMd`
+  // omitted means no pre-existing file (simulates a brand-new worktree).
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `qw-854-${label}-`));
+  const workingDir = path.join(root, "proj");
+  fs.mkdirSync(workingDir, { recursive: true });
+  const agents = {};
+  for (const [agentKey, { cwdName, existingAgentsMd }] of Object.entries(agentsLayout)) {
+    const cwd = path.join(root, cwdName);
+    fs.mkdirSync(cwd, { recursive: true });
+    if (existingAgentsMd != null) {
+      fs.writeFileSync(path.join(cwd, "AGENTS.md"), existingAgentsMd);
+    }
+    agents[agentKey] = { cwd };
+  }
+  return { root, workingDir, agents };
+}
+
+(async () => {
+  // Sanity: real seed templates exist on disk. The test fails loudly here
+  // rather than silently asserting against a missing-file surprise.
+  for (const slug of ["head", "re1", "re2", "dev"]) {
+    const p = path.join(TEMPLATES_DIR, "seeds", `${slug}.AGENTS.md`);
+    assert.ok(fs.existsSync(p), `seed template missing: ${p}`);
+  }
+  const re1Seed = realReadFileSync(path.join(TEMPLATES_DIR, "seeds", "re1.AGENTS.md"), "utf-8");
+  const re2Seed = realReadFileSync(path.join(TEMPLATES_DIR, "seeds", "re2.AGENTS.md"), "utf-8");
+  // The seeds must contain the {{reviewer_token_path}} placeholder for the
+  // preservation contract to be meaningful. Asserted up front so a future
+  // template refactor that drops the placeholder fails this test loudly.
+  assert.ok(re1Seed.includes("{{reviewer_token_path}}"), "re1 seed lost the token path placeholder");
+  assert.ok(re2Seed.includes("{{reviewer_token_path}}"), "re2 seed lost the token path placeholder");
+
+  // ── Test 1: custom token path is preserved when no body override is given.
+  //    Seed existing re1/re2 with a `/custom/...` path; head/dev with no
+  //    GH_TOKEN line. After re-seed, the re1/re2 files still reference
+  //    `/custom/...` AND now reference GITHUB.md (proving the discovery
+  //    section was refreshed from the current template).
+  {
+    const projId = `pTest1-${crypto.randomBytes(4).toString("hex")}`;
+    const CUSTOM_RE1 = "/Users/op/.local/re1-custom-token";
+    const CUSTOM_RE2 = "/Users/op/.local/re2-custom-token";
+    const { workingDir, agents } = makeTempProject("custom", {
+      head: { cwdName: "proj-head", existingAgentsMd: "# Head\n\nStale head body.\n" },
+      dev:  { cwdName: "proj-dev",  existingAgentsMd: "# Dev\n\nStale dev body.\n" },
+      re1:  { cwdName: "proj-re1",  existingAgentsMd: `# Reviewer 1\n\n## GitHub Authentication\nexport GH_TOKEN=$(cat ${CUSTOM_RE1})\n` },
+      re2:  { cwdName: "proj-re2",  existingAgentsMd: `# Reviewer 2\n\n## GitHub Authentication\nexport GH_TOKEN=$(cat ${CUSTOM_RE2})\n` },
+    });
+
+    stubCfgJson = JSON.stringify({
+      projects: [{ id: projId, name: "Test1", repo: "ex/test1", working_dir: workingDir, agents }],
+    });
+
+    await withServer(async (base) => {
+      const { status, body } = await post(`${base}/api/projects/${projId}/reseed-agents`, { force: true });
+      assert.equal(status, 200, `expected 200, got ${status} ${JSON.stringify(body)}`);
+      assert.equal(body.ok, true);
+      assert.equal(body.reseeded.length, 4, "all 4 agents re-seeded");
+    });
+
+    const re1After = realReadFileSync(path.join(agents.re1.cwd, "AGENTS.md"), "utf-8");
+    const re2After = realReadFileSync(path.join(agents.re2.cwd, "AGENTS.md"), "utf-8");
+
+    // The exact #854 acceptance criterion: custom path preserved verbatim.
+    assert.ok(re1After.includes(`$(cat ${CUSTOM_RE1})`),
+      `re1 lost custom token path. Got:\n${re1After}`);
+    assert.ok(re2After.includes(`$(cat ${CUSTOM_RE2})`),
+      `re2 lost custom token path. Got:\n${re2After}`);
+
+    // The default token path must NOT appear (preservation, not append).
+    const defaultPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
+    assert.ok(!re1After.includes(`$(cat ${defaultPath})`),
+      "re1 also has default path — substitution leaked the fallback");
+    assert.ok(!re2After.includes(`$(cat ${defaultPath})`),
+      "re2 also has default path — substitution leaked the fallback");
+
+    // Discovery section refreshed: current re1/re2 seeds point at GITHUB.md.
+    assert.ok(re1After.includes("GITHUB.md"), "re1 missing GITHUB.md after re-seed");
+    assert.ok(re2After.includes("GITHUB.md"), "re2 missing GITHUB.md after re-seed");
+
+    // Head/dev have no GH_TOKEN line in their seeds — verify the resolver
+    // didn't accidentally inject one when falling through to the default.
+    const headAfter = realReadFileSync(path.join(agents.head.cwd, "AGENTS.md"), "utf-8");
+    const devAfter  = realReadFileSync(path.join(agents.dev.cwd, "AGENTS.md"), "utf-8");
+    assert.ok(!headAfter.includes("GH_TOKEN=$(cat"), "head seed should have no GH_TOKEN line");
+    assert.ok(!devAfter.includes("GH_TOKEN=$(cat"),  "dev seed should have no GH_TOKEN line");
+  }
+
+  // ── Test 2: default-path projects are unaffected. When the existing re1/re2
+  //    AGENTS.md uses the canonical default token path, re-seed produces the
+  //    same default path back — confirming the resolver doesn't perturb
+  //    projects that never had a custom path.
+  {
+    const projId = `pTest2-${crypto.randomBytes(4).toString("hex")}`;
+    const defaultPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
+    const { workingDir, agents } = makeTempProject("default", {
+      head: { cwdName: "proj-head", existingAgentsMd: null },
+      dev:  { cwdName: "proj-dev",  existingAgentsMd: null },
+      re1:  { cwdName: "proj-re1",  existingAgentsMd: `# Reviewer 1\nexport GH_TOKEN=$(cat ${defaultPath})\n` },
+      re2:  { cwdName: "proj-re2",  existingAgentsMd: `# Reviewer 2\nexport GH_TOKEN=$(cat ${defaultPath})\n` },
+    });
+
+    stubCfgJson = JSON.stringify({
+      projects: [{ id: projId, name: "Test2", repo: "ex/test2", working_dir: workingDir, agents }],
+    });
+
+    await withServer(async (base) => {
+      const { status, body } = await post(`${base}/api/projects/${projId}/reseed-agents`, { force: true });
+      assert.equal(status, 200);
+      assert.equal(body.ok, true);
+    });
+
+    const re1After = realReadFileSync(path.join(agents.re1.cwd, "AGENTS.md"), "utf-8");
+    assert.ok(re1After.includes(`$(cat ${defaultPath})`), "default-path re1 round-trips through re-seed");
+  }
+
+  // ── Test 3: cfg.reviewer_token_path is used when no AGENTS.md exists yet
+  //    and no body override is given. (Legitimate "operator just created the
+  //    worktree but no AGENTS.md yet" path.)
+  {
+    const projId = `pTest3-${crypto.randomBytes(4).toString("hex")}`;
+    const CFG_DEFAULT = "/etc/quadwork/global-token";
+    const { workingDir, agents } = makeTempProject("cfg", {
+      re1: { cwdName: "proj-re1", existingAgentsMd: null }, // brand-new worktree
+      re2: { cwdName: "proj-re2", existingAgentsMd: null },
+    });
+
+    stubCfgJson = JSON.stringify({
+      reviewer_token_path: CFG_DEFAULT,
+      projects: [{ id: projId, name: "Test3", repo: "ex/test3", working_dir: workingDir, agents }],
+    });
+
+    await withServer(async (base) => {
+      const { status, body } = await post(`${base}/api/projects/${projId}/reseed-agents`, { force: true });
+      assert.equal(status, 200);
+      assert.equal(body.ok, true);
+    });
+
+    const re1After = realReadFileSync(path.join(agents.re1.cwd, "AGENTS.md"), "utf-8");
+    const re2After = realReadFileSync(path.join(agents.re2.cwd, "AGENTS.md"), "utf-8");
+    assert.ok(re1After.includes(`$(cat ${CFG_DEFAULT})`), "cfg.reviewer_token_path used for new re1");
+    assert.ok(re2After.includes(`$(cat ${CFG_DEFAULT})`), "cfg.reviewer_token_path used for new re2");
+  }
+
+  // ── Test 4: explicit body.reviewerTokenPath wins over the existing AGENTS.md
+  //    extraction (operator-side opt-in via the API; this is the override path).
+  {
+    const projId = `pTest4-${crypto.randomBytes(4).toString("hex")}`;
+    const EXISTING = "/old/extracted/path";
+    const OVERRIDE = "/new/override/path";
+    const { workingDir, agents } = makeTempProject("override", {
+      re1: { cwdName: "proj-re1", existingAgentsMd: `# Reviewer 1\nexport GH_TOKEN=$(cat ${EXISTING})\n` },
+      re2: { cwdName: "proj-re2", existingAgentsMd: `# Reviewer 2\nexport GH_TOKEN=$(cat ${EXISTING})\n` },
+    });
+
+    stubCfgJson = JSON.stringify({
+      projects: [{ id: projId, name: "Test4", repo: "ex/test4", working_dir: workingDir, agents }],
+    });
+
+    await withServer(async (base) => {
+      const { status, body } = await post(`${base}/api/projects/${projId}/reseed-agents`, {
+        force: true,
+        reviewerTokenPath: OVERRIDE,
+      });
+      assert.equal(status, 200);
+      assert.equal(body.ok, true);
+    });
+
+    const re1After = realReadFileSync(path.join(agents.re1.cwd, "AGENTS.md"), "utf-8");
+    assert.ok(re1After.includes(`$(cat ${OVERRIDE})`), "body override beats existing extraction");
+    assert.ok(!re1After.includes(`$(cat ${EXISTING})`), "old extracted path replaced by override");
+  }
+
+  console.log("routes.reseedTokenPreservation.test.js: all assertions passed (4 endpoint scenarios)");
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Fixes #854. The #845 re-seed always substituted `{{reviewer_token_path}}` with the hardcoded default `~/.quadwork/reviewer-token` (ControlBar posts no `reviewerTokenPath`), so any project set up with a custom `GH_TOKEN=$(cat /custom/...)` line silently lost it and re1/re2 then failed to authenticate.
- Substitution is now **per-agent** and resolves the token path in priority order: `body.reviewerTokenPath` → extracted from this worktree's existing AGENTS.md → `cfg.reviewer_token_path` → default. Head/dev seeds have no GH_TOKEN line so they fall through to the default cleanly.
- New pure helper `_extractReviewerTokenPath(existing)` parses `GH_TOKEN=$(cat …)` with optional `export` prefix, optional outer double-quote wrapping, and optional inner single/double quoting (handles paths with spaces). The existing AGENTS.md is now read BEFORE substitution; that read was already needed by the #845 merger so no new I/O.

## Acceptance criteria

- [x] Re-seeding a project set up with a custom reviewer token path keeps re1/re2 `GH_TOKEN=$(cat <custom-path>)` unchanged (Test 1 endpoint-level).
- [x] Default-path projects are unaffected (Test 2).
- [x] Existing AGENTS.md / config token path is preferred over the hardcoded default when no body override is provided (Tests 1, 3).
- [x] Parse common shell forms robustly: `export GH_TOKEN=$(cat /path)`, `export GH_TOKEN=\"$(cat /path)\"`, quoted/spaced paths, single quotes, tabs, indentation (extractor unit test, 15 cases).
- [x] Endpoint-level test asserts custom token survives + discovery sections update.
- [x] `npm run build` passes.

## Test plan

- [x] `node server/routes.extractReviewerTokenPath.test.js` → 15 parse-form cases pass.
- [x] `node server/routes.reseedTokenPreservation.test.js` → 4 endpoint scenarios pass (custom-preserved, default-roundtrip, cfg-fallback, body-override).
- [x] `node server/routes.reseedAgentsMd.test.js` → 8 cases pass (existing merger contract intact).
- [x] `node server/routes.resolveReseedTargets.test.js` → 7 cases pass (#855 contract intact).
- [x] `npm test` → 28 passed, 0 failed, 2 skipped.
- [x] `npm run build` → ✓ Compiled successfully.

Closes #854