### PR TITLE
[#862] Forbid seeds from killing the QuadWork orchestrator / @dev ports

### DIFF
--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -29,16 +29,16 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
 ### Rule 4: Orchestrator Port Protection
-The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js development server (its own port — `next dev`'s listener, NOT an agent mention) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
 
 **NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
-- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `kill <pid>` against any process bound to port 8400 or the Next.js development server port
 - `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
 - `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
 - `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
-- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / Next.js development server
 
-For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next.js development server port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
 
 If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
 

--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -28,6 +28,20 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
+### Rule 4: Orchestrator Port Protection
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+
+**NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
+- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
+- `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
+- `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+
+If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
+
 ---
 
 You are Dev, the primary implementation agent.

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -29,16 +29,16 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
 ### Rule 4: Orchestrator Port Protection
-The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js development server (its own port — `next dev`'s listener, NOT an agent mention) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
 
 **NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
-- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `kill <pid>` against any process bound to port 8400 or the Next.js development server port
 - `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
 - `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
 - `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
-- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / Next.js development server
 
-For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next.js development server port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
 
 If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
 

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -28,6 +28,20 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
+### Rule 4: Orchestrator Port Protection
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+
+**NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
+- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
+- `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
+- `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+
+If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
+
 ---
 
 You are Head, the project owner and coordinator agent.

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -29,16 +29,16 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
 ### Rule 4: Orchestrator Port Protection
-The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js development server (its own port — `next dev`'s listener, NOT an agent mention) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
 
 **NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
-- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `kill <pid>` against any process bound to port 8400 or the Next.js development server port
 - `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
 - `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
 - `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
-- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / Next.js development server
 
-For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next.js development server port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
 
 If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
 

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -28,6 +28,20 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
+### Rule 4: Orchestrator Port Protection
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+
+**NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
+- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
+- `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
+- `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+
+If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
+
 ---
 
 You are **RE1**, the first reviewer agent. Your chat identity is `re1`.

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -28,6 +28,20 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
+### Rule 4: Orchestrator Port Protection
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+
+**NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
+- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
+- `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
+- `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+
+If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
+
 ---
 
 You are **RE2**, the second reviewer agent. Your chat identity is `re2`.

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -29,16 +29,16 @@ If you need to reference sensitive data, use a placeholder like `<WALLET_ADDRESS
 This rule applies to ALL output that touches GitHub or git — issues, PR bodies, review comments, commit messages, and file contents.
 
 ### Rule 4: Orchestrator Port Protection
-The QuadWork orchestrator (port **8400**, Express backend) and the Next.js @dev server (its own port) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
+The QuadWork orchestrator (port **8400**, Express backend) and the Next.js development server (its own port — `next dev`'s listener, NOT an agent mention) are live self-host infrastructure during review. Killing them takes down the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project.
 
 **NEVER kill, restart, or manage processes on these ports.** Forbidden commands include — but are not limited to:
-- `kill <pid>` against any process bound to port 8400 or the Next @dev port
+- `kill <pid>` against any process bound to port 8400 or the Next.js development server port
 - `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match that could hit them
 - `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
 - `lsof -ti:8400 | xargs kill`, or any `lsof … kill` / `lsof … xargs` chain targeting these ports
-- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server
+- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / Next.js development server
 
-For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next @dev port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
+For runtime or visual checks, use a throwaway port such as `PORT=8499` (or any free port other than 8400 and the Next.js development server port). Where possible, prefer `npm run build` output, unit/integration tests, and code review over spinning up a runtime.
 
 If something on port 8400 looks wrong, report it to the operator via `chat_send` — do not try to fix it by restarting.
 


### PR DESCRIPTION
## Summary

Adds **Rule 4 — Orchestrator Port Protection** to all four seed templates (`templates/seeds/head.AGENTS.md`, `dev.AGENTS.md`, `re1.AGENTS.md`, `re2.AGENTS.md`) under the existing `MANDATORY RULES — READ BEFORE DOING ANYTHING` section. Identical wording across the four so the rule is enforced uniformly across the agent quad.

During self-host review the live QuadWork orchestrator on port `8400` and the Next.js @dev server back the chat MCP, batch progress, GITHUB.md sync, the scheduled trigger, and every other agent in the project. An agent killing or restarting either takes the whole project down mid-batch (the #861 / pr-861 re-review incident — the operator explicitly flagged "killing port 8400 is what took the server down").

## Wording of the new rule

The rule forbids:
- `kill <pid>` against any process bound to port 8400 or the Next @dev port
- `pkill -f "next"`, `pkill -f "quadwork"`, `pkill -f "node.*8400"`, or any similar broad pattern match
- `fuser -k 8400/tcp` or `fuser -k <next-dev-port>/tcp`
- `lsof -ti:8400 | xargs kill` / any `lsof … kill` / `lsof … xargs` chain targeting these ports
- `npm run start`, `npm run dev`, `quadwork start`, or any restart of the live orchestrator / @dev server

And points agents at:
- A throwaway port such as `PORT=8499` for runtime / visual checks
- `npm run build` output, unit/integration tests, and code review as preferred alternatives

Plus: if something on port 8400 looks wrong, agents must `chat_send` the operator instead of restarting.

## Files

- `templates/seeds/head.AGENTS.md` — +14 lines (new Rule 4 block)
- `templates/seeds/dev.AGENTS.md`  — +14 lines (same block)
- `templates/seeds/re1.AGENTS.md`  — +14 lines (same block)
- `templates/seeds/re2.AGENTS.md`  — +14 lines (same block)

Total diff: +56 / -0, four templates, no code touched.

## Re-seed propagation

Existing operator-running quads pick up the new rule on the next `_performReseedWrites` cycle. The merger (`reseedAgentsMd`) preserves agent customizations, so the new rule slots into the canonical section without disturbing per-agent additions.

## Acceptance criteria — all met

- [x] All 4 seed templates contain the orchestrator-port guardrail (verified via `grep -l "Rule 4: Orchestrator Port Protection" templates/seeds/*.AGENTS.md`).
- [x] Wording forbids `kill` / `pkill` / `fuser` / `lsof ... kill` against port 8400 and the Next @dev port.
- [x] Guidance points agents at `PORT=8499` (or any free port) for runtime checks, with build/tests/code review as the preferred path.
- [x] No code or logic changes — templates only.

## Test plan

- [x] `npm test` → 29 suites pass (including `routes.reseedAgentsMd.test.js`, `routes.reseedTokenPreservation.test.js`, `routes.resolveReseedTargets.test.js`).
- [x] `git diff --stat` — only the four seed templates touched.
- [ ] Reviewer verification: confirm the rule wording is enforceable and the new Rule 4 block lives in the right position in each seed.

Fixes #862

Generated with Claude Code (https://claude.com/claude-code)