### PR TITLE
[#793] Operator MCP: batch management (set_batch, append_batch, ensure_batch)

### DIFF
--- a/server/mcp-operator/tools/batch.js
+++ b/server/mcp-operator/tools/batch.js
@@ -1,0 +1,91 @@
+"use strict";
+
+// #793: batch-definition tools (Tier 2 — act). Create/replace and append to a
+// project's OVERNIGHT-QUEUE.md (the batch the scheduled trigger feeds agents).
+// New file under tools/ — additive, auto-merged by #790's loader, no edits to
+// existing modules. These WRITE the batch definition; they do NOT start it
+// (that's #794).
+//
+// Queue writes can strand ~/.quadwork/<id>/ state for an unknown id, so every
+// tool calls assertKnownProject(project) before any write.
+
+function requireContent(content) {
+  if (typeof content !== "string" || content === "") {
+    throw new Error("content must be a non-empty string.");
+  }
+}
+
+module.exports = {
+  defs: [
+    {
+      name: "set_batch",
+      description:
+        "Replace a project's OVERNIGHT-QUEUE.md with `content` (full overwrite). This defines the batch but does NOT start it. Rejects empty content. Use append_batch to add to an existing queue instead of replacing it.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+          content: { type: "string", description: "Full markdown content for OVERNIGHT-QUEUE.md." },
+        },
+        required: ["project", "content"],
+      },
+    },
+    {
+      name: "append_batch",
+      description:
+        "Append `content` to the end of a project's OVERNIGHT-QUEUE.md (read-then-write; creates the queue from scratch if absent). Does NOT start the batch. LOST-UPDATE CAVEAT: the read→write is not atomic and is not locked — if you (or the dashboard) edit the queue between this tool's read and write, that edit is overwritten. Re-read the queue (read_queue) before appending if you may have edited it elsewhere.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+          content: { type: "string", description: "Markdown to append after the existing queue content." },
+        },
+        required: ["project", "content"],
+      },
+    },
+    {
+      name: "ensure_batch",
+      description:
+        "Ensure a project's OVERNIGHT-QUEUE.md exists, creating it from the template if absent (idempotent — never overwrites). Returns { ok, existed }. Useful before the first append_batch.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+        },
+        required: ["project"],
+      },
+    },
+  ],
+
+  handlers: {
+    set_batch: async (params, ctx) => {
+      const { project, content } = params;
+      requireContent(content);
+      await ctx.assertKnownProject(project);
+      await ctx.httpRequest("PUT", `/api/queue?project=${encodeURIComponent(project)}`, { content });
+      return { ok: true };
+    },
+
+    append_batch: async (params, ctx) => {
+      const { project, content } = params;
+      requireContent(content);
+      await ctx.assertKnownProject(project);
+      // No server-side append exists (POST only creates-from-template), so do
+      // it MCP-side: read current content, combine, PUT back.
+      const current = await ctx.httpRequest("GET", `/api/queue?project=${encodeURIComponent(project)}`);
+      const existing = current && typeof current.content === "string" ? current.content : "";
+      // Exact combine rule — no stray leading blank line when the queue is empty.
+      const base = existing.trimEnd();
+      const combined = base ? base + "\n" + content : content;
+      await ctx.httpRequest("PUT", `/api/queue?project=${encodeURIComponent(project)}`, { content: combined });
+      return { ok: true };
+    },
+
+    ensure_batch: async (params, ctx) => {
+      const { project } = params;
+      await ctx.assertKnownProject(project);
+      const res = await ctx.httpRequest("POST", `/api/queue?project=${encodeURIComponent(project)}`);
+      return { ok: !!(res && res.ok), existed: !!(res && res.existed) };
+    },
+  },
+};

--- a/server/mcp-operator/tools/batch.test.js
+++ b/server/mcp-operator/tools/batch.test.js
@@ -1,0 +1,173 @@
+"use strict";
+
+// #793: tests for batch-definition tools. Fake backend models /api/queue
+// (GET/PUT/POST) with an in-memory file so we can assert the exact bytes
+// written — including the append combine rule (no leading newline on an empty
+// queue) — and prove unknown projects write nothing.
+
+const http = require("http");
+const { createContext } = require("../context");
+const batch = require("./batch");
+
+const handlers = batch.handlers;
+
+const FAKE_CONFIG = {
+  projects: [{ id: "plotlink", name: "PlotLink", repo: "realproject7/plotlink", agents: { head: {}, dev: {} } }],
+};
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log(`  PASS: ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+// In-memory queue file. `queue.content === null` means the file does not exist.
+function startServer(initial = null) {
+  const requests = [];
+  const queue = { content: initial };
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        let parsed;
+        try {
+          parsed = body ? JSON.parse(body) : undefined;
+        } catch {
+          parsed = undefined;
+        }
+        requests.push({ method: req.method, url: req.url, body: parsed });
+        const send = (obj, status = 200) => {
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(obj));
+        };
+        if (req.method === "GET" && req.url.startsWith("/api/config")) return send(FAKE_CONFIG);
+        if (req.url.startsWith("/api/queue")) {
+          if (req.method === "GET") {
+            return queue.content === null
+              ? send({ ok: true, exists: false, content: "" })
+              : send({ ok: true, exists: true, content: queue.content });
+          }
+          if (req.method === "PUT") {
+            if (typeof (parsed && parsed.content) !== "string") return send({ error: "Missing content" }, 400);
+            queue.content = parsed.content;
+            return send({ ok: true });
+          }
+          if (req.method === "POST") {
+            const existed = queue.content !== null;
+            if (!existed) queue.content = "<<template>>";
+            return send({ ok: true, existed });
+          }
+        }
+        return send({ error: "not found" }, 404);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests, queue }));
+  });
+}
+
+async function expectThrows(fn) {
+  try {
+    await fn();
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function runTests() {
+  console.log("\n--- MCP Operator Batch Management Tests (#793) ---\n");
+
+  // ── set_batch: full replace ─────────────────────────────────────────────
+  {
+    const { server, port, requests, queue } = await startServer("## OLD\n- stale\n");
+    const ctx = createContext(port);
+    const r = await handlers.set_batch({ project: "plotlink", content: "## Batch 11\n- #800\n" }, ctx);
+    assert(r && r.ok === true, "set_batch returns { ok: true }");
+    assert(queue.content === "## Batch 11\n- #800\n", "set_batch fully replaces queue content via PUT");
+    const put = requests.find((x) => x.method === "PUT");
+    assert(put && put.body.content === "## Batch 11\n- #800\n", "set_batch PUT body equals input content");
+    server.close();
+  }
+
+  // ── set_batch: empty/invalid content rejected (no write) ────────────────
+  {
+    const { server, port, requests } = await startServer("## keep\n");
+    const ctx = createContext(port);
+    const emptyErr = await expectThrows(() => handlers.set_batch({ project: "plotlink", content: "" }, ctx));
+    assert(emptyErr && /non-empty string/.test(emptyErr.message), "set_batch rejects empty content");
+    assert(!requests.some((x) => x.method === "PUT"), "set_batch with empty content makes NO PUT");
+    server.close();
+  }
+
+  // ── append_batch: existing content → existing + new ─────────────────────
+  {
+    const { server, port, queue } = await startServer("## Batch 11\n- #800\n"); // note trailing newline
+    const ctx = createContext(port);
+    await handlers.append_batch({ project: "plotlink", content: "- #801\n" }, ctx);
+    assert(
+      queue.content === "## Batch 11\n- #800\n- #801\n",
+      "append_batch appends new content after trimmed existing (single newline join, no blank line)"
+    );
+    server.close();
+  }
+
+  // ── append_batch: no existing file → only the new content (no leading \n) ─
+  {
+    const { server, port, requests, queue } = await startServer(null);
+    const ctx = createContext(port);
+    await handlers.append_batch({ project: "plotlink", content: "## Fresh\n- #802\n" }, ctx);
+    assert(queue.content === "## Fresh\n- #802\n", "append_batch on empty queue PUTs only the new content (no leading newline)");
+    const get = requests.find((x) => x.method === "GET" && x.url.startsWith("/api/queue"));
+    assert(get != null, "append_batch reads the queue before writing (read-then-PUT, not POST-append)");
+    server.close();
+  }
+
+  // ── ensure_batch: creates when absent, idempotent when present ───────────
+  {
+    const { server, port } = await startServer(null);
+    const ctx = createContext(port);
+    const created = await handlers.ensure_batch({ project: "plotlink" }, ctx);
+    assert(created.ok === true && created.existed === false, "ensure_batch creates the queue when absent (existed:false)");
+    const again = await handlers.ensure_batch({ project: "plotlink" }, ctx);
+    assert(again.ok === true && again.existed === true, "ensure_batch is idempotent when present (existed:true)");
+    server.close();
+  }
+
+  // ── unknown project → error, no write (across all three tools) ──────────
+  {
+    const { server, port, requests } = await startServer("## keep\n");
+    const ctx = createContext(port);
+    for (const [name, fn] of [
+      ["set_batch", () => handlers.set_batch({ project: "ghost", content: "x" }, ctx)],
+      ["append_batch", () => handlers.append_batch({ project: "ghost", content: "x" }, ctx)],
+      ["ensure_batch", () => handlers.ensure_batch({ project: "ghost" }, ctx)],
+    ]) {
+      requests.length = 0;
+      const err = await expectThrows(fn);
+      assert(
+        err && err.message === "Unknown project: ghost. Use list_projects to see valid ids.",
+        `${name} on unknown project throws the clean error`
+      );
+      assert(
+        !requests.some((x) => x.method === "PUT" || x.method === "POST"),
+        `${name} on unknown project makes NO write`
+      );
+    }
+    server.close();
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds the batch-definition tools — create/replace and append to a project's `OVERNIGHT-QUEUE.md` (the batch the scheduled trigger feeds to agents). Parent epic #789, Tier 2 (act). Builds on the #790 scaffold.

New file **`server/mcp-operator/tools/batch.js`** — auto-merged by #790's loader, **no edits to existing tool files**. These **write** the batch definition; they do **not** start it (that's #794). Every tool calls `assertKnownProject(project)` before any write (queue writes can strand `~/.quadwork/<id>/` state).

## Tools
- **`set_batch` `{ project, content }`** — rejects empty/non-string `content`, then `PUT /api/queue` (full replace of `OVERNIGHT-QUEUE.md`). Returns `{ ok: true }`.
- **`append_batch` `{ project, content }`** — no server-side append exists (`POST /api/queue` only creates-from-template), so this is **read-then-PUT MCP-side**:
  1. `GET /api/queue` → current content (missing → `""`)
  2. Exact combine rule (no stray leading blank line on an empty queue):
     ```js
     const base = (existing || "").trimEnd();
     const combined = base ? base + "\n" + content : content;
     ```
  3. `PUT /api/queue` with `combined`.
  **Lost-update caveat documented in the tool description:** the GET→PUT isn't atomic or locked; a dashboard edit between read and write is overwritten — re-read with `read_queue` before appending if you may have edited it elsewhere.
- **`ensure_batch` `{ project }`** (the optional one — cheap, so included) — `POST /api/queue`, creates from template if absent (idempotent, never overwrites). Returns `{ ok, existed }`. Useful before the first `append_batch`.

## Verification
- **`batch.test.js` — 16/16 pass** (in-memory queue models GET/PUT/POST):
  - `set_batch` PUT body == input; empty content → error with **no PUT**;
  - `append_batch` existing → `existing + "\n" + new` (single-newline join, no blank line); **empty queue → new-only, no leading newline**; proves it does a **GET before PUT** (read-then-PUT, not POST-append);
  - `ensure_batch` create (`existed:false`) then idempotent (`existed:true`);
  - all three reject an unknown project with the clean error and **make no write**.
- `npm test` → **33 passed, 0 failed, 2 skipped**.
- `npm run build` → green.
- `tools/list` over stdio now registers all 9 operator tools (`append_batch, batch_status, ensure_batch, list_agents, list_projects, read_chat, read_queue, send_message, set_batch`) — no edit to `mcp-operator.js`.

## Dependencies
- Requires #790 (merged). The GET in `append_batch` calls `/api/queue` directly (does not hard-depend on #791's `read_queue`).

Closes #793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)