### PR TITLE
[#864] Stop batch-active on cleared queue + prefer merged PR in duplicate picker

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1128,8 +1128,14 @@ async function sendTriggerMessage(projectId) {
         const bp = await bpRes.json();
         // #810: gate auto-stop on completeConfirmed (two distinct successful
         // fetch cycles), NOT a single transient/stale `complete`.
-        if (bp && bp.completeConfirmed) {
-          console.log(`[auto-trigger] ${projectId}: batch complete (confirmed), auto-stopped`);
+        // #864: also auto-stop on an explicit operator clear (`liveActiveBatchCleared`).
+        // The preserved snapshot may keep `items` non-empty / `complete` mixed, so
+        // `completeConfirmed` alone won't fire when items don't all resolve as
+        // merged/closed (e.g. a duplicate unmerged PR). The cleared flag is the
+        // operator's intent and overrides those signals for lifecycle purposes.
+        const clearedByOperator = !!(bp && bp.liveActiveBatchCleared);
+        if (bp && (bp.completeConfirmed || clearedByOperator)) {
+          console.log(`[auto-trigger] ${projectId}: batch ${clearedByOperator ? "cleared by operator" : "complete (confirmed)"}, auto-stopped`);
           stopTrigger(projectId);
           // Also stop caffeinate if no other triggers remain running
           // (#441 companion fix). caffeinateProcess is global (not
@@ -1724,13 +1730,21 @@ async function autoStopPollingTick() {
       // #810: gate auto-stop on completeConfirmed (two distinct successful fetch
       // cycles), not a single transient/stale `complete`. Track prev on the
       // confirmed value so the bridge-stop transition guard fires on it.
+      // #864: an explicit operator clear (`liveActiveBatchCleared`) ALSO triggers
+      // the stop path, so trigger + bridges shut down when Head sets the Active
+      // Batch section to empty even if the preserved snapshot's items don't all
+      // resolve as merged/closed (e.g. a duplicate unmerged PR keeps the items
+      // in `in_review`). The cleared flag is the operator's intent.
       const confirmed = !!bp.completeConfirmed;
+      const clearedByOperator = !!bp.liveActiveBatchCleared;
+      const shouldStop = confirmed || clearedByOperator;
       const prev = _bridgeBatchPrev.get(project.id);
-      _bridgeBatchPrev.set(project.id, { complete: confirmed, hasItems });
+      _bridgeBatchPrev.set(project.id, { complete: shouldStop, hasItems });
 
-      if (bp && confirmed) {
+      if (bp && shouldStop) {
         if (hasTriggerAuto) {
-          console.log(`[auto-trigger] ${project.id}: batch complete (confirmed), auto-stopped (poller)`);
+          const reason = clearedByOperator ? "cleared by operator" : "complete (confirmed)";
+          console.log(`[auto-trigger] ${project.id}: batch ${reason}, auto-stopped (poller)`);
           stopTrigger(project.id);
           if (caffeinateProcess.process && triggers.size === 0) {
             try { caffeinateProcess.process.kill("SIGTERM"); } catch {}
@@ -1746,7 +1760,9 @@ async function autoStopPollingTick() {
       }
 
       // #518: detect batch-start transition → auto-start bridges
-      if (hasBridgeAuto && hasItems && !bp.complete) {
+      // #864: do NOT auto-start on a cleared queue even though hasItems may be
+      // true from the preserved snapshot — the operator's clear is a stop signal.
+      if (hasBridgeAuto && hasItems && !bp.complete && !clearedByOperator) {
         const isNewBatch = !prev || prev.complete || !prev.hasItems;
         if (isNewBatch) {
           await autoStartBridges(project.id, project, qwPort);

--- a/server/routes.batchActiveCompletion.test.js
+++ b/server/routes.batchActiveCompletion.test.js
@@ -20,8 +20,24 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const cp = require("child_process");
 
 const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+// #864: replace child_process.execFile BEFORE require("./routes") so the
+// util.promisify(execFile) reference bound inside routes.js sees the stub. The
+// snapshot freshness check uses ghJsonExecAsync → execFile(gh ...). For tests
+// we never want to spawn gh: returning a synthetic non-404 error makes
+// checkBatchSnapshotFreshness fall to its "unknown" branch (snapshot preserved,
+// not deleted), which is what the cleared-queue scenario needs.
+const realRunner = cp.execFile;
+cp.execFile = function stubRunner(file, args, opts, cb) {
+  const done = typeof opts === "function" ? opts : cb;
+  const err = new Error("test stub: gh not invoked");
+  err.code = "ENOTEST";
+  if (typeof done === "function") return done(err, "", "");
+  return realRunner.apply(this, arguments);
+};
 
 // ── fs stubs installed BEFORE require("./routes") ──────────────────────────
 // routes.js reads CONFIG_PATH via getRepo/isProjectIdle on every call, and
@@ -37,12 +53,18 @@ const real = {
 };
 let cfgJson = JSON.stringify({ projects: [] });
 let queueText = "";
+// #864: per-test snapshot fixture. Default null → readBatchSnapshot returns
+// null (existing tests rely on this). A test can set this to a JSON string to
+// simulate a preserved snapshot file on disk; checkBatchSnapshotFreshness is
+// also stubbed via _checkBatchSnapshotFreshnessStub below so we don't fire gh.
+let snapshotJson = null;
 fs.readFileSync = function stubReadFileSync(p, ...rest) {
   if (p === CONFIG_PATH) return cfgJson;
   if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) return queueText;
   // batch-progress-cache.json absent → readBatchSnapshot returns null and the
   // upstream checkBatchSnapshotFreshness gh call is skipped entirely.
   if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    if (snapshotJson !== null) return snapshotJson;
     const err = new Error("ENOENT (test stub)");
     err.code = "ENOENT";
     throw err;
@@ -192,11 +214,103 @@ function inReviewSnapshot(repo, n) {
     _graphqlCache.clear();
     cfgJson = JSON.stringify({ projects: [{ id: "empty-batch-proj", repo: "o/r", idle: false }] });
     queueText = "# Queue\n\n## Active Batch\n\n## Backlog\n";
+    snapshotJson = null;
 
     const data = await getOrComputeBatchProgress("empty-batch-proj");
     ok(data !== null && Array.isArray(data.items) && data.items.length === 0, "B6: empty Active Batch → empty items");
     ok(data.complete === false, "B6: complete === false on empty");
+    ok(data.liveActiveBatchCleared === true, "B6: empty-with-readable-queue → liveActiveBatchCleared:true");
     ok(isBatchActiveFromProgress(data) === false, "B6: empty → not active");
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // C. #864 regression: an explicitly cleared `## Active Batch` section must
+  //    drop /api/batch-active to false even when the preserved snapshot keeps
+  //    the prior batch's items visible for history. Concrete shape from the
+  //    #836 incident: closed issue #836 with merged PR #850 + later closed-
+  //    unmerged duplicate PR #851; Head sets Active Batch to `(none)` so the
+  //    operator-cleared signal must override any items still present from the
+  //    snapshot.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  // C1. Pure helper: liveActiveBatchCleared:true short-circuits even when items
+  //     are present and complete is false (the live #836 incident shape).
+  ok(
+    isBatchActiveFromProgress({ items: [{ status: "in_review" }], complete: false, liveActiveBatchCleared: true }) === false,
+    "C1: liveActiveBatchCleared:true → not active even with in-review item (#864)"
+  );
+  ok(
+    isBatchActiveFromProgress({ items: [{ status: "merged" }], complete: true, liveActiveBatchCleared: true }) === false,
+    "C1: liveActiveBatchCleared:true → not active when also complete (consistent)"
+  );
+  ok(
+    isBatchActiveFromProgress({ items: [{ status: "in_review" }], complete: false, liveActiveBatchCleared: false }) === true,
+    "C1: liveActiveBatchCleared:false → unchanged behavior (active with in-review item)"
+  );
+
+  // C2. End-to-end: queue explicitly cleared (`(none)` in Active Batch) but a
+  //     preserved snapshot still holds issue #836. With the picker fix the
+  //     snapshot resolves issue #836 to merged via merged PR #850; even before
+  //     that fix the lifecycle flag alone would force active:false. This test
+  //     covers BOTH the cleared-flag wiring and the snapshot resolution.
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "cleared-836", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n(none)\n\n## Backlog\n";
+    snapshotJson = JSON.stringify({ batchNumber: 9, issueNumbers: [836] });
+    // Pre-populate the GraphQL snapshot with the #836 shape: closed issue +
+    // merged PR #850. The picker fix means progressFromSnapshot finds #850 and
+    // resolves the row as merged, so the snapshot would normally land on
+    // complete:true. But the cleared flag must drop active to false regardless.
+    _graphqlCache.set("o/r", {
+      ts: Date.now(),
+      issues: [],
+      prs: [],
+      closedIssues: [{ number: 836, title: "feat: real fix", url: "https://x/i/836" }],
+      mergedPrs: [{ number: 850, title: "[#836] real fix", url: "https://x/p/850", merged_at: "2026-05-20T10:00:00Z", reviews: [] }],
+      openPrsWindowComplete: true,
+      closedPrsWindowComplete: true,
+      closedPrIssueNums: [836],
+    });
+
+    const data = await getOrComputeBatchProgress("cleared-836");
+    ok(data !== null, "C2: cleared queue + snapshot → non-null payload");
+    ok(data.liveActiveBatchCleared === true, "C2: liveActiveBatchCleared:true reflects the operator's `(none)` clear");
+    ok(Array.isArray(data.items) && data.items.length === 1 && data.items[0].issue_number === 836,
+       "C2: preserved snapshot still surfaces issue #836 for history");
+    ok(data.items[0].status === "merged", "C2: #836 resolves as merged via PR #850 from the GraphQL snapshot");
+    ok(isBatchActiveFromProgress(data) === false,
+       "C2: /api/batch-active reports false on the cleared queue (the #864 fix)");
+  }
+
+  // C3. Unreadable queue file (#316 bypass) must NOT be mistaken for an explicit
+  //     clear — the operator never touched the file, so lifecycle signals must
+  //     not flip off based on a transient read error.
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "queue-missing", repo: "o/r", idle: false }] });
+    // Force the queue read to throw — the routes.js try/catch will set
+    // queueReadOk=false and resolveDisplayedBatch returns the empty state.
+    const prevRead = fs.readFileSync;
+    fs.readFileSync = function (p, ...rest) {
+      if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) {
+        const err = new Error("ENOENT (test stub)");
+        err.code = "ENOENT";
+        throw err;
+      }
+      return prevRead(p, ...rest);
+    };
+    snapshotJson = null;
+
+    const data = await getOrComputeBatchProgress("queue-missing");
+    fs.readFileSync = prevRead;
+    ok(data !== null, "C3: unreadable queue still returns a payload (#316 bypass)");
+    ok(data.liveActiveBatchCleared === false,
+       "C3: unreadable queue → liveActiveBatchCleared:false (distinct from explicit clear)");
+    ok(isBatchActiveFromProgress(data) === false,
+       "C3: empty items short-circuit still keeps it inactive (orthogonal)");
   }
 
   console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/server/routes.js
+++ b/server/routes.js
@@ -2318,15 +2318,26 @@ function buildNoPrRow(issue) {
 // would also surface `[#807]` for n=80), so we re-apply the strict `^\s*\[#N\]`
 // regex the snapshot matcher uses. Returns the freshest matching PR number (or
 // null), treating a search failure as "no linked PR found".
-// Pure: pick the freshest PR (highest number) whose title matches the STRICT
-// `^\s*\[#N\]` convention from a set of REST search items. Guards `[#807]` from
-// matching n=80 even though Search's loose `in:title 80` would surface it.
-// Returns the PR number or null. Exported for unit tests.
+// Pure: pick the right PR whose title matches the STRICT `^\s*\[#N\]` convention
+// from a set of REST search items. Guards `[#807]` from matching n=80 even
+// though Search's loose `in:title 80` would surface it. Returns the PR number
+// or null. Exported for unit tests.
+//
+// #864: when more than one strict match exists (e.g. a closed-unmerged duplicate
+// opened after the real merged PR for the same issue), prefer a MERGED match
+// over an unmerged one — otherwise the highest-PR-number tie-break picks the
+// duplicate and downstream progress flips a CLOSED issue back to in_review,
+// keeping the batch falsely "active" after Head clears the queue. Within each
+// pool (merged-only when any merged exist, otherwise everything matched) we
+// still tie-break by highest PR number, preserving the existing freshest-wins
+// behavior for non-duplicate cases.
 function pickLinkedPrFromSearch(items, n) {
   const titleRe = new RegExp(`^\\s*\\[#${n}\\]`);
   const matches = (Array.isArray(items) ? items : []).filter((it) => titleRe.test((it && it.title) || ""));
   if (matches.length === 0) return null;
-  return matches.slice().sort((a, b) => (b.number || 0) - (a.number || 0))[0].number;
+  const merged = matches.filter((it) => it && it.pull_request && it.pull_request.merged_at);
+  const pool = merged.length > 0 ? merged : matches;
+  return pool.slice().sort((a, b) => (b.number || 0) - (a.number || 0))[0].number;
 }
 
 // The actual REST Search call, split out so findLinkedPrByTitle's
@@ -2464,8 +2475,17 @@ function summarizeItems(items) {
 // Active Batch section. Returns null when there's no progress payload (an
 // undefined input — current callers always pass a value), defensively
 // treated as "not active" at the route.
+//
+// #864: lifecycle consumers (this route, trigger auto-stop, reseed safe-boundary
+// checks via isActiveFromProgress) must NOT consider an explicitly cleared
+// `## Active Batch` section as active. resolveDisplayedBatch still serves the
+// preserved snapshot so /api/batch-progress can render the prior batch for
+// history, but the lifecycle signal must follow the operator's intent. The
+// `liveActiveBatchCleared` flag set by getOrComputeBatchProgress short-circuits
+// the items-based check below.
 function isBatchActiveFromProgress(progress) {
   if (!progress) return null;
+  if (progress.liveActiveBatchCleared) return false;
   const items = Array.isArray(progress.items) ? progress.items : [];
   return items.length > 0 && !progress.complete;
 }
@@ -2592,13 +2612,20 @@ async function getOrComputeBatchProgress(projectId) {
   // snapshot-aware helper so merged items stay visible after Head
   // moves them from Active Batch to Done, until a new batch starts.
   const { batchNumber, issueNumbers } = resolveDisplayedBatch(queueText, projectId, { queueReadOk });
+  // #864: lifecycle-signal flag. The displayed batch may be the preserved
+  // snapshot (so /api/batch-progress keeps showing it), but lifecycle consumers
+  // (/api/batch-active, trigger auto-stop, reseed safe-boundary) must follow
+  // the operator's explicit clear. Compute from the LIVE parse, only when the
+  // queue file actually read OK — the #316 bypass (queueReadOk=false) must NOT
+  // be mistaken for an explicit clear, since the operator never touched it.
+  const liveActiveBatchCleared = queueReadOk && parseActiveBatch(queueText).issueNumbers.length === 0;
   // #828 P2: batch identity = number + issue set. evalBatchCompleteConfirmed
   // resets its streak when this changes, so a new already-complete batch can't
   // inherit the prior batch's first cycle and confirm in one tick.
   const batchKey = `${batchNumber}::${[...issueNumbers].sort((a, b) => a - b).join(",")}`;
   if (issueNumbers.length === 0) {
     evalBatchCompleteConfirmed(projectId, batchKey, false, null); // reset any complete streak
-    const data = { batch_number: batchNumber, items: [], summary: "", complete: false, completeConfirmed: false };
+    const data = { batch_number: batchNumber, items: [], summary: "", complete: false, completeConfirmed: false, liveActiveBatchCleared };
     _batchProgressCache.set(projectId, { ts: Date.now(), data });
     return data;
   }
@@ -2631,7 +2658,7 @@ async function getOrComputeBatchProgress(projectId) {
   // before any auto-stop consumer may act on it (never auto-stop on a single
   // transient/stale complete). Keyed on the snapshot's ts as the cycle marker.
   const completeConfirmed = evalBatchCompleteConfirmed(projectId, batchKey, complete, snapshot ? snapshot.ts : null);
-  const data = { batch_number: batchNumber, items, summary, complete, completeConfirmed };
+  const data = { batch_number: batchNumber, items, summary, complete, completeConfirmed, liveActiveBatchCleared };
   _batchProgressCache.set(projectId, { ts: Date.now(), data });
   return data;
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -2323,21 +2323,33 @@ function buildNoPrRow(issue) {
 // though Search's loose `in:title 80` would surface it. Returns the PR number
 // or null. Exported for unit tests.
 //
-// #864: when more than one strict match exists (e.g. a closed-unmerged duplicate
-// opened after the real merged PR for the same issue), prefer a MERGED match
-// over an unmerged one — otherwise the highest-PR-number tie-break picks the
-// duplicate and downstream progress flips a CLOSED issue back to in_review,
-// keeping the batch falsely "active" after Head clears the queue. Within each
-// pool (merged-only when any merged exist, otherwise everything matched) we
-// still tie-break by highest PR number, preserving the existing freshest-wins
-// behavior for non-duplicate cases.
-function pickLinkedPrFromSearch(items, n) {
+// #864: when more than one strict match exists for a CLOSED issue (e.g. a
+// closed-unmerged duplicate opened after the real merged PR for the same
+// issue), prefer a MERGED match over an unmerged one — otherwise the
+// highest-PR-number tie-break picks the duplicate and downstream progress
+// flips a CLOSED issue back to in_review, keeping the batch falsely "active"
+// after Head clears the queue.
+//
+// #864/RE1: the merged-preference is GATED on `opts.issueState === "CLOSED"`.
+// For an OPEN/reopened issue, applying it would let an OLDER merged PR beat a
+// NEWER active duplicate/reopen PR with the same `[#N]` prefix — the picker
+// would return the stale merged PR number and progressForItemRest would fall
+// through to in_review-with-the-wrong-PR (since the `merged && CLOSED` row
+// requires the issue to be closed). The default (no opts → open-by-omission)
+// is the legacy freshest-wins behavior, preserving back-compat for direct
+// callers and tests that don't yet supply issue state.
+function pickLinkedPrFromSearch(items, n, opts = {}) {
   const titleRe = new RegExp(`^\\s*\\[#${n}\\]`);
   const matches = (Array.isArray(items) ? items : []).filter((it) => titleRe.test((it && it.title) || ""));
   if (matches.length === 0) return null;
-  const merged = matches.filter((it) => it && it.pull_request && it.pull_request.merged_at);
-  const pool = merged.length > 0 ? merged : matches;
-  return pool.slice().sort((a, b) => (b.number || 0) - (a.number || 0))[0].number;
+  const preferMerged = opts.issueState === "CLOSED";
+  if (preferMerged) {
+    const merged = matches.filter((it) => it && it.pull_request && it.pull_request.merged_at);
+    if (merged.length > 0) {
+      return merged.slice().sort((a, b) => (b.number || 0) - (a.number || 0))[0].number;
+    }
+  }
+  return matches.slice().sort((a, b) => (b.number || 0) - (a.number || 0))[0].number;
 }
 
 // The actual REST Search call, split out so findLinkedPrByTitle's
@@ -2358,9 +2370,9 @@ async function _searchLinkedPrItems(repo, n) {
 // with a merged PR would render closed). So failure THROWS, and the caller
 // (progressForItemRest, awaiting without a catch) drops the item to the
 // non-authoritative "fetch failed" row, retried on the next cache miss.
-async function findLinkedPrByTitle(repo, n, search = _searchLinkedPrItems) {
+async function findLinkedPrByTitle(repo, n, search = _searchLinkedPrItems, opts = {}) {
   const items = await search(repo, n);
-  return pickLinkedPrFromSearch(items, n);
+  return pickLinkedPrFromSearch(items, n, opts);
 }
 
 // Authoritative by-number resolution for an active-batch issue the board
@@ -2382,7 +2394,10 @@ async function progressForItemRest(repo, issueNumber) {
   // Throws (→ route's "fetch failed" row) if Search itself fails, so a
   // could-not-determine is NEVER mistaken for proof of no linked PR. A null
   // here means Search SUCCEEDED with zero strict [#N] matches — authoritative.
-  const prNumber = await findLinkedPrByTitle(repo, issueNumber);
+  // #864/RE1: pass issue.state so the picker only prefers a merged duplicate
+  // for CLOSED issues; OPEN/reopened issues keep legacy freshest-wins, so a
+  // newer active duplicate PR isn't masked by an older merged one.
+  const prNumber = await findLinkedPrByTitle(repo, issueNumber, _searchLinkedPrItems, { issueState: issue.state });
   // No linked PR (authoritative). #350: honor the issue's own state — a CLOSED
   // issue with no linked PR is fully done (superseded/not-planned/runbook) →
   // 100% ✓; only a truly OPEN issue with no PR is queued.

--- a/server/routes.restMigration828.test.js
+++ b/server/routes.restMigration828.test.js
@@ -44,6 +44,41 @@ async function run() {
     ok(pickLinkedPrFromSearch([{ number: 5, title: "  [#42] leading ws" }], 42) === 5, "leading whitespace before [#N] still matches");
   }
 
+  // ── #864: duplicate strict [#N] matches — prefer the MERGED one over a later
+  //    closed-unmerged duplicate (highest-PR-number tie-break would otherwise
+  //    pick the duplicate and the downstream row flips a CLOSED issue to
+  //    in_review, keeping the batch falsely "active" after the queue is cleared).
+  //    Concrete shape: issue #836 closed, merged PR #850, later closed-unmerged
+  //    duplicate PR #851 with the same `[#836]` title prefix.
+  {
+    const items = [
+      { number: 850, title: "[#836] real fix", pull_request: { merged_at: "2026-05-20T10:00:00Z" } },
+      { number: 851, title: "[#836] duplicate", pull_request: { merged_at: null } },
+    ];
+    ok(pickLinkedPrFromSearch(items, 836) === 850, "merged PR #850 wins over later closed-unmerged duplicate #851 (#864)");
+    // Reversed input order: merged should still win regardless of search-result ordering.
+    ok(pickLinkedPrFromSearch([...items].reverse(), 836) === 850, "merged-preferred selection is order-independent");
+    // Multiple merged + multiple unmerged → among merged, highest # still wins.
+    const multi = [
+      { number: 700, title: "[#42] old merge", pull_request: { merged_at: "2026-01-01T00:00:00Z" } },
+      { number: 705, title: "[#42] newer merge", pull_request: { merged_at: "2026-02-01T00:00:00Z" } },
+      { number: 800, title: "[#42] later dup",  pull_request: { merged_at: null } },
+    ];
+    ok(pickLinkedPrFromSearch(multi, 42) === 705, "among merged matches, highest PR number still wins; unmerged duplicate ignored");
+    // Zero merged matches → fall back to highest-PR-number across all matches (legacy behavior).
+    const noMerged = [
+      { number: 300, title: "[#9] open", pull_request: { merged_at: null } },
+      { number: 305, title: "[#9] newer open", pull_request: { merged_at: null } },
+    ];
+    ok(pickLinkedPrFromSearch(noMerged, 9) === 305, "no merged candidates → freshest (highest #) wins (unchanged)");
+    // Items without `pull_request` (defensive) treated as not-merged.
+    const noPrShape = [
+      { number: 500, title: "[#5] missing pr field" },
+      { number: 510, title: "[#5] also missing" },
+    ];
+    ok(pickLinkedPrFromSearch(noPrShape, 5) === 510, "missing pull_request field treated as not-merged → falls back to highest #");
+  }
+
   // ── #828 / RE1 #830: a Search FAILURE must NOT collapse to an authoritative
   //    no-PR (which would render an out-of-window OPEN issue as queued, or a
   //    CLOSED issue with a merged PR as closed). findLinkedPrByTitle returns

--- a/server/routes.restMigration828.test.js
+++ b/server/routes.restMigration828.test.js
@@ -45,38 +45,57 @@ async function run() {
   }
 
   // ── #864: duplicate strict [#N] matches — prefer the MERGED one over a later
-  //    closed-unmerged duplicate (highest-PR-number tie-break would otherwise
-  //    pick the duplicate and the downstream row flips a CLOSED issue to
-  //    in_review, keeping the batch falsely "active" after the queue is cleared).
-  //    Concrete shape: issue #836 closed, merged PR #850, later closed-unmerged
-  //    duplicate PR #851 with the same `[#836]` title prefix.
+  //    closed-unmerged duplicate ONLY for CLOSED issues. RE1 review: applying
+  //    merged-first globally would let an older merged PR beat a newer active
+  //    duplicate / reopen PR on an OPEN issue. The picker now takes the
+  //    calling issue's state so the merged-preference is scoped to the only
+  //    shape it's needed for (closed-and-done with a stale duplicate).
+  //    Concrete CLOSED shape: issue #836 closed, merged PR #850, later
+  //    closed-unmerged duplicate PR #851 with the same `[#836]` title prefix.
   {
     const items = [
       { number: 850, title: "[#836] real fix", pull_request: { merged_at: "2026-05-20T10:00:00Z" } },
       { number: 851, title: "[#836] duplicate", pull_request: { merged_at: null } },
     ];
-    ok(pickLinkedPrFromSearch(items, 836) === 850, "merged PR #850 wins over later closed-unmerged duplicate #851 (#864)");
+    ok(pickLinkedPrFromSearch(items, 836, { issueState: "CLOSED" }) === 850, "CLOSED issue: merged PR #850 wins over later closed-unmerged duplicate #851 (#864)");
     // Reversed input order: merged should still win regardless of search-result ordering.
-    ok(pickLinkedPrFromSearch([...items].reverse(), 836) === 850, "merged-preferred selection is order-independent");
-    // Multiple merged + multiple unmerged → among merged, highest # still wins.
+    ok(pickLinkedPrFromSearch([...items].reverse(), 836, { issueState: "CLOSED" }) === 850, "CLOSED issue: merged-preferred selection is order-independent");
+    // Multiple merged + multiple unmerged on a CLOSED issue → among merged, highest # still wins.
     const multi = [
       { number: 700, title: "[#42] old merge", pull_request: { merged_at: "2026-01-01T00:00:00Z" } },
       { number: 705, title: "[#42] newer merge", pull_request: { merged_at: "2026-02-01T00:00:00Z" } },
       { number: 800, title: "[#42] later dup",  pull_request: { merged_at: null } },
     ];
-    ok(pickLinkedPrFromSearch(multi, 42) === 705, "among merged matches, highest PR number still wins; unmerged duplicate ignored");
-    // Zero merged matches → fall back to highest-PR-number across all matches (legacy behavior).
+    ok(pickLinkedPrFromSearch(multi, 42, { issueState: "CLOSED" }) === 705, "CLOSED issue: among merged matches, highest PR number still wins; unmerged duplicate ignored");
+    // Zero merged matches on a CLOSED issue → fall back to highest-PR-number across all matches.
     const noMerged = [
       { number: 300, title: "[#9] open", pull_request: { merged_at: null } },
       { number: 305, title: "[#9] newer open", pull_request: { merged_at: null } },
     ];
-    ok(pickLinkedPrFromSearch(noMerged, 9) === 305, "no merged candidates → freshest (highest #) wins (unchanged)");
+    ok(pickLinkedPrFromSearch(noMerged, 9, { issueState: "CLOSED" }) === 305, "CLOSED issue: no merged candidates → freshest (highest #) wins (legacy fallback)");
     // Items without `pull_request` (defensive) treated as not-merged.
     const noPrShape = [
       { number: 500, title: "[#5] missing pr field" },
       { number: 510, title: "[#5] also missing" },
     ];
-    ok(pickLinkedPrFromSearch(noPrShape, 5) === 510, "missing pull_request field treated as not-merged → falls back to highest #");
+    ok(pickLinkedPrFromSearch(noPrShape, 5, { issueState: "CLOSED" }) === 510, "CLOSED issue: missing pull_request field treated as not-merged → falls back to highest #");
+
+    // ── #864/RE1: OPEN issue with an older merged PR + newer active duplicate
+    //    (e.g. a reopened issue where someone is finishing the work in a new
+    //    PR). The picker MUST keep legacy freshest-wins so the active PR's
+    //    in_review/approval status surfaces, not the stale merged PR's data.
+    //    Without this gate, progressForItemRest would pick the merged PR,
+    //    skip the `merged && CLOSED` branch (issue is OPEN), and fall through
+    //    to in_review with the WRONG PR's review data.
+    const openWithStaleMerge = [
+      { number: 850, title: "[#836] old, merged then reopened", pull_request: { merged_at: "2026-05-20T10:00:00Z" } },
+      { number: 870, title: "[#836] new active fix",            pull_request: { merged_at: null } },
+    ];
+    ok(pickLinkedPrFromSearch(openWithStaleMerge, 836, { issueState: "OPEN" }) === 870, "OPEN issue: newer active duplicate wins over older merged PR (legacy freshest-wins preserved)");
+    // Default (no opts) preserves legacy back-compat for any external caller
+    // that hasn't been updated to pass issueState (also exercises the test-only
+    // direct callers in this file's existing P1 block).
+    ok(pickLinkedPrFromSearch(openWithStaleMerge, 836) === 870, "no opts (legacy call shape): freshest-wins preserved → newer active PR (back-compat)");
   }
 
   // ── #828 / RE1 #830: a Search FAILURE must NOT collapse to an authoritative


### PR DESCRIPTION
## Summary

Two coupled fixes for the lifecycle drift Operator hit on quadwork's Batch 9:

- **Cleared-queue lifecycle signal**: `getOrComputeBatchProgress` now exposes a `liveActiveBatchCleared` flag when the operator empties `## Active Batch` in OVERNIGHT-QUEUE.md. `/api/batch-progress` still shows the preserved snapshot for history, but `/api/batch-active`, manual reseed, `autoReseedOnStartup`, and trigger auto-stop (poller + `sendTriggerMessage`) now treat the cleared section as the operator's stop signal — even when the snapshot keeps items visible. The #316 unreadable-queue bypass is preserved as a distinct case (not mistaken for an explicit clear).
- **Duplicate `[#N]` PR picker**: `pickLinkedPrFromSearch` now prefers a merged match over an unmerged one when more than one strict `[#N]` PR exists for the same issue. The previous "highest PR number wins" tie-break picked the later closed-unmerged duplicate PR #851 over the actual merged PR #850 for closed issue #836, which flipped the row to `in_review` and kept the batch falsely "active". Within each pool (merged-only when any merged exist, otherwise everything matched) the freshest-wins tie-break is unchanged, so non-duplicate cases behave exactly as before.

## Files

- `server/routes.js` — `liveActiveBatchCleared` plumbed through `getOrComputeBatchProgress`; `isBatchActiveFromProgress` short-circuits on it; `pickLinkedPrFromSearch` prefers merged matches.
- `server/index.js` — trigger auto-stop (poller + `sendTriggerMessage`) honors the cleared flag; bridge auto-start guard skips it.
- `server/routes.batchActiveCompletion.test.js` — new C-section: pure helper truth-table for the flag, end-to-end #836 scenario (cleared queue + preserved snapshot resolves merged via PR #850), #316 unreadable-queue regression.
- `server/routes.restMigration828.test.js` — new #864 picker cases: merged-over-duplicate selection, order independence, multi-merged tie-break, no-merged fallback, missing pull_request field.

## Acceptance criteria — all met

- [x] Cleared \`## Active Batch\` → \`/api/batch-active\` returns \`{active:false}\` even with preserved snapshot.
- [x] \`/api/batch-progress\` still surfaces the preserved batch; only lifecycle consumers drop active.
- [x] Linked-PR REST Search fallback resolves the #836 shape correctly: merged PR #850 wins over later closed-unmerged duplicate PR #851.
- [x] Picker does not choose purely by highest PR number when that produces an incomplete state for an already-closed issue.
- [x] Regression coverage for the #836 shape (closed issue + merged + duplicate + cleared queue) lives in both test files.

## Test plan

- [x] \`npm test\` (29 suites, 0 failed) including the new picker + cleared-queue cases.
- [x] \`npm run build\` (Next.js 16.2.6, 9/9 pages, TS check clean).
- [ ] Reviewer verification: confirm the cleared-queue + preserved-snapshot scenario via the new C2 test path.

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)