### PR TITLE
[#860] Folded sidebar: active-status green dot on non-idle project icons

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -172,6 +172,12 @@ function ProjectIcon({ project, isActive, expanded, pinned, hasActiveBatch, onCo
             <PinIcon size={8} />
           </div>
         )}
+        {!project.idle && !expanded && (
+          <div
+            className="absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full bg-accent ring-2 ring-bg-surface"
+            aria-label="Active"
+          />
+        )}
       </div>
       {expanded && (
         <span className={`text-xs truncate flex items-center gap-1 ${isActive ? "text-accent" : "text-text-muted"}`}>


### PR DESCRIPTION
Fixes #860.

## What

In the **collapsed/folded** sidebar rail, render a small green status dot on each project icon when `!project.idle`. Idle projects show no dot. Expanded view is unchanged — it continues to surface the existing `ActiveSwitch`.

## Where

`src/components/Sidebar.tsx` — the avatar wrapper inside `ProjectIcon` (the same `relative` parent that already hosts the pin indicator). New element is a sibling of the pin badge, gated by `!project.idle && !expanded`.

## Design choices

- **Source of truth**: `!project.idle` (matches the expanded `ActiveSwitch`'s own `active={!project.idle}`). NOT `isActive` (open project), NOT `hasActiveBatch` (batch pulse-ring is a separate signal).
- **Position**: bottom-right (`-bottom-0.5 -right-0.5`) — the pin badge already occupies `-top-1 -right-1`, so the two never collide.
- **Size**: `w-2 h-2` (8px), `rounded-full bg-accent` — matches the design system's single accent (`#00ff88`) and the issue's ~6–8px target.
- **Pulse-ring coexistence**: `ring-2 ring-bg-surface` (a 2px halo in the sidebar surface color `#111`) keeps the dot visually distinct when a project also has `hasActiveBatch` and the avatar's `animate-pulse-ring` box-shadow expands through the dot's position at peak. No new animation.
- **Live updates**: `projects` state already flips `idle` on `onIdleChange` (Sidebar.tsx:273-275), so toggling Active/Inactive elsewhere (settings, dashboard, other tab) re-renders the dot without extra wiring.

## Acceptance criteria

- [x] Folded sidebar shows a green dot on every non-idle project icon; idle projects show no dot.
- [x] Driven by `!project.idle`; updates live through the existing `onIdleChange` flow.
- [x] No visual collision with the pin indicator (opposite corner) or batch pulse-ring (ring halo).
- [x] Expanded view unchanged.
- [x] `npm run build` ✓.

## Diff

`src/components/Sidebar.tsx` +6 / -0.