### PR TITLE
[#866] GitHub rate-limit status badge (core/graphql/search) in GITHUB header

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -59,6 +59,14 @@ const _graphqlRateLimit = {
   resetAt: 0,        // epoch ms
   updatedAt: 0,      // epoch ms when we last fetched
 };
+// #866: search is a separate, much smaller bucket (30/min). Tracked only for
+// the always-on header badge — no server-side gh call gates on it.
+const _searchRateLimit = {
+  limit: 30,
+  remaining: 30,
+  resetAt: 0,        // epoch ms
+  updatedAt: 0,      // epoch ms when we last fetched
+};
 const RATE_LIMIT_POLL_MS = 60_000;       // refresh every 60s
 const RATE_LIMIT_LOW_THRESHOLD = 200;    // below this → back off
 const RATE_LIMIT_CRITICAL = 50;          // below this → stop all infra gh calls
@@ -66,11 +74,13 @@ let _rateLimitTimer = null;
 
 async function refreshRateLimit() {
   try {
-    // One `gh api rate_limit` call returns every resource bucket; grab both
-    // core (REST) and graphql so each stream can gate on its own budget (#802).
+    // One `gh api rate_limit` call returns every resource bucket; grab core
+    // (REST), graphql and search. core/graphql each gate their own stream
+    // (#802); search is display-only for the header badge (#866). The
+    // rate_limit endpoint is itself exempt — zero budget cost.
     const { stdout } = await _execFileAsync("gh", [
       "api", "rate_limit", "--jq",
-      "{core: (.resources.core | {limit,remaining,reset}), graphql: (.resources.graphql | {limit,remaining,reset})}",
+      "{core: (.resources.core | {limit,remaining,reset}), graphql: (.resources.graphql | {limit,remaining,reset}), search: (.resources.search | {limit,remaining,reset})}",
     ], { encoding: "utf-8", timeout: 10000 });
     const data = JSON.parse(stdout);
     _rateLimit.limit = data.core.limit;
@@ -83,6 +93,12 @@ async function refreshRateLimit() {
       _graphqlRateLimit.remaining = data.graphql.remaining;
       _graphqlRateLimit.resetAt = data.graphql.reset * 1000;
       _graphqlRateLimit.updatedAt = Date.now();
+    }
+    if (data.search) {
+      _searchRateLimit.limit = data.search.limit;
+      _searchRateLimit.remaining = data.search.remaining;
+      _searchRateLimit.resetAt = data.search.reset * 1000;
+      _searchRateLimit.updatedAt = Date.now();
     }
   } catch (err) {
     _rateLimit.error = err.message;
@@ -932,11 +948,23 @@ router.get("/api/projects", async (req, res) => {
 
 // ─── GitHub Rate Limit (#554) ──────────────────────────────────────────────
 
+// #866: expose each bucket as { limit, remaining, resetInMinutes, resetAt }
+// so the header badge can color core / graphql / search independently.
+function bucketView(b) {
+  return {
+    limit: b.limit,
+    remaining: b.remaining,
+    resetAt: b.resetAt,
+    resetInMinutes: b.resetAt > Date.now() ? Math.ceil((b.resetAt - Date.now()) / 60000) : 0,
+  };
+}
+
 router.get("/api/github/rate-limit", (_req, res) => {
   const resetIn = _rateLimit.resetAt > Date.now()
     ? Math.ceil((_rateLimit.resetAt - Date.now()) / 60000)
     : 0;
   res.json({
+    // Top-level fields are core (REST), kept for the existing alert banner.
     limit: _rateLimit.limit,
     remaining: _rateLimit.remaining,
     resetAt: _rateLimit.resetAt,
@@ -945,6 +973,10 @@ router.get("/api/github/rate-limit", (_req, res) => {
     critical: isRateLimited(),
     updatedAt: _rateLimit.updatedAt,
     error: _rateLimit.error,
+    // #866: per-bucket detail for the always-on header badge.
+    core: bucketView(_rateLimit),
+    graphql: bucketView(_graphqlRateLimit),
+    search: bucketView(_searchRateLimit),
   });
 });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,7 @@
   --accent-dim: #00cc6a;
   --border: #2a2a2a;
   --error: #ff4444;
+  --warning: #ffaa00; /* #866: amber for rate-limit "warning" state */
 }
 
 @theme inline {
@@ -20,6 +21,7 @@
   --color-accent-dim: var(--accent-dim);
   --color-border: var(--border);
   --color-error: var(--error);
+  --color-warning: var(--warning);
   --font-mono: var(--font-geist-mono);
 }
 

--- a/src/components/GitHubRateLimitBadge.tsx
+++ b/src/components/GitHubRateLimitBadge.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// #866: always-on GitHub rate-limit badge for the GITHUB panel header.
+// Self-contained: fetches /api/github/rate-limit on the same 60s cadence as
+// GitHubPanel and renders all three buckets (core / graphql / search) inline,
+// each colored independently by its OWN remaining %. Reuses the existing
+// exempt `gh api rate_limit` poll (#554/#802) — no new billable API calls.
+
+interface Bucket {
+  limit: number;
+  remaining: number;
+  resetInMinutes: number;
+}
+
+interface RateLimitResponse {
+  core?: Bucket;
+  graphql?: Bucket;
+  search?: Bucket;
+}
+
+const BUCKETS: { key: keyof RateLimitResponse; label: string }[] = [
+  { key: "core", label: "core" },
+  { key: "graphql", label: "gql" },
+  { key: "search", label: "search" },
+];
+
+// Per-bucket color by its own remaining %: green ≥50% healthy, red ≤5% (or 0)
+// gone, orange in between (warning). search is a small bucket (30/min) so its
+// % swings fast — that's expected.
+function bucketColor(b: Bucket): string {
+  if (!b.limit) return "text-text-muted";
+  const pct = b.remaining / b.limit;
+  if (b.remaining === 0 || pct <= 0.05) return "text-error";
+  if (pct >= 0.5) return "text-accent";
+  return "text-warning";
+}
+
+export default function GitHubRateLimitBadge() {
+  const [data, setData] = useState<RateLimitResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      fetch("/api/github/rate-limit")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (!cancelled && d) setData(d);
+        })
+        .catch(() => {});
+    };
+    load();
+    const id = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  // Degrade gracefully: render nothing until we have data, and skip any bucket
+  // the endpoint didn't return rather than crashing.
+  const visible = data
+    ? BUCKETS.filter(({ key }) => {
+        const b = data[key];
+        return b && typeof b.remaining === "number" && typeof b.limit === "number";
+      })
+    : [];
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-[10px] font-mono text-text-muted">
+      {visible.map(({ key, label }) => {
+        const b = data![key]!;
+        return (
+          <span
+            key={key}
+            className="flex items-center gap-1 whitespace-nowrap"
+            title={`${label}: ${b.remaining}/${b.limit} remaining · resets in ${b.resetInMinutes}m`}
+          >
+            <span className={bucketColor(b)} aria-hidden>
+              ●
+            </span>
+            <span>{label}</span>
+            <span>
+              {b.remaining}/{b.limit}
+            </span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -5,6 +5,7 @@ import PanelHeader from "./PanelHeader";
 import InfoTooltip from "./InfoTooltip";
 import ChatPanel from "./ChatPanel";
 import GitHubPanel from "./GitHubPanel";
+import GitHubRateLimitBadge from "./GitHubRateLimitBadge";
 import ControlBar from "./ControlBar";
 import AgentTerminalsGrid from "./AgentTerminalsGrid";
 import OperatorFeaturesPanel from "./OperatorFeaturesPanel";
@@ -319,7 +320,10 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
             <InfoTooltip>
               {t.githubTooltip}
             </InfoTooltip>
-          } />
+          }>
+            {/* #866: always-on rate-limit status badge, top-right of the GITHUB header */}
+            <GitHubRateLimitBadge />
+          </PanelHeader>
           <div className="flex-1 min-h-0">
             <GitHubPanel projectId={projectId} idle={idle} />
           </div>


### PR DESCRIPTION
## Summary
Adds an always-on GitHub rate-limit status badge to the **GITHUB panel header (top-right)** showing **all three buckets — core / graphql / search** — each colored independently 🟢→🟠→🔴 by its own remaining budget, so the operator sees the full picture at a glance instead of only learning via the alert banner once it's already low. Mostly a display addition on top of the existing #554/#802 plumbing.

## Backend (`server/routes.js`, ~12 lines)
- Extended the existing **exempt** `gh api rate_limit` jq to also grab `search` alongside core/graphql; stashed in a new `_searchRateLimit` (display-only — no server-side gh call gates on it).
- `/api/github/rate-limit` now exposes per-bucket `core` / `graphql` / `search` objects (`{ limit, remaining, resetInMinutes, resetAt }`) via a small `bucketView()` helper. The existing top-level core fields (`limit/remaining/low/critical`) are **kept for backward-compat** with the current alert banner.
- **No new billable API calls** — `rate_limit` is exempt and already polled every 60s.

## Frontend
- New self-contained **`src/components/GitHubRateLimitBadge.tsx`** — fetches `/api/github/rate-limit` on the same 60s cadence and renders all three buckets inline (`core` / `gql` / `search`), each with a per-bucket color dot + `remaining/limit`, and reset-in minutes on hover (`title`). Example:
  ```
  ● core 4982/5000   ● gql 2100/5000   ● search 1/30
  ```
- **Color per bucket, on its own remaining %:** 🟢 green ≥50% · 🟠 orange <50% · 🔴 red ≤5% or 0. (`search` is a 30/min bucket so its % swings fast — expected.)
- **Graceful degradation:** renders nothing until data arrives, and skips any bucket the endpoint didn't return — no crash when the endpoint errors or a bucket is missing.
- Mounted in the GITHUB `PanelHeader` children slot (top-right) in `ProjectDashboard.tsx` (1-line wiring + import).
- `globals.css`: added a `--warning` (#ffaa00) amber token + `--color-warning` mapping for the warning state (dark/monospace/sharp, no glow — matches design tokens).

## Left as-is
- The existing low/critical alert banner in `GitHubPanel.tsx` stays (it's the loud warning; the badge is the always-on at-a-glance status).

## Verification
- `npm run build` → green (on latest main, rebased clean).
- `GitHubRateLimitBadge.tsx` lints clean (the 2 pre-existing `set-state-in-effect` warnings in `ProjectDashboard.tsx:148` are untouched legacy code).
- `/api/github/rate-limit` verified end-to-end (router mounted in a minimal app): returns `core {5000/5000}`, `graphql {5000/5000}`, `search {30/30}` plus the backward-compat top-level fields.
- Note: a live full-dashboard screenshot was omitted — the dev backend binds port 8400, which the running QuadWork instance (hosting the agent chat) already occupies; standing up a competing server would disrupt it. The badge is small and self-contained; color hexes map directly to the design tokens.

Closes #866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)