### PR TITLE
[#790] MCP operator server scaffold + transport + list_projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.2.1",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
-    "quadwork": "./bin/quadwork.js"
+    "quadwork": "./bin/quadwork.js",
+    "quadwork-mcp-operator": "./server/mcp-operator.js"
   },
   "files": [
     "bin/",

--- a/server/mcp-operator.js
+++ b/server/mcp-operator.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+"use strict";
+
+// #790: QuadWork MCP operator server. A stdio JSON-RPC server, spawned by the
+// MCP client (Claude Code / Claude Desktop), NOT by QuadWork itself:
+//
+//   claude mcp add quadwork -- quadwork-mcp-operator --port 8400
+//
+// Operator-scoped: `project` is a per-tool argument, not a launch flag. The
+// transport framing mirrors server/mcp-chat-shim.js. Tools live in
+// mcp-operator/tools/*.js and are auto-merged by loadTools() — adding a new
+// tool means adding a new file, never editing this one.
+
+const fs = require("fs");
+const path = require("path");
+const readline = require("readline");
+const { createContext } = require("./mcp-operator/context");
+
+const args = process.argv.slice(2);
+function flag(name) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : null;
+}
+
+const PORT = flag("port");
+if (!PORT) {
+  process.stderr.write("Usage: quadwork-mcp-operator --port <port>\n");
+  process.exit(1);
+}
+
+const ctx = createContext(PORT);
+
+// Tool-module loader: merge defs (for tools/list) + handlers (for dispatch)
+// from every *.js under mcp-operator/tools/. Skips *.test.js.
+function loadTools() {
+  const toolsDir = path.join(__dirname, "mcp-operator", "tools");
+  const defs = [];
+  const handlers = {};
+  for (const file of fs.readdirSync(toolsDir)) {
+    if (!file.endsWith(".js") || file.endsWith(".test.js")) continue;
+    const mod = require(path.join(toolsDir, file));
+    if (Array.isArray(mod.defs)) defs.push(...mod.defs);
+    if (mod.handlers) Object.assign(handlers, mod.handlers);
+  }
+  return { defs, handlers };
+}
+
+const { defs: TOOL_DEFS, handlers: TOOL_HANDLERS } = loadTools();
+
+function jsonRpc(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+// Every tools/call is wrapped so a thrown/rejected handler becomes a JSON-RPC
+// error — the stdio loop must never crash on a failed call.
+async function handleToolCall(id, name, params) {
+  const handler = TOOL_HANDLERS[name];
+  if (!handler) return jsonRpcError(id, -32601, `Unknown tool: ${name}`);
+  try {
+    const result = await handler(params || {}, ctx);
+    return jsonRpc(id, { content: [{ type: "text", text: JSON.stringify(result) }] });
+  } catch (err) {
+    return jsonRpcError(id, -32000, err.message);
+  }
+}
+
+async function handleMessage(msg) {
+  const { id, method, params } = msg;
+
+  if (method === "initialize") {
+    return jsonRpc(id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: { name: "quadwork-operator", version: "1.0.0" },
+    });
+  }
+
+  if (method === "initialized") {
+    return null;
+  }
+
+  if (method === "tools/list") {
+    return jsonRpc(id, { tools: TOOL_DEFS });
+  }
+
+  if (method === "tools/call") {
+    return handleToolCall(id, params?.name, params?.arguments || {});
+  }
+
+  if (method === "ping") {
+    return jsonRpc(id, {});
+  }
+
+  if (id != null) {
+    return jsonRpcError(id, -32601, `Method not found: ${method}`);
+  }
+  return null;
+}
+
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+rl.on("line", async (line) => {
+  if (!line.trim()) return;
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    process.stdout.write(jsonRpcError(null, -32700, "Parse error") + "\n");
+    return;
+  }
+  // Belt-and-braces: even an unexpected throw in dispatch is mapped to a
+  // JSON-RPC error rather than killing the loop.
+  let response;
+  try {
+    response = await handleMessage(msg);
+  } catch (err) {
+    response = jsonRpcError(msg && msg.id != null ? msg.id : null, -32000, err.message);
+  }
+  if (response) {
+    process.stdout.write(response + "\n");
+  }
+});
+
+rl.on("close", () => {
+  process.exit(0);
+});

--- a/server/mcp-operator.test.js
+++ b/server/mcp-operator.test.js
@@ -1,0 +1,230 @@
+"use strict";
+
+// #790: tests for the MCP operator scaffold.
+//   1. list_projects over stdio proxies GET /api/config → { id, name, repo }
+//      only (the internal `agents` id list is stripped from public output).
+//   2. httpRequest maps ECONNREFUSED and a timeout to clean errors.
+//   3. assertKnownProject / assertKnownAgent pass known ids and throw the
+//      clean error for unknown ones — with no further (tool) HTTP call.
+
+const { spawn } = require("child_process");
+const http = require("http");
+const path = require("path");
+const { createContext } = require("./mcp-operator/context");
+
+const OPERATOR = path.join(__dirname, "mcp-operator.js");
+
+// Config the fake backend serves. `agents` is an OBJECT (mirrors the real
+// config.json) with per-agent fields that MUST NOT leak through the tools.
+const FAKE_CONFIG = {
+  projects: [
+    {
+      id: "plotlink",
+      name: "PlotLink",
+      repo: "realproject7/plotlink",
+      agents: {
+        head: { model: "claude-opus-4-8", token: "secret-head" },
+        dev: { model: "claude-opus-4-8" },
+        re1: {},
+        re2: {},
+      },
+      extraField: "should-not-leak",
+    },
+    {
+      id: "quadwork",
+      name: "QuadWork",
+      repo: "realproject7/quadwork",
+      agents: { head: {}, dev: {}, re1: {}, re2: {} },
+    },
+  ],
+  operator_name: "tester",
+};
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log(`  PASS: ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+// A fake QuadWork backend that records every request path so we can prove
+// validation short-circuits before any tool HTTP call.
+function startConfigServer() {
+  const requests = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      if (req.method === "GET" && req.url.startsWith("/api/config")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(FAKE_CONFIG));
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests }));
+  });
+}
+
+// A server that accepts the connection but never responds — to exercise the
+// httpRequest timeout path quickly.
+function startBlackholeServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer(() => {
+      /* never respond */
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port }));
+  });
+}
+
+function sendJsonRpc(proc, msg) {
+  proc.stdin.write(JSON.stringify(msg) + "\n");
+}
+
+function readResponse(proc) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timeout waiting for response")), 5000);
+    const handler = (data) => {
+      clearTimeout(timeout);
+      proc.stdout.removeListener("data", handler);
+      try {
+        resolve(JSON.parse(data.toString().trim().split("\n").pop()));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    proc.stdout.on("data", handler);
+  });
+}
+
+async function expectThrows(fn, label) {
+  try {
+    await fn();
+    return null;
+  } catch (err) {
+    return err;
+  } finally {
+    void label;
+  }
+}
+
+async function runTests() {
+  console.log("\n--- MCP Operator Scaffold Tests (#790) ---\n");
+
+  // ── 1. list_projects end-to-end over stdio ──────────────────────────────
+  const { server: cfgServer, port: cfgPort, requests } = await startConfigServer();
+
+  const op = spawn("node", [OPERATOR, "--port", String(cfgPort)], { stdio: ["pipe", "pipe", "pipe"] });
+  op.stderr.on("data", (d) => process.stderr.write(`[operator stderr] ${d}`));
+
+  sendJsonRpc(op, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  const initResp = await readResponse(op);
+  assert(initResp.result?.protocolVersion === "2024-11-05", "initialize returns protocol version");
+  assert(initResp.result?.serverInfo?.name === "quadwork-operator", "initialize identifies as quadwork-operator");
+
+  sendJsonRpc(op, { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+  const listResp = await readResponse(op);
+  const toolNames = (listResp.result?.tools || []).map((t) => t.name);
+  assert(toolNames.includes("list_projects"), "tools/list includes list_projects");
+
+  sendJsonRpc(op, {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "list_projects", arguments: {} },
+  });
+  const callResp = await readResponse(op);
+  assert(callResp.result?.content?.[0]?.type === "text", "list_projects returns text content");
+  const projects = JSON.parse(callResp.result.content[0].text);
+  assert(Array.isArray(projects) && projects.length === 2, "list_projects returns both projects");
+  assert(projects[0].id === "plotlink" && projects[0].repo === "realproject7/plotlink", "list_projects id/repo correct");
+  const keys = Object.keys(projects[0]).sort().join(",");
+  assert(keys === "id,name,repo", `list_projects returns only id/name/repo (got ${keys})`);
+  assert(!("agents" in projects[0]) && !("extraField" in projects[0]), "list_projects strips agents + extra fields");
+  assert(requests.some((r) => r.startsWith("GET /api/config")), "list_projects proxied GET /api/config");
+
+  // ── 2. unknown tool → JSON-RPC error, loop survives ─────────────────────
+  sendJsonRpc(op, {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: { name: "does_not_exist", arguments: {} },
+  });
+  const errResp = await readResponse(op);
+  assert(errResp.error != null, "unknown tool returns a JSON-RPC error");
+  // Loop must still be alive after the error:
+  sendJsonRpc(op, { jsonrpc: "2.0", id: 5, method: "ping" });
+  const pingResp = await readResponse(op);
+  assert(pingResp.id === 5 && pingResp.result != null, "stdio loop survives a failed call (ping after error)");
+
+  op.stdin.end();
+  await new Promise((r) => op.on("close", r));
+  cfgServer.close();
+
+  // ── 3. httpRequest: ECONNREFUSED ────────────────────────────────────────
+  // Open then immediately close a server to get a definitely-closed port.
+  const { server: deadServer, port: deadPort } = await startBlackholeServer();
+  await new Promise((r) => deadServer.close(r));
+  const refusedCtx = createContext(deadPort);
+  const refusedErr = await expectThrows(() => refusedCtx.httpRequest("GET", "/api/config"));
+  assert(
+    refusedErr && refusedErr.message === `QuadWork is not running on port ${deadPort}. Start it first.`,
+    "httpRequest maps ECONNREFUSED to a clean error"
+  );
+
+  // ── 4. httpRequest: timeout ─────────────────────────────────────────────
+  const { server: blackhole, port: bhPort } = await startBlackholeServer();
+  const timeoutCtx = createContext(bhPort, { timeoutMs: 200 });
+  const timeoutErr = await expectThrows(() => timeoutCtx.httpRequest("GET", "/api/config"));
+  assert(
+    timeoutErr && timeoutErr.message === `QuadWork did not respond within 5s (port ${bhPort}).`,
+    "httpRequest maps a timeout to a clean error"
+  );
+  blackhole.close();
+
+  // ── 5. assertKnownProject / assertKnownAgent ────────────────────────────
+  const { server: cfg2, port: cfg2Port, requests: req2 } = await startConfigServer();
+  const ctx = createContext(cfg2Port);
+
+  // known project passes
+  let okErr = await expectThrows(() => ctx.assertKnownProject("plotlink"));
+  assert(okErr === null, "assertKnownProject passes a known id");
+
+  // unknown project throws, and only /api/config was hit (no tool HTTP call)
+  req2.length = 0;
+  const badProjErr = await expectThrows(() => ctx.assertKnownProject("nope"));
+  assert(
+    badProjErr && badProjErr.message === "Unknown project: nope. Use list_projects to see valid ids.",
+    "assertKnownProject throws the clean error for an unknown id"
+  );
+  assert(
+    req2.every((r) => r.startsWith("GET /api/config")),
+    "assertKnownProject makes no tool HTTP call beyond /api/config"
+  );
+
+  // known agent passes
+  okErr = await expectThrows(() => ctx.assertKnownAgent("plotlink", "dev"));
+  assert(okErr === null, "assertKnownAgent passes a known (project, agent)");
+
+  // unknown agent throws
+  const badAgentErr = await expectThrows(() => ctx.assertKnownAgent("plotlink", "ghost"));
+  assert(
+    badAgentErr && badAgentErr.message === "Unknown agent: ghost in plotlink.",
+    "assertKnownAgent throws the clean error for an unknown agent"
+  );
+
+  cfg2.close();
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/mcp-operator/context.js
+++ b/server/mcp-operator/context.js
@@ -1,0 +1,119 @@
+"use strict";
+
+// #790: shared per-tool context for the MCP operator server. Every tool
+// handler receives the object returned by `createContext(port)` as its second
+// argument. Centralizing `httpRequest` + the project/agent validators here
+// (rather than inlining them in mcp-operator.js) keeps them unit-testable and
+// gives the conflict-free tool modules (#791–#795) a single import surface.
+
+const http = require("http");
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * Build the context handed to every tool handler.
+ * @param {string|number} port  QuadWork backend port (base is 127.0.0.1).
+ * @param {{timeoutMs?: number}} [opts]  timeoutMs overrides the 5s request
+ *   abort — used by tests to fire the timeout path fast. The user-facing
+ *   timeout message is fixed at "within 5s" regardless (#790 contract).
+ */
+function createContext(port, opts = {}) {
+  const PORT = String(port);
+  const BASE = `http://127.0.0.1:${PORT}`;
+  const timeoutMs = opts.timeoutMs != null ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  // Request hardening (moved here from #796 — every tool depends on it).
+  // Attaches a 5s abort, and maps ECONNREFUSED / timeout / non-2xx into clean
+  // tool errors. No raw "API error ..." dumps leak to the operator.
+  function httpRequest(method, urlPath, body) {
+    return new Promise((resolve, reject) => {
+      const url = new URL(urlPath, BASE);
+      const reqOpts = {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method,
+        headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(timeoutMs),
+      };
+      const req = http.request(reqOpts, (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => {
+          const status = res.statusCode;
+          let parsed;
+          try {
+            parsed = data ? JSON.parse(data) : undefined;
+          } catch {
+            parsed = undefined;
+          }
+          if (status >= 200 && status < 300) {
+            resolve(parsed === undefined ? data : parsed);
+            return;
+          }
+          if (parsed && typeof parsed.error === "string") {
+            reject(new Error(parsed.error));
+          } else {
+            reject(new Error(`${method} ${url.pathname} failed: HTTP ${status}`));
+          }
+        });
+      });
+      req.on("error", (err) => {
+        // AbortSignal.timeout fires a TimeoutError (code ABORT_ERR).
+        if (err.code === "ABORT_ERR" || err.name === "AbortError" || err.name === "TimeoutError") {
+          reject(new Error(`QuadWork did not respond within 5s (port ${PORT}).`));
+        } else if (err.code === "ECONNREFUSED") {
+          reject(new Error(`QuadWork is not running on port ${PORT}. Start it first.`));
+        } else {
+          reject(err);
+        }
+      });
+      if (body !== undefined) req.write(JSON.stringify(body));
+      req.end();
+    });
+  }
+
+  // Internal: authoritative project list for validation. Returns the agent id
+  // list only (head/dev/re1/re2) — never the per-agent model/token/reasoning
+  // fields. This is the source for both assertKnownProject and the public
+  // list_projects (which strips `agents` again before returning).
+  async function getConfiguredProjects() {
+    const cfg = await httpRequest("GET", "/api/config");
+    const projects = Array.isArray(cfg && cfg.projects) ? cfg.projects : [];
+    return projects.map((p) => ({
+      id: p.id,
+      name: p.name,
+      repo: p.repo,
+      agents: p.agents ? Object.keys(p.agents) : [],
+    }));
+  }
+
+  // Every project-scoped tool (#791–#795) MUST call this before its HTTP call —
+  // read OR write — except list_agents, which validates only when `project` is
+  // supplied. Backend trigger/chat/queue endpoints accept unknown ids and
+  // strand state (live timers, stray ~/.quadwork/<id>/ files), so the guard
+  // lives client-side here.
+  async function assertKnownProject(id) {
+    const projects = await getConfiguredProjects();
+    if (!projects.some((p) => p.id === id)) {
+      throw new Error(`Unknown project: ${id}. Use list_projects to see valid ids.`);
+    }
+  }
+
+  // Used by agent_control (#795) so an unknown agent is rejected with NO HTTP
+  // control call — backend stop accepts any :agent string and returns ok:true.
+  async function assertKnownAgent(project, agent) {
+    const projects = await getConfiguredProjects();
+    const p = projects.find((x) => x.id === project);
+    if (!p) {
+      throw new Error(`Unknown project: ${project}. Use list_projects to see valid ids.`);
+    }
+    if (!p.agents.includes(agent)) {
+      throw new Error(`Unknown agent: ${agent} in ${project}.`);
+    }
+  }
+
+  return { port: PORT, base: BASE, httpRequest, getConfiguredProjects, assertKnownProject, assertKnownAgent };
+}
+
+module.exports = { createContext, DEFAULT_TIMEOUT_MS };

--- a/server/mcp-operator/tools/projects.js
+++ b/server/mcp-operator/tools/projects.js
@@ -1,0 +1,30 @@
+"use strict";
+
+// #790: tools/projects.js — the FIRST conflict-free tool module. Each module
+// under tools/ exports { defs, handlers } and is auto-merged by the loader in
+// mcp-operator.js. Later tickets (#791–#795) add a NEW file here; they never
+// edit a shared array/switch, which is what makes the parallel batch
+// genuinely conflict-free.
+
+module.exports = {
+  defs: [
+    {
+      name: "list_projects",
+      description:
+        "List the QuadWork projects configured on this machine. Returns id, name and repo for each project. Use the returned ids with the other operator tools.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+    },
+  ],
+  handlers: {
+    // Public output is only { id, name, repo } — the internal `agents` id list
+    // is a validation aid (assertKnownProject/assertKnownAgent), not
+    // operator-facing, so strip it here.
+    list_projects: async (_params, ctx) => {
+      const projects = await ctx.getConfiguredProjects();
+      return projects.map((p) => ({ id: p.id, name: p.name, repo: p.repo }));
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Foundation ticket for the MCP operator server (parent epic #789, Tier 1). Ships the stdio scaffold every later tool builds on, plus the three cross-cutting concerns those tickets depend on, with **one** working tool (`list_projects`) proving the connection end-to-end.

## What's in this PR
- **`server/mcp-operator.js`** — stdio JSON-RPC server (`initialize` / `tools/list` / `tools/call` / `ping`). Transport framing mirrors `server/mcp-chat-shim.js`. Operator-scoped: `--port` only; `project` is a per-tool arg. Every `tools/call` is wrapped so a thrown/rejected handler returns a JSON-RPC error — the loop never crashes. Has `#!/usr/bin/env node` + executable bit.
- **Conflict-free tool structure** — `server/mcp-operator/tools/*.js` each export `{ defs, handlers }`; `loadTools()` merges them. **Later tickets (#791–#795) add a NEW file under `tools/` — they never edit a shared array/switch.** That's what makes the parallel batch genuinely conflict-free.
- **Request hardening** (moved here from #796) — `httpRequest` attaches `AbortSignal.timeout(5000)` and maps:
  - `ECONNREFUSED` → `"QuadWork is not running on port <port>. Start it first."`
  - timeout → `"QuadWork did not respond within 5s (port <port>)."`
  - non-2xx `{error}` → that error text; non-2xx without JSON → `"<method> <path> failed: HTTP <status>"`.
- **Shared validation** — internal `getConfiguredProjects()` → `GET /api/config`, returns `{ id, name, repo, agents }` where `agents` is the **id list only** (`Object.keys`) — no model/token/reasoning fields. `assertKnownProject(id)` and `assertKnownAgent(project, agent)` throw clean tool errors. Contract for #791–#795: **every project-scoped tool calls `assertKnownProject` before its HTTP call (read OR write)**, except `list_agents` (validates only when `project` is supplied).
- **`list_projects`** — public output stripped to `{ id, name, repo }` (the `agents` id list is an internal validation aid, not operator-facing).
- **`package.json`** — adds `"quadwork-mcp-operator": "./server/mcp-operator.js"` bin. Shipped via the existing `server/` whitelist.

## Registration
```
claude mcp add quadwork -- quadwork-mcp-operator --port 8400
```

## Verification
- `server/mcp-operator.test.js`: **18/18 pass** — list_projects over stdio proxies `GET /api/config` and returns id/name/repo only (agents + extra fields stripped); unknown tool returns a JSON-RPC error and the loop survives (ping after); `httpRequest` ECONNREFUSED + timeout mapped errors; `assertKnownProject`/`assertKnownAgent` pass known / throw clean on unknown with no further HTTP call.
- `npm test` → **30 passed, 0 failed, 2 skipped** (whole suite green).
- `npm run build` → green.
- `npm pack --dry-run` → includes `server/mcp-operator.js`, `server/mcp-operator/context.js`, `server/mcp-operator/tools/projects.js`; excludes `mcp-operator.test.js`.
- End-to-end: spawned the bin via its shebang (`./server/mcp-operator.js --port <p>`) against a fake `/api/config` — `initialize` → `tools/list` → `list_projects` all return correctly.

## Notes
- QuadWork's own process is unchanged (additive bin only). Server is launched by the MCP client, not spawned by QuadWork.
- No auth headers — localhost trust boundary, same as the agent shim.

Closes #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)