### PR TITLE
[#791] Operator MCP: Tier 1 read tools (read_chat, batch_status, read_queue, list_agents)

### DIFF
--- a/server/mcp-operator/tools/read.js
+++ b/server/mcp-operator/tools/read.js
@@ -1,0 +1,126 @@
+"use strict";
+
+// #791: Tier 1 read-only observation tools. A NEW file under tools/ — additive,
+// no edits to existing tool modules (the conflict-free structure from #790).
+//
+// Reads are NOT side-effect-free on unknown projects: GET /api/chat →
+// readMessages CREATES ~/.quadwork/<project>/chat/general.jsonl if missing, so
+// a bogus id strands state. Every project-scoped tool here calls
+// assertKnownProject(project) BEFORE its HTTP call. list_agents validates only
+// when `project` is supplied. (httpRequest's timeout/ECONNREFUSED/non-2xx
+// mapping comes for free from #790.)
+
+module.exports = {
+  defs: [
+    {
+      name: "read_chat",
+      description:
+        "Read recent messages from a project's team chat. Returns the message array (id, sender, text, ts as raw ISO, type, channel). Honors since_id / limit for paging.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+          since_id: { type: "number", description: "Only return messages with id greater than this." },
+          limit: { type: "number", description: "Max messages to return (default 50)." },
+        },
+        required: ["project"],
+      },
+    },
+    {
+      name: "batch_status",
+      description:
+        "Get a project's overnight-batch status as { active, progress }, merged from /api/batch-active and /api/batch-progress. CAVEAT (#864): `active:true` can persist after Head clears the queue (preserved-snapshot / duplicate-PR edge); do NOT treat active:true as authoritative for 'work remaining' until #864 lands.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+        },
+        required: ["project"],
+      },
+    },
+    {
+      name: "read_queue",
+      description:
+        "Read a project's OVERNIGHT-QUEUE.md. Returns { exists, content } where content is the raw markdown (empty string when the file does not exist).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+        },
+        required: ["project"],
+      },
+    },
+    {
+      name: "list_agents",
+      description:
+        "List agents and their state. Returns EVERY configured agent (config ∪ runtime) as { project, agent, state, error } — state is running/stopped/missing, so stopped or untracked agents are included, not just live sessions. Omit `project` to list all projects, or pass one to filter.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Optional project id to filter by (validated when supplied)." },
+        },
+      },
+    },
+  ],
+
+  handlers: {
+    read_chat: async (params, ctx) => {
+      const { project, since_id, limit } = params;
+      await ctx.assertKnownProject(project);
+      const qs = new URLSearchParams({ project });
+      if (since_id != null) qs.set("since_id", String(since_id));
+      if (limit != null) qs.set("limit", String(limit));
+      return ctx.httpRequest("GET", `/api/chat?${qs.toString()}`);
+    },
+
+    batch_status: async (params, ctx) => {
+      const { project } = params;
+      await ctx.assertKnownProject(project);
+      const p = encodeURIComponent(project);
+      const [active, progress] = await Promise.all([
+        ctx.httpRequest("GET", `/api/batch-active?project=${p}`),
+        ctx.httpRequest("GET", `/api/batch-progress?project=${p}`),
+      ]);
+      return { active, progress };
+    },
+
+    read_queue: async (params, ctx) => {
+      const { project } = params;
+      await ctx.assertKnownProject(project);
+      const res = await ctx.httpRequest("GET", `/api/queue?project=${encodeURIComponent(project)}`);
+      return { exists: !!(res && res.exists), content: (res && res.content) || "" };
+    },
+
+    // Merge configured ∪ runtime — /api/agents alone returns only live
+    // agentSessions and misses configured-but-stopped agents. Mirrors the
+    // config-first pattern in the reset route (server/index.js).
+    list_agents: async (params, ctx) => {
+      const { project } = params;
+      if (project) await ctx.assertKnownProject(project);
+      const configured = await ctx.getConfiguredProjects();
+      const runtime = await ctx.httpRequest("GET", "/api/agents");
+      const rt = runtime && typeof runtime === "object" ? runtime : {};
+      const projects = project ? configured.filter((p) => p.id === project) : configured;
+
+      const result = [];
+      for (const p of projects) {
+        const ids = new Set(p.agents);
+        // Include any live session id under this project not in config (defensive).
+        for (const key of Object.keys(rt)) {
+          const slash = key.indexOf("/");
+          if (slash > 0 && key.slice(0, slash) === p.id) ids.add(key.slice(slash + 1));
+        }
+        for (const agent of ids) {
+          const session = rt[`${p.id}/${agent}`];
+          result.push({
+            project: p.id,
+            agent,
+            state: session ? session.state : "missing",
+            error: session ? session.error || null : null,
+          });
+        }
+      }
+      return result;
+    },
+  },
+};

--- a/server/mcp-operator/tools/read.test.js
+++ b/server/mcp-operator/tools/read.test.js
@@ -1,0 +1,149 @@
+"use strict";
+
+// #791: tests for the Tier 1 read tools. Drives the handlers directly via a
+// #790 context pointed at a fake QuadWork backend that records every request
+// path — so we can prove unknown-project reads make NO downstream HTTP call
+// (no orphan ~/.quadwork/<id>/ state), and that list_agents merges
+// config ∪ runtime. (Transport/stdio is already covered by mcp-operator.test.js.)
+
+const http = require("http");
+const { createContext } = require("../context");
+const read = require("./read");
+
+const handlers = read.handlers;
+
+const FAKE_CONFIG = {
+  projects: [
+    {
+      id: "plotlink",
+      name: "PlotLink",
+      repo: "realproject7/plotlink",
+      agents: { head: {}, dev: {}, re1: {}, re2: {} },
+    },
+    {
+      id: "quadwork",
+      name: "QuadWork",
+      repo: "realproject7/quadwork",
+      agents: { head: {}, dev: {}, re1: {}, re2: {} },
+    },
+  ],
+};
+
+const CHAT_MESSAGES = [
+  { id: 1, sender: "head", text: "go", ts: "2026-05-30T00:00:00.000Z", type: "message", channel: "general" },
+  { id: 2, sender: "dev", text: "ok", ts: "2026-05-30T00:01:00.000Z", type: "message", channel: "general" },
+];
+
+// /api/agents returns ONLY live sessions: head running, dev stopped. re1/re2
+// are configured but absent → must surface as "missing".
+const RUNTIME_AGENTS = {
+  "plotlink/head": { state: "running", error: null },
+  "plotlink/dev": { state: "stopped", error: null },
+};
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log(`  PASS: ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+function startServer() {
+  const requests = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      const send = (obj, status = 200) => {
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(obj));
+      };
+      const url = req.url;
+      if (url.startsWith("/api/config")) return send(FAKE_CONFIG);
+      if (url.startsWith("/api/chat")) return send(CHAT_MESSAGES);
+      if (url.startsWith("/api/batch-active")) return send({ active: true });
+      if (url.startsWith("/api/batch-progress")) return send({ total: 3, done: 1, items: [{ issue: 791, state: "open" }] });
+      if (url.startsWith("/api/queue")) return send({ ok: true, exists: true, content: "## Active Batch\n- #791\n" });
+      if (url.startsWith("/api/agents")) return send(RUNTIME_AGENTS);
+      return send({ error: "not found" }, 404);
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests }));
+  });
+}
+
+async function expectThrows(fn) {
+  try {
+    await fn();
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function runTests() {
+  console.log("\n--- MCP Operator Tier 1 Read Tools Tests (#791) ---\n");
+
+  const { server, port, requests } = await startServer();
+  const ctx = createContext(port);
+
+  // ── read_chat: known project, paging ────────────────────────────────────
+  requests.length = 0;
+  const chat = await handlers.read_chat({ project: "plotlink", since_id: 1, limit: 25 }, ctx);
+  assert(Array.isArray(chat) && chat.length === 2, "read_chat returns the message array");
+  assert(chat[0].sender === "head" && chat[0].ts === "2026-05-30T00:00:00.000Z", "read_chat passes ts through raw (ISO)");
+  const chatReq = requests.find((r) => r.includes("/api/chat"));
+  assert(chatReq && chatReq.includes("since_id=1") && chatReq.includes("limit=25"), "read_chat honors since_id + limit");
+
+  // ── read_chat: unknown project → throws, NO /api/chat request ────────────
+  requests.length = 0;
+  const badChatErr = await expectThrows(() => handlers.read_chat({ project: "ghost" }, ctx));
+  assert(
+    badChatErr && badChatErr.message === "Unknown project: ghost. Use list_projects to see valid ids.",
+    "read_chat on unknown project throws the clean error"
+  );
+  assert(!requests.some((r) => r.includes("/api/chat")), "read_chat unknown project makes NO /api/chat request (no orphan file)");
+
+  // ── batch_status: merge active + progress ───────────────────────────────
+  const batch = await handlers.batch_status({ project: "plotlink" }, ctx);
+  assert(batch && batch.active && batch.active.active === true, "batch_status includes active");
+  assert(batch && batch.progress && batch.progress.total === 3, "batch_status includes progress (merged)");
+
+  // ── read_queue: returns markdown ────────────────────────────────────────
+  const queue = await handlers.read_queue({ project: "plotlink" }, ctx);
+  assert(queue.exists === true && queue.content.includes("## Active Batch"), "read_queue returns { exists, content }");
+
+  // ── list_agents: no project → all projects, no validation throw ─────────
+  const allAgents = await handlers.list_agents({}, ctx);
+  assert(Array.isArray(allAgents) && allAgents.length === 8, "list_agents (no project) returns all configured agents across projects");
+
+  // ── list_agents: bogus project → validation error, NO /api/agents call ──
+  requests.length = 0;
+  const badAgentErr = await expectThrows(() => handlers.list_agents({ project: "ghost" }, ctx));
+  assert(
+    badAgentErr && badAgentErr.message === "Unknown project: ghost. Use list_projects to see valid ids.",
+    "list_agents with bogus project throws the validation error"
+  );
+  assert(!requests.some((r) => r.includes("/api/agents")), "list_agents bogus project makes NO /api/agents call");
+
+  // ── list_agents: config ∪ runtime merge + per-agent state ───────────────
+  const plAgents = await handlers.list_agents({ project: "plotlink" }, ctx);
+  const byAgent = Object.fromEntries(plAgents.map((a) => [a.agent, a.state]));
+  assert(plAgents.length === 4, "list_agents (filtered) returns all 4 configured agents");
+  assert(byAgent.head === "running", "list_agents shows runtime state for a live agent (head=running)");
+  assert(byAgent.dev === "stopped", "list_agents shows runtime state for a stopped agent (dev=stopped)");
+  assert(byAgent.re1 === "missing" && byAgent.re2 === "missing", "list_agents includes configured-but-untracked agents as 'missing'");
+  assert(plAgents.every((a) => a.project === "plotlink"), "list_agents filters to the requested project");
+
+  server.close();
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds the read-only observation tools so the operator agent can see what the team is doing without changing any agent state. Parent epic #789, Tier 1. Builds on the #790 scaffold.

All four tools live in **one new file — `server/mcp-operator/tools/read.js`** — auto-merged by #790's loader. **Zero edits to existing tool files or `mcp-operator.js`** (the conflict-free structure working as designed).

## Validate-first (reads aren't side-effect-free)
`GET /api/chat` → `readMessages` **creates** `~/.quadwork/<project>/chat/general.jsonl` if missing, so a bogus id strands state. Per the epic rule, every project-scoped tool calls **`assertKnownProject(project)` before any HTTP call** — `read_chat`, `batch_status`, `read_queue`. `list_agents` validates only when `project` is supplied.

## Tools
- **`read_chat`** `{ project, since_id?, limit? }` → `GET /api/chat` (honors `since_id`/`limit`); returns the raw message array with ISO `ts`.
- **`batch_status`** `{ project }` → merges `GET /api/batch-active` + `GET /api/batch-progress` into `{ active, progress }`. **Tool description documents the #864 caveat:** `active:true` can persist after Head clears the queue — don't treat it as authoritative for "work remaining" until #864 lands.
- **`read_queue`** `{ project }` → `GET /api/queue` → `{ exists, content }` (raw OVERNIGHT-QUEUE.md markdown).
- **`list_agents`** `{ project? }` → **merges config ∪ runtime**, returning **every configured agent** (`/api/config` keys) with its state from `/api/agents` as `{ project, agent, state, error }`. `/api/agents` alone only returns live `agentSessions`, so configured-but-stopped/untracked agents would be missed — they surface here as `missing`. Mirrors the reset route's config-first pattern.

## Verification
- **`server/mcp-operator/tools/read.test.js` — 16/16 pass.** Fake backend records every request path:
  - per-tool path + returned shape (read_chat paging, batch merge, queue markdown);
  - unknown-project `read_chat` → clean error AND **no `/api/chat` request** (proves no orphan file);
  - `list_agents` no-project lists all 8 across projects; bogus-project errors **before any `/api/agents` call**; the config∪runtime merge surfaces `re1`/`re2` as `missing` while `head=running` / `dev=stopped` reflect runtime.
- `npm test` → **31 passed, 0 failed, 2 skipped**.
- `npm run build` → green.
- `tools/list` over stdio now registers `list_projects, read_chat, batch_status, read_queue, list_agents` with no edit to `mcp-operator.js`.
- `npm pack --dry-run` ships `read.js`, excludes `read.test.js`.

## Dependencies
- Requires #790 (merged) — scaffold, `httpRequest`, `assertKnownProject`, loader.
- `batch_status` depends on #864 for trustworthy `active` reads; shipped with the documented caveat until #864 lands.

Closes #791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)