### PR TITLE
[#856] Auto-reseed worktree AGENTS.md on version upgrade

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1904,6 +1904,16 @@ server.listen(PORT, "127.0.0.1", async () => {
 
   runStartupMigrations(startupCfg);
 
+  // #856: Auto-reseed worktree AGENTS.md when the package version changes.
+  // Per-project completion state lives in ~/.quadwork/reseed-state.json, so
+  // projects deferred mid-batch stay pending and retry on the next startup.
+  // Failures here MUST NOT block server boot.
+  try {
+    await routes.autoReseedOnStartup(startupCfg);
+  } catch (err) {
+    console.error(`[reseed] auto-reseed failed: ${err.message}`);
+  }
+
   if (startupCfg.butler && startupCfg.butler.enabled && startupCfg.butler.auto_start) {
     const result = spawnButlerPty();
     if (result.ok) console.log(`[butler] auto-started (PID: ${result.pid})`);

--- a/server/routes.autoReseed.test.js
+++ b/server/routes.autoReseed.test.js
@@ -1,0 +1,386 @@
+// #856 tests for autoReseedOnStartup + the per-project state file.
+//
+// Layers covered:
+//   - _loadReseedState / _saveReseedState round-trip + corruption tolerance.
+//   - _readPackageVersion fallback on missing/malformed package.json.
+//   - autoReseedOnStartup decision matrix with injected `getProgress` and
+//     `performWrites`:
+//       * project already at current version → skip (no write to state).
+//       * project at older version, batch idle → reseed (state advanced).
+//       * project at older version, batch active → defer (state UNCHANGED
+//         so the next startup retries).
+//       * project at older version, batch state unknown (null result OR
+//         throw) → defer (fail-closed gate, state UNCHANGED).
+//       * project with no working_dir → silently skipped.
+//       * write throws → state UNCHANGED (so retry on next startup).
+//       * deferred-then-resolved across two boots → second boot re-seeds
+//         AND advances state for that project; already-current projects
+//         from boot 1 remain skipped on boot 2.
+//   - End-to-end with real `_performReseedWrites` against temp worktree
+//     dirs — verifies the upgrade flow actually writes new templates AND
+//     the resulting AGENTS.md has GITHUB.md discovery (the #856 user
+//     observable: "existing upgraded users get GITHUB.md as primary").
+//
+// Plain node:assert script — auto-discovered by the #836 runner. Run
+// directly with `node server/routes.autoReseed.test.js`.
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const crypto = require("crypto");
+
+const {
+  autoReseedOnStartup,
+  _loadReseedState,
+  _saveReseedState,
+  _readPackageVersion,
+  _performReseedWrites,
+} = require("./routes");
+
+function tmp(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `qw-856-${label}-`));
+}
+
+function quietLog() {
+  const lines = [];
+  return { log: (m) => lines.push(m), lines };
+}
+
+(async () => {
+  // ── State file: missing → empty default ──────────────────────────────────
+  {
+    const missing = path.join(tmp("state-missing"), "absent.json");
+    assert.deepEqual(_loadReseedState(missing), { completedByProjectVersion: {} });
+  }
+
+  // ── State file: malformed JSON → empty default (don't crash boot) ────────
+  {
+    const dir = tmp("state-bad");
+    const p = path.join(dir, "state.json");
+    fs.writeFileSync(p, "not-json-at-all{");
+    assert.deepEqual(_loadReseedState(p), { completedByProjectVersion: {} });
+  }
+
+  // ── State file: wrong-shape value (array, number, missing key) → empty ──
+  {
+    const dir = tmp("state-wrong");
+    const p = path.join(dir, "state.json");
+    fs.writeFileSync(p, JSON.stringify({ completedByProjectVersion: [1, 2, 3] }));
+    assert.deepEqual(_loadReseedState(p), { completedByProjectVersion: {} });
+
+    fs.writeFileSync(p, JSON.stringify({ somethingElse: { x: "y" } }));
+    assert.deepEqual(_loadReseedState(p), { completedByProjectVersion: {} });
+
+    // Non-string version values get stripped (defensive against a future
+    // writer that puts numbers/objects in — never compares equal to a
+    // package.json string).
+    fs.writeFileSync(p, JSON.stringify({ completedByProjectVersion: { a: "1.0.0", b: 2, c: { v: "3" } } }));
+    assert.deepEqual(_loadReseedState(p), { completedByProjectVersion: { a: "1.0.0" } });
+  }
+
+  // ── State file: round-trip ───────────────────────────────────────────────
+  {
+    const dir = tmp("state-roundtrip");
+    const p = path.join(dir, "state.json");
+    _saveReseedState({ completedByProjectVersion: { proj1: "2.1.0", proj2: "2.0.5" } }, p);
+    assert.deepEqual(_loadReseedState(p), { completedByProjectVersion: { proj1: "2.1.0", proj2: "2.0.5" } });
+  }
+
+  // ── _readPackageVersion ──────────────────────────────────────────────────
+  {
+    const dir = tmp("pkg");
+    // Missing → 0.0.0 fallback.
+    assert.equal(_readPackageVersion(path.join(dir, "missing.json")), "0.0.0");
+    // Malformed → 0.0.0.
+    const bad = path.join(dir, "bad.json");
+    fs.writeFileSync(bad, "{not json");
+    assert.equal(_readPackageVersion(bad), "0.0.0");
+    // Missing version field → 0.0.0.
+    const noVer = path.join(dir, "no-ver.json");
+    fs.writeFileSync(noVer, JSON.stringify({ name: "x" }));
+    assert.equal(_readPackageVersion(noVer), "0.0.0");
+    // Valid version → returned verbatim.
+    const ok = path.join(dir, "ok.json");
+    fs.writeFileSync(ok, JSON.stringify({ name: "x", version: "9.9.9" }));
+    assert.equal(_readPackageVersion(ok), "9.9.9");
+  }
+
+  // ── Decision matrix with injected deps ───────────────────────────────────
+  // Use a fake `performWrites` so we don't touch any real fs in this section
+  // — we're testing the orchestration, not the write loop (which #845/#854/#855
+  // already cover end-to-end).
+  function makeRun(opts) {
+    const dir = tmp("run");
+    const statePath = path.join(dir, "state.json");
+    if (opts.initialState) _saveReseedState(opts.initialState, statePath);
+    const writes = [];
+    const performWrites = opts.performWrites || ((project) => {
+      writes.push(project.id);
+      return { reseeded: [`head/AGENTS.md`], skipped: [], preserved: {} };
+    });
+    const getProgress = opts.getProgress || (async () => ({ items: [], complete: false }));
+    const isActiveFromProgress = opts.isActiveFromProgress || ((p) => {
+      if (!p) return null;
+      if (!Array.isArray(p.items)) return null;
+      return p.items.some((i) => i && i.status !== "merged" && i.status !== "closed");
+    });
+    const { log, lines } = quietLog();
+    return {
+      statePath, writes, log, lines,
+      run: () => autoReseedOnStartup(opts.cfg, {
+        version: opts.version,
+        statePath, getProgress, isActiveFromProgress, performWrites, log,
+      }),
+    };
+  }
+
+  // 1. Already current — no performWrites call, no state mutation.
+  {
+    const cfg = { projects: [{ id: "p1", working_dir: "/tmp/p1" }] };
+    const ctx = makeRun({
+      cfg, version: "2.1.0",
+      initialState: { completedByProjectVersion: { p1: "2.1.0" } },
+    });
+    const out = await ctx.run();
+    assert.equal(out.decisions.length, 1);
+    assert.deepEqual(out.decisions[0], { projectId: "p1", action: "skip", reason: "already current" });
+    assert.deepEqual(ctx.writes, []);
+    // State unchanged.
+    assert.deepEqual(_loadReseedState(ctx.statePath), { completedByProjectVersion: { p1: "2.1.0" } });
+  }
+
+  // 2. Out-of-date, batch idle → reseed AND state advanced.
+  {
+    const cfg = { projects: [{ id: "p2", working_dir: "/tmp/p2" }] };
+    const ctx = makeRun({
+      cfg, version: "2.1.0",
+      initialState: { completedByProjectVersion: { p2: "2.0.0" } },
+    });
+    const out = await ctx.run();
+    assert.equal(out.decisions[0].action, "reseeded");
+    assert.deepEqual(ctx.writes, ["p2"]);
+    assert.equal(_loadReseedState(ctx.statePath).completedByProjectVersion.p2, "2.1.0");
+  }
+
+  // 3. Fresh install (no state file at all) → reseeds everything, then is
+  //    no-op on subsequent run.
+  {
+    const cfg = { projects: [{ id: "a", working_dir: "/tmp/a" }, { id: "b", working_dir: "/tmp/b" }] };
+    const ctx = makeRun({ cfg, version: "2.1.0" });
+    const out1 = await ctx.run();
+    assert.equal(out1.decisions.length, 2);
+    assert.equal(out1.decisions[0].action, "reseeded");
+    assert.equal(out1.decisions[1].action, "reseeded");
+    assert.deepEqual(ctx.writes, ["a", "b"]);
+    assert.deepEqual(_loadReseedState(ctx.statePath).completedByProjectVersion, { a: "2.1.0", b: "2.1.0" });
+    // Subsequent run: both skip.
+    ctx.writes.length = 0;
+    const out2 = await ctx.run();
+    assert.ok(out2.decisions.every((d) => d.action === "skip"));
+    assert.deepEqual(ctx.writes, []);
+  }
+
+  // 4. Batch active → DEFERRED, state UNCHANGED. The exact #856 contract
+  //    ("Per-project reseed state is load-bearing").
+  {
+    const cfg = { projects: [{ id: "busy", working_dir: "/tmp/busy" }] };
+    const ctx = makeRun({
+      cfg, version: "2.1.0",
+      getProgress: async () => ({ items: [{ status: "in_review" }], complete: false }),
+    });
+    const out = await ctx.run();
+    assert.deepEqual(out.decisions[0], { projectId: "busy", action: "deferred", reason: "batch active" });
+    assert.deepEqual(ctx.writes, []);
+    assert.deepEqual(_loadReseedState(ctx.statePath), { completedByProjectVersion: {} });
+    assert.ok(ctx.lines.some((l) => /will retry on next startup/.test(l)),
+      "deferral is logged with retry hint");
+  }
+
+  // 5. Batch state unknown (null result) → defer.
+  {
+    const cfg = { projects: [{ id: "?", working_dir: "/tmp/q" }] };
+    const ctx = makeRun({
+      cfg, version: "2.1.0",
+      getProgress: async () => null,
+    });
+    const out = await ctx.run();
+    assert.equal(out.decisions[0].action, "deferred");
+    assert.deepEqual(ctx.writes, []);
+  }
+
+  // 6. Batch progress call throws → defer (fail-closed gate, same contract
+  //    as the #853 manual endpoint).
+  {
+    const cfg = { projects: [{ id: "x", working_dir: "/tmp/x" }] };
+    const ctx = makeRun({
+      cfg, version: "2.1.0",
+      getProgress: async () => { throw new Error("network blip"); },
+    });
+    const out = await ctx.run();
+    assert.equal(out.decisions[0].action, "deferred");
+    assert.match(out.decisions[0].reason, /network blip/);
+    assert.deepEqual(_loadReseedState(ctx.statePath), { completedByProjectVersion: {} });
+  }
+
+  // 7. write throws → state UNCHANGED, decision recorded as error.
+  {
+    const cfg = { projects: [{ id: "boom", working_dir: "/tmp/boom" }] };
+    const ctx = makeRun({
+      cfg, version: "2.1.0",
+      performWrites: () => { throw new Error("missing seed"); },
+    });
+    const out = await ctx.run();
+    assert.equal(out.decisions[0].action, "error");
+    assert.equal(out.decisions[0].error, "missing seed");
+    assert.deepEqual(_loadReseedState(ctx.statePath), { completedByProjectVersion: {} });
+  }
+
+  // 8. Mix: one skip, one deferred, one reseeded — independent decisions,
+  //    only the reseeded project's state advances.
+  {
+    const cfg = { projects: [
+      { id: "ok-already", working_dir: "/tmp/ok-already" },
+      { id: "busy",       working_dir: "/tmp/busy" },
+      { id: "needs",      working_dir: "/tmp/needs" },
+    ]};
+    const ctx = makeRun({
+      cfg, version: "2.1.0",
+      initialState: { completedByProjectVersion: { "ok-already": "2.1.0", needs: "1.9.0" } },
+      getProgress: async (id) => id === "busy"
+        ? { items: [{ status: "in_review" }], complete: false }
+        : { items: [], complete: false },
+    });
+    const out = await ctx.run();
+    const byId = Object.fromEntries(out.decisions.map((d) => [d.projectId, d.action]));
+    assert.deepEqual(byId, { "ok-already": "skip", busy: "deferred", needs: "reseeded" });
+    const after = _loadReseedState(ctx.statePath).completedByProjectVersion;
+    assert.deepEqual(after, { "ok-already": "2.1.0", needs: "2.1.0" });
+    assert.equal(after.busy, undefined, "deferred project does NOT get a state entry");
+  }
+
+  // 9. Deferred-then-resolved across two boots — the #856 retry contract.
+  //    Boot 1: busy project deferred. Boot 2: batch idle, project re-seeds.
+  //    Other already-current project remains a skip both boots.
+  {
+    const cfg = { projects: [
+      { id: "current", working_dir: "/tmp/current" },
+      { id: "later",   working_dir: "/tmp/later" },
+    ]};
+    const dir = tmp("two-boots");
+    const statePath = path.join(dir, "state.json");
+    _saveReseedState({ completedByProjectVersion: { current: "2.1.0" } }, statePath);
+
+    let batchActive = true;
+    const writes = [];
+    const performWrites = (p) => { writes.push(p.id); return { reseeded: ["head/AGENTS.md"], skipped: [], preserved: {} }; };
+    const getProgress = async (id) => id === "later" && batchActive
+      ? { items: [{ status: "in_review" }], complete: false }
+      : { items: [], complete: false };
+    const { log } = quietLog();
+
+    // Boot 1.
+    const boot1 = await autoReseedOnStartup(cfg, { version: "2.1.0", statePath, getProgress, performWrites, log });
+    const boot1ById = Object.fromEntries(boot1.decisions.map((d) => [d.projectId, d.action]));
+    assert.deepEqual(boot1ById, { current: "skip", later: "deferred" });
+    assert.deepEqual(writes, []);
+    // State unchanged for `later` — the load-bearing per-project state.
+    assert.equal(_loadReseedState(statePath).completedByProjectVersion.later, undefined);
+
+    // Boot 2: batch idle now.
+    batchActive = false;
+    const boot2 = await autoReseedOnStartup(cfg, { version: "2.1.0", statePath, getProgress, performWrites, log });
+    const boot2ById = Object.fromEntries(boot2.decisions.map((d) => [d.projectId, d.action]));
+    assert.deepEqual(boot2ById, { current: "skip", later: "reseeded" });
+    assert.deepEqual(writes, ["later"], "only `later` reseeded on boot 2 — `current` stayed up-to-date");
+    assert.equal(_loadReseedState(statePath).completedByProjectVersion.later, "2.1.0");
+  }
+
+  // 10. Project without working_dir is silently skipped (no decision row, no
+  //     state mutation, no log line).
+  {
+    const cfg = { projects: [
+      { id: "good", working_dir: "/tmp/good" },
+      { id: "bare" },        // no working_dir
+      { id: "bare2", working_dir: "" },
+    ]};
+    const ctx = makeRun({ cfg, version: "2.1.0" });
+    const out = await ctx.run();
+    assert.equal(out.decisions.length, 1);
+    assert.equal(out.decisions[0].projectId, "good");
+  }
+
+  // ── End-to-end: real _performReseedWrites against temp worktrees ─────────
+  // This is the "existing upgraded users get GITHUB.md" user-visible check.
+  // Pre-#809 AGENTS.md content is replaced by the current template (which
+  // references GITHUB.md), and the project's state advances to the new
+  // version. Asserts the auto-reseed + write path fits together end-to-end.
+  {
+    const projId = `e2e-${crypto.randomBytes(4).toString("hex")}`;
+    const root = tmp("e2e");
+    const workingDir = path.join(root, "proj");
+    fs.mkdirSync(workingDir, { recursive: true });
+    const re1Dir = path.join(root, "proj-re1");
+    const re2Dir = path.join(root, "proj-re2");
+    fs.mkdirSync(re1Dir, { recursive: true });
+    fs.mkdirSync(re2Dir, { recursive: true });
+    // Pre-#809 stale re1 AGENTS.md: positive `gh pr list` discovery
+    // instruction (the exact thing #809 replaced with GITHUB.md). The
+    // heading matches the current template heading so the #845 merger
+    // overwrites the body — which is precisely how a real pre-#809 file
+    // got upgraded: the section was always called the same thing, only
+    // the body content changed.
+    const stale = [
+      "# Reviewer 1",
+      "",
+      "## GitHub State (discovery)",
+      "Use `gh pr list` to find open PRs in this repo. Filter by your username.",
+      "",
+    ].join("\n");
+    fs.writeFileSync(path.join(re1Dir, "AGENTS.md"), stale);
+    fs.writeFileSync(path.join(re2Dir, "AGENTS.md"),
+      stale.replace("# Reviewer 1", "# Reviewer 2"));
+
+    const cfg = { projects: [{
+      id: projId, name: "E2E", working_dir: workingDir,
+      agents: { re1: { cwd: re1Dir }, re2: { cwd: re2Dir } },
+    }] };
+    const dir = tmp("e2e-state");
+    const statePath = path.join(dir, "state.json");
+    const { log } = quietLog();
+
+    const out = await autoReseedOnStartup(cfg, {
+      version: "9.9.9", statePath, log,
+      // No batch infra in this temp project — short-circuit to "idle".
+      getProgress: async () => ({ items: [], complete: false }),
+    });
+    assert.equal(out.decisions[0].action, "reseeded");
+    assert.equal(_loadReseedState(statePath).completedByProjectVersion[projId], "9.9.9");
+
+    const re1After = fs.readFileSync(path.join(re1Dir, "AGENTS.md"), "utf-8");
+    const re2After = fs.readFileSync(path.join(re2Dir, "AGENTS.md"), "utf-8");
+    // The user-visible #856 outcome: existing upgraded users see GITHUB.md
+    // discovery, not the stale pre-#809 positive `gh pr list` instruction.
+    assert.ok(re1After.includes("GITHUB.md"), "re1 has GITHUB.md after auto-reseed");
+    assert.ok(re2After.includes("GITHUB.md"), "re2 has GITHUB.md after auto-reseed");
+    // The stale positive-instruction sentence is gone (only anti-instruction
+    // and fallback mentions of `gh pr list` may remain — those live in the
+    // fresh template's `**fallback only**` sentence).
+    assert.ok(!re1After.includes("Use `gh pr list` to find open PRs in this repo."),
+      "re1 stale positive instruction replaced");
+
+    // Second auto-reseed call → no-op.
+    const writesAgain = [];
+    await autoReseedOnStartup(cfg, {
+      version: "9.9.9", statePath, log,
+      getProgress: async () => ({ items: [], complete: false }),
+      performWrites: (p) => { writesAgain.push(p.id); return _performReseedWrites(p, cfg); },
+    });
+    assert.deepEqual(writesAgain, [], "second startup at same version skips already-current projects");
+  }
+
+  console.log("routes.autoReseed.test.js: all assertions passed");
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/routes.js
+++ b/server/routes.js
@@ -3152,8 +3152,37 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
     }
   }
 
+  let result;
+  try {
+    result = _performReseedWrites(project, cfg, {
+      reviewerUser: body.reviewerUser,
+      reviewerTokenPath: body.reviewerTokenPath,
+    });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+  return res.json({
+    ok: true,
+    reseeded: result.reseeded,
+    skipped: result.skipped,
+    preserved: result.preserved,
+    note: "Re-seeded files take effect on next agent restart.",
+  });
+});
+
+// #856: Per-target write loop, extracted so the manual route handler and the
+// auto-reseed startup hook share one implementation. Throws on missing seed
+// template (the route handler maps that to a 500). Returns the same shape
+// the endpoint returns so the auto-reseed log can include per-project stats.
+//
+// `opts.reviewerUser` and `opts.reviewerTokenPath` are operator overrides:
+// when set they win over the per-agent extraction / cfg fallback. Auto-reseed
+// passes neither so each project uses the same priority chain manual re-seed
+// uses (per-agent extraction → cfg → default).
+function _performReseedWrites(project, cfg, opts = {}) {
+  const workingDir = project.working_dir;
   const dirName = path.basename(workingDir);
-  const reviewerUser = body.reviewerUser ?? cfg.reviewer_github_user ?? "";
+  const reviewerUser = opts.reviewerUser ?? cfg.reviewer_github_user ?? "";
   const defaultReviewerTokenPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
 
   // #855: walk the project's configured agents (resolved by `cwd`) instead of
@@ -3167,15 +3196,12 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
     if (!fs.existsSync(wtDir)) { skipped.push(`${agentKey} (no worktree)`); continue; }
     const seedSrc = path.join(TEMPLATES_DIR, "seeds", `${canonical}.AGENTS.md`);
     if (!fs.existsSync(seedSrc)) {
-      return res.status(500).json({
-        ok: false,
-        error: `Missing seed template: templates/seeds/${canonical}.AGENTS.md`,
-      });
+      throw new Error(`Missing seed template: templates/seeds/${canonical}.AGENTS.md`);
     }
 
     // #854: Read the existing AGENTS.md FIRST so the per-agent token path
     // resolution can see what the operator currently has. Resolution order:
-    //   1. explicit body override (`body.reviewerTokenPath`)
+    //   1. explicit opts override (`opts.reviewerTokenPath`)
     //   2. extracted from this worktree's existing AGENTS.md
     //   3. project/global config (`cfg.reviewer_token_path`)
     //   4. default `~/.quadwork/reviewer-token`
@@ -3188,7 +3214,7 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
       try { existing = fs.readFileSync(agentsMd, "utf-8"); } catch { existing = ""; }
     }
     const tokenPath =
-      body.reviewerTokenPath
+      opts.reviewerTokenPath
       || _extractReviewerTokenPath(existing)
       || cfg.reviewer_token_path
       || defaultReviewerTokenPath;
@@ -3206,14 +3232,127 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
       preserved[agentKey] = merged.preservedHeadings;
     }
   }
-  return res.json({
-    ok: true,
-    reseeded,
-    skipped,
-    preserved,
-    note: "Re-seeded files take effect on next agent restart.",
-  });
-});
+  return { reseeded, skipped, preserved };
+}
+
+// ─── #856: Auto-reseed on version upgrade ────────────────────────────────
+//
+// On every server startup we compare the current package version against a
+// per-project completion record in `~/.quadwork/reseed-state.json`. Any
+// project that hasn't been re-seeded for the current version gets re-seeded
+// from the current templates so existing users pick up new seed instructions
+// (e.g. GITHUB.md discovery) without ever clicking the manual button.
+//
+// The per-project state is load-bearing: a project deferred mid-batch stays
+// pending in the state file so the very next startup (or any future safe-
+// boundary hook) retries it. Using a single global "last run version"
+// marker would strand any deferred project — once the marker advanced past
+// the upgrade version, the deferred project would never be re-seeded.
+
+const RESEED_STATE_PATH = path.join(os.homedir(), ".quadwork", "reseed-state.json");
+const PACKAGE_JSON_PATH = path.join(__dirname, "..", "package.json");
+
+function _readPackageVersion(pkgPath = PACKAGE_JSON_PATH) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    return typeof pkg.version === "string" && pkg.version ? pkg.version : "0.0.0";
+  } catch { return "0.0.0"; }
+}
+
+function _loadReseedState(statePath = RESEED_STATE_PATH) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, "utf-8"));
+    const map = parsed && typeof parsed === "object" && parsed !== null && parsed.completedByProjectVersion;
+    const completed = map && typeof map === "object" && !Array.isArray(map) ? { ...map } : {};
+    // Drop non-string version values so a corrupt write can't poison the
+    // up-to-date check (which is a string equality).
+    for (const k of Object.keys(completed)) {
+      if (typeof completed[k] !== "string") delete completed[k];
+    }
+    return { completedByProjectVersion: completed };
+  } catch { return { completedByProjectVersion: {} }; }
+}
+
+function _saveReseedState(state, statePath = RESEED_STATE_PATH) {
+  try {
+    const dir = path.dirname(statePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch {}
+  // Single fs.writeFileSync — write-replace is atomic enough for this
+  // boot-time-only writer (no concurrent writer exists).
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+}
+
+async function autoReseedOnStartup(cfg, opts = {}) {
+  const version = opts.version || _readPackageVersion();
+  const statePath = opts.statePath || RESEED_STATE_PATH;
+  const log = opts.log || ((m) => console.log(m));
+  // Dependency-injected for tests so we don't have to spin up gh.
+  const getProgress = opts.getProgress || getOrComputeBatchProgress;
+  const isActiveFromProgress = opts.isActiveFromProgress || isBatchActiveFromProgress;
+  const performWrites = opts.performWrites || _performReseedWrites;
+
+  const state = _loadReseedState(statePath);
+  const decisions = [];
+  const projects = (cfg?.projects || []).filter((p) => p && p.id && p.working_dir);
+
+  for (const project of projects) {
+    if (state.completedByProjectVersion[project.id] === version) {
+      decisions.push({ projectId: project.id, action: "skip", reason: "already current" });
+      continue;
+    }
+
+    // Fail-closed batch gate, same contract as the manual /reseed-agents
+    // route (#853): a throw OR a null result both mean "we cannot prove the
+    // batch is idle, so we MUST defer rather than risk mid-batch instruction
+    // drift". The deferred state stays pending so the next startup retries.
+    let active;
+    try {
+      const progress = await getProgress(project.id);
+      active = isActiveFromProgress(progress);
+    } catch (err) {
+      decisions.push({ projectId: project.id, action: "deferred", reason: `batch-state check threw: ${err.message}` });
+      log(`[reseed] ${project.id}: deferred — batch state unknown (${err.message}); will retry on next startup`);
+      continue;
+    }
+    if (active === null) {
+      decisions.push({ projectId: project.id, action: "deferred", reason: "batch state unknown" });
+      log(`[reseed] ${project.id}: deferred — batch state unknown; will retry on next startup`);
+      continue;
+    }
+    if (active === true) {
+      decisions.push({ projectId: project.id, action: "deferred", reason: "batch active" });
+      log(`[reseed] ${project.id}: deferred — batch active; will retry on next startup`);
+      continue;
+    }
+
+    let result;
+    try {
+      result = performWrites(project, cfg, {});
+    } catch (err) {
+      decisions.push({ projectId: project.id, action: "error", error: err.message });
+      log(`[reseed] ${project.id}: ERROR — ${err.message}; state NOT advanced, will retry on next startup`);
+      continue;
+    }
+
+    state.completedByProjectVersion[project.id] = version;
+    try {
+      _saveReseedState(state, statePath);
+    } catch (err) {
+      // If we can't persist, the project will re-seed again next boot.
+      // Idempotent (file rewrite + #845 merger) so this is annoying-but-safe.
+      log(`[reseed] ${project.id}: WARN — could not persist reseed-state (${err.message}); will re-seed next startup`);
+    }
+    decisions.push({
+      projectId: project.id, action: "reseeded",
+      reseeded: result.reseeded, skipped: result.skipped, preserved: result.preserved,
+    });
+    log(`[reseed] ${project.id}: reseeded for v${version} — wrote ${result.reseeded.length} file(s)` +
+        (result.skipped.length ? `, skipped ${result.skipped.length}` : ""));
+  }
+
+  return { version, decisions };
+}
 
 // ─── Rename ────────────────────────────────────────────────────────────────
 
@@ -3784,6 +3923,16 @@ module.exports._canonicalAgentSlug = _canonicalAgentSlug;
 // #854: expose the GH_TOKEN path extractor so the parse forms (`export`,
 // double-quoted, inner-quoted, etc.) are exercisable without a temp fs.
 module.exports._extractReviewerTokenPath = _extractReviewerTokenPath;
+// #856: expose the auto-reseed startup hook + supporting state/version
+// helpers. server/index.js calls `autoReseedOnStartup` after config is
+// loaded; the helpers are exposed for unit tests + the integration test
+// (state corruption, version round-trip, per-project decision matrix).
+module.exports.autoReseedOnStartup = autoReseedOnStartup;
+module.exports._loadReseedState = _loadReseedState;
+module.exports._saveReseedState = _saveReseedState;
+module.exports._readPackageVersion = _readPackageVersion;
+module.exports._performReseedWrites = _performReseedWrites;
+module.exports.RESEED_STATE_PATH = RESEED_STATE_PATH;
 // #839 (re1 follow-up): expose the shared compute path plus the caches it
 // reads so the cache-miss completed-batch case is exercisable end-to-end.
 module.exports.getOrComputeBatchProgress = getOrComputeBatchProgress;


### PR DESCRIPTION
## Summary

- Fixes #856. Existing users upgrading the QuadWork package never picked up new seed-template content (e.g. the #809 GITHUB.md discovery instructions) because the #845 re-seed endpoint required an operator click. This change auto-re-seeds on every startup when `package.json` version differs from the per-project completion state.
- **Per-project state is load-bearing** (per the issue's explicit criterion): a project deferred mid-batch stays pending in `~/.quadwork/reseed-state.json` so the very next startup (or any future safe-boundary hook) retries it. A single global "last run version" marker would strand any deferred project — once the marker advanced past the upgrade version, the deferred project would never be re-seeded.
- The per-target write loop is extracted to `_performReseedWrites(project, cfg, opts)` so the manual route handler (`POST /api/projects/:project/reseed-agents`) and the new `autoReseedOnStartup` hook share one implementation. Manual endpoint behavior, response shape, and error mapping are unchanged.

## Per-project decision matrix

| Condition                            | Action      | State change                    |
|--------------------------------------|-------------|---------------------------------|
| `state[id] === current version`      | `skip`      | none                            |
| Batch-state check throws             | `deferred`  | none (fail-closed, retry next)  |
| Batch-state returns `null`           | `deferred`  | none (fail-closed, retry next)  |
| Batch active                         | `deferred`  | none (retry next startup)       |
| `_performReseedWrites` throws        | `error`     | none (retry next startup)       |
| Writes succeed                       | `reseeded`  | `state[id] = current version`   |

## State file

`~/.quadwork/reseed-state.json`:
```json
{ "completedByProjectVersion": { "<projectId>": "<pkg version>" } }
```

## Wiring

`server/index.js` calls `routes.autoReseedOnStartup(startupCfg)` inside the existing `server.listen` async callback, right after `runStartupMigrations`. Errors are caught and logged — boot must not fail because of a re-seed issue.

## Acceptance criteria

- [x] On a version bump, projects' worktree `AGENTS.md` files auto-update to current templates without manual clicking, preserving placeholders and operator notes (`_performReseedWrites` reuses #845 merger + #854 token preservation + #855 cwd resolution).
- [x] Projects with an active batch are deferred, not re-seeded mid-batch; the deferral is logged with a `will retry on next startup` hint.
- [x] Per-project reseed state is load-bearing — a deferred project stays pending and retries on a later startup (tested explicitly via the cross-boot retry scenario).
- [x] No re-seed when that project has already completed reseed for the current version (tested with `skip` action returning instead of writing).
- [x] Existing upgraded users get `GITHUB.md` discovery as primary instruction; old positive `gh pr list` instruction is replaced (end-to-end test writes a pre-#809 stale AGENTS.md and confirms post-reseed content).
- [x] `npm run build` passes.

## Test plan

- [x] `node server/routes.autoReseed.test.js` covers: state load (missing / malformed / wrong-shape / round-trip / non-string-version stripping), `_readPackageVersion` (missing/malformed/no-version/valid), decision matrix (already current, fresh install, batch active, batch unknown via null and via throw, write throws, mix), cross-boot retry, missing-working-dir silent skip, end-to-end real-write with pre-#809 stale templates.
- [x] `npm test` → 29 passed, 0 failed, 2 skipped.
- [x] `npm run build` → ✓ Compiled successfully.

Closes #856