### PR TITLE
[#870] Review batches — server: batch-type marker + queue-driven completion

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -2215,32 +2215,55 @@ async function checkBatchSnapshotFreshness(repo, snapshot) {
 // the live Active Batch contains items the snapshot doesn't); in
 // all other cases the snapshot wins, so items Head moved to Done
 // stay visible until the operator starts the next batch.
-function resolveDisplayedBatch(queueText, projectId, { queueReadOk = true } = {}) {
-  // Queue file deleted / unreadable → fall back to empty state per
-  // #316's edge case. Returning the snapshot here would "heal" a
-  // genuinely missing file into stale data the operator can't
-  // reconcile without nuking ~/.quadwork/{id}/batch-progress-cache.json
-  // manually.
-  if (!queueReadOk) return { batchNumber: null, issueNumbers: [] };
-  const current = parseActiveBatch(queueText);
-  const snapshot = readBatchSnapshot(projectId);
+// Decide whether the displayed batch comes from the LIVE Active Batch parse or
+// the preserved snapshot. A new batch (explicit Batch: N bump OR live items the
+// snapshot doesn't have) → "live"; otherwise a non-empty snapshot wins
+// ("snapshot"), so items Head moved to Done stay visible until the next batch
+// starts. Extracted so #870's type pre-check follows the SAME decision.
+function pickDisplayedSource(current, snapshot) {
   const hasExplicitBump =
     current.batchNumber !== null &&
     (!snapshot || snapshot.batchNumber === null || current.batchNumber > snapshot.batchNumber);
   const hasNewItems =
     current.issueNumbers.length > 0 &&
     (!snapshot || current.issueNumbers.some((n) => !snapshot.issueNumbers.includes(n)));
+  if (hasExplicitBump || hasNewItems) return "live";
+  if (snapshot && Array.isArray(snapshot.issueNumbers) && snapshot.issueNumbers.length > 0) return "snapshot";
+  return "live";
+}
+
+function resolveDisplayedBatch(queueText, projectId, { queueReadOk = true } = {}) {
+  // Queue file deleted / unreadable → fall back to empty state per
+  // #316's edge case. Returning the snapshot here would "heal" a
+  // genuinely missing file into stale data the operator can't
+  // reconcile without nuking ~/.quadwork/{id}/batch-progress-cache.json
+  // manually.
+  if (!queueReadOk) return { batchNumber: null, issueNumbers: [], batch_type: "code", reviewItems: [] };
+  const current = parseActiveBatch(queueText);
+  const snapshot = readBatchSnapshot(projectId);
+  const source = pickDisplayedSource(current, snapshot);
   let next;
-  if (hasExplicitBump || hasNewItems) {
-    next = { batchNumber: current.batchNumber, issueNumbers: current.issueNumbers.slice() };
-  } else if (snapshot && Array.isArray(snapshot.issueNumbers) && snapshot.issueNumbers.length > 0) {
+  if (source === "live") {
+    next = {
+      batchNumber: current.batchNumber,
+      issueNumbers: current.issueNumbers.slice(),
+      // #870: type + per-item review states from the LIVE Active Batch.
+      batch_type: parseBatchType(queueText),
+      reviewItems: parseReviewItems(queueText),
+    };
+  } else {
     next = {
       batchNumber: snapshot.batchNumber ?? null,
       issueNumbers: snapshot.issueNumbers.slice(),
+      // #870: a just-archived review batch keeps its type + review states from
+      // the snapshot, so it renders without GitHub and is NEVER reinterpreted
+      // as code. Absent (legacy / code snapshots) → "code"/[] — back-compatible.
+      batch_type: snapshot.batch_type || "code",
+      reviewItems: Array.isArray(snapshot.reviewItems) ? snapshot.reviewItems : [],
     };
-  } else {
-    next = { batchNumber: current.batchNumber, issueNumbers: current.issueNumbers.slice() };
   }
+  // Snapshot persists batchNumber/issueNumbers (existing consumers) PLUS the
+  // additive #870 batch_type/reviewItems.
   if (next.issueNumbers.length > 0) writeBatchSnapshot(projectId, next);
   return next;
 }
@@ -2300,6 +2323,126 @@ function parseActiveBatch(queueText) {
     }
   }
   return { batchNumber, issueNumbers };
+}
+
+// #870: review-batch support. The queue's `## Active Batch` section may carry a
+// `**Batch type:** code | ticket-review | pr-review` line (right after
+// `**Batch:** N`). Absent/unrecognized → "code" (preserves existing behavior
+// exactly). Review batches compute progress from the Active Batch item states
+// alone — no GitHub calls.
+const ACTIVE_BATCH_SECTION_RE = /##\s+Active Batch[\s\S]*?(?=\n##\s|$)/i;
+const REVIEW_BATCH_TYPES = new Set(["ticket-review", "pr-review"]);
+
+function parseBatchType(queueText) {
+  if (typeof queueText !== "string" || !queueText) return "code";
+  const m = queueText.match(ACTIVE_BATCH_SECTION_RE);
+  if (!m) return "code";
+  const tm = m[0].match(/\*\*Batch type:\*\*\s*(code|ticket-review|pr-review)\b/i);
+  return tm ? tm[1].toLowerCase() : "code";
+}
+
+// Parse one Active Batch item's review-state annotation — the text after
+// `- #123 — `. Recognizes queued / in-review / in-review (N/2) / approved /
+// changes-requested; the leading separator (`—`, `-`, `:`, `]`, …) is stripped,
+// and anything unrecognized falls back to `queued` (safe default).
+function parseReviewState(raw) {
+  const s = String(raw || "").trim().replace(/^[^a-z0-9]+/i, "").toLowerCase();
+  if (s.startsWith("approved")) return { review_state: "approved", approvals: 2 };
+  if (s.startsWith("changes")) return { review_state: "changes-requested", approvals: 0 };
+  if (s.startsWith("in-review") || s.startsWith("in review")) {
+    const mm = s.match(/\((\d)\s*\/\s*2\)/);
+    return { review_state: "in-review", approvals: mm ? parseInt(mm[1], 10) : 0 };
+  }
+  return { review_state: "queued", approvals: 0 };
+}
+
+// Parse the `## Active Batch` review items: `- #<n> — <state>`. Same line
+// grammar as parseActiveBatch (so the issue set matches exactly), plus the
+// trailing state annotation. Scoped to Active Batch — NEVER `## Done`.
+const REVIEW_ITEM_LINE_RE = /^\s*(?:[-*]\s+|\d+\.\s+)?(?:\[[ xX]\]\s+)?\[?#(\d{1,6})\]?\b(.*)$/;
+function parseReviewItems(queueText) {
+  if (typeof queueText !== "string" || !queueText) return [];
+  const m = queueText.match(ACTIVE_BATCH_SECTION_RE);
+  if (!m) return [];
+  const seen = new Set();
+  const items = [];
+  for (const line of m[0].split("\n")) {
+    const lm = line.match(REVIEW_ITEM_LINE_RE);
+    if (!lm) continue;
+    const n = parseInt(lm[1], 10);
+    if (seen.has(n)) continue;
+    seen.add(n);
+    const { review_state, approvals } = parseReviewState(lm[2]);
+    items.push({ issue: n, review_state, approvals });
+  }
+  return items;
+}
+
+// Map a parsed review state → the batch-progress item, EXTENDING the existing
+// item shape ({ issue_number, title, url, pr_number, status, progress, label })
+// with review_state + approvals. pr-review items ARE PRs → set pr_number;
+// ticket-review omits it (frontend type is pr_number?: number — never null).
+function reviewItemView(ri, batchType, ghIndex) {
+  const n = ri.issue;
+  const meta = ghIndex && ghIndex.get(n);
+  let progress, status, label;
+  if (ri.review_state === "approved") { progress = 100; status = "approved"; label = "Approved ✓"; }
+  else if (ri.review_state === "changes-requested") { progress = 0; status = "changes_requested"; label = "changes requested"; }
+  else if (ri.review_state === "in-review") {
+    if (ri.approvals >= 1) { progress = 50; status = "in_review"; label = `In review · ${ri.approvals}/2 approvals`; }
+    else { progress = 20; status = "in_review"; label = "In review"; }
+  } else { progress = 0; status = "queued"; label = "Queued"; }
+  const item = {
+    issue_number: n,
+    title: (meta && meta.title) || `#${n}`,
+    url: (meta && meta.url) || null,
+    status,
+    progress,
+    label,
+    review_state: ri.review_state,
+    approvals: ri.approvals,
+  };
+  if (batchType === "pr-review") item.pr_number = n;
+  return item;
+}
+
+function summarizeReviewItems(reviewItems) {
+  const total = reviewItems.length;
+  let approved = 0, inReview = 0, changes = 0, queued = 0;
+  for (const r of reviewItems) {
+    if (r.review_state === "approved") approved++;
+    else if (r.review_state === "in-review") inReview++;
+    else if (r.review_state === "changes-requested") changes++;
+    else queued++;
+  }
+  const parts = [`${approved}/${total} approved`];
+  if (inReview > 0) parts.push(`${inReview} in review`);
+  if (changes > 0) parts.push(`${changes} changes requested`);
+  if (queued > 0) parts.push(`${queued} queued`);
+  return parts.join(" · ");
+}
+
+// Build a number → { title, url } index from the project's GITHUB.md (file
+// read only — NO gh call). Resolves review-item titles/urls; absent/unparseable
+// file → empty map and items fall back to `#N` / null url.
+function loadGithubItemIndex(projectId) {
+  const map = new Map();
+  let text;
+  try {
+    text = fs.readFileSync(path.join(CONFIG_DIR, projectId, "GITHUB.md"), "utf-8");
+  } catch {
+    return map;
+  }
+  const parsed = parseGithub(text);
+  if (!parsed || !parsed.ok) return map;
+  for (const list of [parsed.openIssues, parsed.closedIssues, parsed.openPRs, parsed.mergedPrs]) {
+    for (const it of list || []) {
+      if (it && typeof it.number === "number" && !map.has(it.number)) {
+        map.set(it.number, { title: it.title, url: it.url });
+      }
+    }
+  }
+  return map;
 }
 
 // #416 / quadwork#299: async variant used by the parallelized batch
@@ -2552,7 +2695,8 @@ router.get("/api/batch-active", async (req, res) => {
   // items outside the recent window.
   const data = await getOrComputeBatchProgress(projectId);
   const active = isBatchActiveFromProgress(data);
-  return res.json({ active: active === null ? false : active });
+  // #870: surface batch_type so the sidebar can label review vs code batches.
+  return res.json({ active: active === null ? false : active, batch_type: (data && data.batch_type) || "code" });
 });
 
 // #807: parsed view of the server-authored GITHUB.md. Single source of truth is
@@ -2601,7 +2745,7 @@ async function getOrComputeBatchProgress(projectId) {
   // precede the fresh-cache and rate-limit returns below.
   if (isProjectIdle(projectId)) {
     if (cached) return { ...cached.data, _idle: true };
-    return { batch_number: null, items: [], summary: "", complete: false, completeConfirmed: false, _idle: true };
+    return { batch_number: null, items: [], summary: "", complete: false, completeConfirmed: false, batch_type: "code", _idle: true };
   }
   const batchTTL = adaptiveTTL(BATCH_PROGRESS_TTL_MS);
   if (cached && Date.now() - cached.ts < batchTTL) {
@@ -2645,7 +2789,25 @@ async function getOrComputeBatchProgress(projectId) {
   // when we'd actually rely on the snapshot — i.e. the live queue
   // read succeeded, so the existing #316 bypass for unreadable
   // queue files keeps precedence.
-  if (queueReadOk) {
+  // #870: determine the displayed batch type up front (read-only) so review
+  // batches skip the GitHub snapshot-freshness check AND the merge-state path
+  // below entirely. The displayed type follows the SAME live-vs-snapshot
+  // decision as resolveDisplayedBatch: a just-archived review batch's live
+  // `**Batch type:**` is gone, so its type must come from the persisted snapshot.
+  const _liveActive = parseActiveBatch(queueText);
+  const _existingSnap = queueReadOk ? readBatchSnapshot(projectId) : null;
+  const _displaySource = queueReadOk ? pickDisplayedSource(_liveActive, _existingSnap) : "live";
+  const displayedBatchType =
+    _displaySource === "snapshot"
+      ? (_existingSnap && _existingSnap.batch_type) || "code"
+      : parseBatchType(queueText);
+  const isReviewBatch = REVIEW_BATCH_TYPES.has(displayedBatchType);
+
+  // #334: validate the on-disk snapshot's first issue against GitHub before
+  // resolveDisplayedBatch can serve it — CODE batches only. Review batches must
+  // make ZERO GitHub calls, and their snapshot issue numbers are queue-authored
+  // (not subject to the purged-repo staleness this check guards).
+  if (queueReadOk && !isReviewBatch) {
     const existing = readBatchSnapshot(projectId);
     if (existing && Array.isArray(existing.issueNumbers) && existing.issueNumbers.length > 0) {
       const freshness = await checkBatchSnapshotFreshness(repo, existing);
@@ -2658,7 +2820,7 @@ async function getOrComputeBatchProgress(projectId) {
   // #429 / quadwork#316: resolve the displayed batch through the
   // snapshot-aware helper so merged items stay visible after Head
   // moves them from Active Batch to Done, until a new batch starts.
-  const { batchNumber, issueNumbers } = resolveDisplayedBatch(queueText, projectId, { queueReadOk });
+  const { batchNumber, issueNumbers, batch_type, reviewItems } = resolveDisplayedBatch(queueText, projectId, { queueReadOk });
   // #864: lifecycle-signal flag. The displayed batch may be the preserved
   // snapshot (so /api/batch-progress keeps showing it), but lifecycle consumers
   // (/api/batch-active, trigger auto-stop, reseed safe-boundary) must follow
@@ -2672,7 +2834,27 @@ async function getOrComputeBatchProgress(projectId) {
   const batchKey = `${batchNumber}::${[...issueNumbers].sort((a, b) => a - b).join(",")}`;
   if (issueNumbers.length === 0) {
     evalBatchCompleteConfirmed(projectId, batchKey, false, null); // reset any complete streak
-    const data = { batch_number: batchNumber, items: [], summary: "", complete: false, completeConfirmed: false, liveActiveBatchCleared };
+    const data = { batch_number: batchNumber, items: [], summary: "", complete: false, completeConfirmed: false, liveActiveBatchCleared, batch_type };
+    _batchProgressCache.set(projectId, { ts: Date.now(), data });
+    return data;
+  }
+
+  // #870: review batch — progress computed ENTIRELY from the current Active
+  // Batch item states (or the preserved snapshot's), with NO GitHub calls. The
+  // queue is HEAD-authored and authoritative, so completeConfirmed = complete —
+  // do NOT route through evalBatchCompleteConfirmed (its two-cycle distinct-ts
+  // guard never advances without a #806 GraphQL fetch a review batch never makes).
+  if (batch_type === "ticket-review" || batch_type === "pr-review") {
+    // Defensive: a review batch should always carry per-item states, but if the
+    // snapshot somehow has issue numbers without them, treat all as queued.
+    const ri = reviewItems.length > 0
+      ? reviewItems
+      : issueNumbers.map((n) => ({ issue: n, review_state: "queued", approvals: 0 }));
+    const ghIndex = loadGithubItemIndex(projectId);
+    const items = ri.map((r) => reviewItemView(r, batch_type, ghIndex));
+    const summary = summarizeReviewItems(ri);
+    const complete = ri.length > 0 && ri.every((r) => r.review_state === "approved");
+    const data = { batch_number: batchNumber, items, summary, complete, completeConfirmed: complete, liveActiveBatchCleared, batch_type };
     _batchProgressCache.set(projectId, { ts: Date.now(), data });
     return data;
   }
@@ -2705,7 +2887,7 @@ async function getOrComputeBatchProgress(projectId) {
   // before any auto-stop consumer may act on it (never auto-stop on a single
   // transient/stale complete). Keyed on the snapshot's ts as the cycle marker.
   const completeConfirmed = evalBatchCompleteConfirmed(projectId, batchKey, complete, snapshot ? snapshot.ts : null);
-  const data = { batch_number: batchNumber, items, summary, complete, completeConfirmed, liveActiveBatchCleared };
+  const data = { batch_number: batchNumber, items, summary, complete, completeConfirmed, liveActiveBatchCleared, batch_type };
   _batchProgressCache.set(projectId, { ts: Date.now(), data });
   return data;
 }
@@ -3955,6 +4137,12 @@ module.exports = router;
 // outside this file; the export is strictly for the node:assert
 // script at server/routes.parseActiveBatch.test.js.
 module.exports.parseActiveBatch = parseActiveBatch;
+// #870: expose review-batch parsers/helpers for the reviewBatch fixture test.
+module.exports.parseBatchType = parseBatchType;
+module.exports.parseReviewItems = parseReviewItems;
+module.exports.parseReviewState = parseReviewState;
+module.exports.reviewItemView = reviewItemView;
+module.exports.summarizeReviewItems = summarizeReviewItems;
 // #350: same pattern — expose the no-linked-PR row builder and
 // summarizeItems for the batch-progress fixture test.
 module.exports.buildNoPrRow = buildNoPrRow;

--- a/server/routes.reviewBatch.test.js
+++ b/server/routes.reviewBatch.test.js
@@ -1,0 +1,220 @@
+// #870: review-batch server tests — batch-type marker + queue-driven
+// completion, with ZERO GitHub calls. Plain node:assert-style script (run with
+// `node server/routes.reviewBatch.test.js`).
+//
+// Mirrors routes.batchActiveCompletion.test.js's harness: stub child_process
+// (so any gh call is observable) and fs (CONFIG_PATH / OVERNIGHT-QUEUE.md /
+// batch-progress-cache.json / GITHUB.md) BEFORE require("./routes").
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const cp = require("child_process");
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+// Count gh invocations so review paths can assert ZERO. The stub also throws,
+// so any accidental gh call on the review path would corrupt the item rows
+// (proving the no-network contract two ways).
+let ghCalls = 0;
+const realRunner = cp.execFile;
+cp.execFile = function stubRunner(file, args, opts, cb) {
+  ghCalls++;
+  const done = typeof opts === "function" ? opts : cb;
+  const err = new Error("test stub: gh must not be invoked on the review path");
+  err.code = "ENOTEST";
+  if (typeof done === "function") return done(err, "", "");
+  return realRunner.apply(this, arguments);
+};
+
+const real = { readFileSync: fs.readFileSync };
+let cfgJson = JSON.stringify({ projects: [] });
+let queueText = "";
+let snapshotJson = null;
+let githubMd = null;
+let snapshotWrites = [];
+fs.readFileSync = function stubReadFileSync(p, ...rest) {
+  if (p === CONFIG_PATH) return cfgJson;
+  if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) return queueText;
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    if (snapshotJson !== null) return snapshotJson;
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
+  }
+  if (typeof p === "string" && p.endsWith("GITHUB.md")) {
+    if (githubMd !== null) return githubMd;
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
+  }
+  return real.readFileSync(p, ...rest);
+};
+// Capture snapshot writes so we can assert batch_type/reviewItems are persisted.
+fs.writeFileSync = function stubWrite(p, data) {
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    snapshotWrites.push(typeof data === "string" ? data : String(data));
+  }
+};
+fs.mkdirSync = () => {};
+fs.statSync = () => ({ mode: 0o700, isDirectory: () => true });
+fs.unlinkSync = () => {};
+
+const {
+  parseBatchType,
+  parseReviewItems,
+  parseReviewState,
+  isBatchActiveFromProgress,
+  getOrComputeBatchProgress,
+  _batchProgressCache,
+  _graphqlCache,
+} = require("./routes");
+
+let passed = 0, failed = 0;
+const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+function reset() {
+  _batchProgressCache.clear();
+  _graphqlCache.clear();
+  snapshotJson = null;
+  githubMd = null;
+  snapshotWrites = [];
+  ghCalls = 0;
+}
+
+(async () => {
+  console.log("\n--- #870 review-batch server tests ---\n");
+
+  // ── parseBatchType ──────────────────────────────────────────────────────
+  ok(parseBatchType("## Active Batch\n\n**Batch:** 1\n\n- #1 — queued\n") === "code", "absent marker → code");
+  ok(parseBatchType("## Active Batch\n\n**Batch:** 1\n**Batch type:** ticket-review\n\n- #1 — queued\n") === "ticket-review", "ticket-review parsed");
+  ok(parseBatchType("## Active Batch\n\n**Batch:** 1\n**Batch type:** pr-review\n\n- #1 — queued\n") === "pr-review", "pr-review parsed");
+  ok(parseBatchType("## Active Batch\n**Batch type:** banana\n\n- #1\n") === "code", "unrecognized type → code");
+  // marker only counts inside Active Batch, not e.g. Done
+  ok(parseBatchType("## Active Batch\n\n(none)\n\n## Done\n\n**Batch type:** pr-review\n") === "code", "marker outside Active Batch ignored");
+
+  // ── parseReviewState ────────────────────────────────────────────────────
+  ok(parseReviewState("— approved").review_state === "approved", "approved state");
+  ok(parseReviewState("in-review (1/2)").approvals === 1, "in-review (1/2) → approvals 1");
+  ok(parseReviewState("in-review").approvals === 0 && parseReviewState("in-review").review_state === "in-review", "in-review → 0 approvals");
+  ok(parseReviewState("changes-requested").review_state === "changes-requested", "changes-requested state");
+  ok(parseReviewState("queued").review_state === "queued", "queued state");
+  ok(parseReviewState("garbage").review_state === "queued", "unrecognized → queued");
+
+  // ── parseReviewItems (scoped to Active Batch, with states) ──────────────
+  {
+    const q = [
+      "# Queue", "", "## Active Batch", "", "**Batch:** 7", "**Batch type:** ticket-review", "",
+      "- #870 — approved", "- #871 — in-review (1/2)", "- #872 — queued", "",
+      "## Done", "", "**Batch:** 6", "- #800 — approved", "",
+    ].join("\n");
+    const items = parseReviewItems(q);
+    ok(items.length === 3, `parseReviewItems scoped to Active Batch (got ${items.length}, must exclude Done's #800)`);
+    ok(items[0].issue === 870 && items[0].review_state === "approved", "item 0 = #870 approved");
+    ok(items[1].issue === 871 && items[1].approvals === 1, "item 1 = #871 in-review 1/2");
+    ok(items[2].issue === 872 && items[2].review_state === "queued", "item 2 = #872 queued");
+  }
+
+  // ── B. Review batch end-to-end: 3 items, 1 approved → not complete ──────
+  {
+    reset();
+    cfgJson = JSON.stringify({ projects: [{ id: "rev", repo: "o/r", idle: false }] });
+    queueText = [
+      "# Queue", "", "## Active Batch", "", "**Batch:** 7", "**Batch type:** ticket-review", "",
+      "- #870 — approved", "- #871 — in-review (1/2)", "- #872 — queued", "", "## Backlog", "",
+    ].join("\n");
+    const data = await getOrComputeBatchProgress("rev");
+    ok(ghCalls === 0, `B: review compute made ZERO gh calls (got ${ghCalls})`);
+    ok(data.batch_type === "ticket-review", "B: batch_type === ticket-review");
+    ok(data.items.length === 3, "B: three items");
+    ok(data.items[0].review_state === "approved" && data.items[0].progress === 100, "B: #870 approved → progress 100");
+    ok(data.items[1].review_state === "in-review" && data.items[1].progress === 50 && data.items[1].approvals === 1, "B: #871 in-review(1/2) → progress 50");
+    ok(data.items[2].review_state === "queued" && data.items[2].progress === 0, "B: #872 queued → progress 0");
+    ok(data.items[0].issue_number === 870 && !("pr_number" in data.items[0]), "B: ticket-review item keeps issue_number, OMITS pr_number");
+    ok(data.complete === false && data.completeConfirmed === false, "B: not all approved → not complete");
+    ok(isBatchActiveFromProgress(data) === true, "B: in-progress review batch is active");
+  }
+
+  // ── C. All approved → complete && completeConfirmed (queue authoritative) ─
+  {
+    reset();
+    cfgJson = JSON.stringify({ projects: [{ id: "rev", repo: "o/r", idle: false }] });
+    queueText = [
+      "# Queue", "", "## Active Batch", "", "**Batch:** 7", "**Batch type:** pr-review", "",
+      "- #870 — approved", "- #871 — approved", "", "## Backlog", "",
+    ].join("\n");
+    const data = await getOrComputeBatchProgress("rev");
+    ok(ghCalls === 0, `C: still ZERO gh calls (got ${ghCalls})`);
+    ok(data.complete === true, "C: all approved → complete");
+    ok(data.completeConfirmed === true, "C: completeConfirmed === complete (no two-cycle gate)");
+    ok(data.items[0].pr_number === 870, "C: pr-review item sets pr_number = n");
+    ok(isBatchActiveFromProgress(data) === false, "C: completed review batch → not active");
+  }
+
+  // ── D. Done-scoping: old approved items in ## Done don't count ──────────
+  {
+    reset();
+    cfgJson = JSON.stringify({ projects: [{ id: "rev", repo: "o/r", idle: false }] });
+    queueText = [
+      "# Queue", "", "## Active Batch", "", "**Batch:** 8", "**Batch type:** ticket-review", "",
+      "- #900 — in-review", "", "## Done", "", "**Batch:** 7", "- #870 — approved", "- #871 — approved", "",
+    ].join("\n");
+    const data = await getOrComputeBatchProgress("rev");
+    ok(data.items.length === 1 && data.items[0].issue_number === 900, "D: only the current Active item counts (Done excluded)");
+    ok(data.complete === false, "D: current item not approved → not complete (Done's approved ignored)");
+  }
+
+  // ── E. Archive interaction: completed review batch moved to Done →
+  //      still renders from the snapshot, NO gh call, never reverts to code ──
+  {
+    reset();
+    cfgJson = JSON.stringify({ projects: [{ id: "rev", repo: "o/r", idle: false }] });
+    // Persisted snapshot from when the batch was active (review + states).
+    snapshotJson = JSON.stringify({
+      batchNumber: 7,
+      issueNumbers: [870, 871],
+      batch_type: "ticket-review",
+      reviewItems: [
+        { issue: 870, review_state: "approved", approvals: 2 },
+        { issue: 871, review_state: "approved", approvals: 2 },
+      ],
+    });
+    // Head archived the block to Done; live Active Batch is cleared (no marker).
+    queueText = [
+      "# Queue", "", "## Active Batch", "", "(no active batch yet)", "",
+      "## Done", "", "**Batch:** 7", "**Batch type:** ticket-review",
+      "- #870 — approved", "- #871 — approved", "",
+    ].join("\n");
+    const data = await getOrComputeBatchProgress("rev");
+    ok(ghCalls === 0, `E: archived review batch made ZERO gh calls (got ${ghCalls}) — not reinterpreted as code`);
+    ok(data.batch_type === "ticket-review", "E: batch_type stays ticket-review from the snapshot (never reverts to code)");
+    ok(data.items.length === 2, "E: still renders the 2 review items from the snapshot");
+    ok(data.items.every((it) => it.review_state === "approved"), "E: items keep their review_state (not code merge-progress)");
+    ok(data.complete === true, "E: archived completed review batch reads complete");
+    ok(isBatchActiveFromProgress(data) === false, "E: lifecycle — cleared Active Batch → not active (sticky display only)");
+    ok(data.liveActiveBatchCleared === true, "E: liveActiveBatchCleared follows the operator's clear");
+  }
+
+  // ── F. Regression: a code batch is unchanged + carries batch_type 'code' ─
+  {
+    reset();
+    cfgJson = JSON.stringify({ projects: [{ id: "code", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 9\n\n- #100 feat: thing\n\n## Backlog\n";
+    // Provide a merged snapshot so the code path resolves the item via the
+    // (stubbed-gh-free) #806 cache, exactly like batchActiveCompletion B1.
+    _graphqlCache.set("o/r", {
+      ts: Date.now(), issues: [], prs: [],
+      closedIssues: [{ number: 100, title: "feat: thing", url: "https://x/i/100" }],
+      mergedPrs: [{ number: 101, title: "[#100] feat: thing", url: "https://x/p/101", merged_at: "2026-01-01T00:00:00Z", reviews: [] }],
+      openPrsWindowComplete: true, closedPrsWindowComplete: true, closedPrIssueNums: [100],
+    });
+    const data = await getOrComputeBatchProgress("code");
+    ok(data.batch_type === "code", "F: code batch → batch_type 'code'");
+    ok(data.items.length === 1 && data.items[0].status === "merged", "F: code item still resolves as merged (no regression)");
+    ok(!("review_state" in data.items[0]), "F: code item has NO review_state field");
+    ok(data.complete === true, "F: code batch completion unchanged");
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})().catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
Backend foundation for review batches (parent epic #869). Adds the **batch-type marker** contract and **review-batch completion semantics**. A review batch's progress is computed entirely from the current `## Active Batch` item states (HEAD-maintained) — **no GitHub calls**. **Code batches are byte-for-byte unchanged** (absent marker = `code`).

All changes are in `server/routes.js` (+ a new test file).

## What's in it

### Marker parsing (extends the existing queue format — does not change it)
- **`parseBatchType()`** reads `**Batch type:** code | ticket-review | pr-review` from **inside `## Active Batch`** (after `**Batch:** N`), absent/unrecognized → `code`. `batch_type` is now present in both `/api/batch-active` and `/api/batch-progress` payloads.
- **`parseReviewItems()` / `parseReviewState()`** parse `- #<n> — <state>` lines using the **same line grammar as `parseActiveBatch`**, scoped to Active Batch (**never `## Done`**), into `{ issue, review_state, approvals }`. States: `queued` / `in-review` / `in-review (N/2)` / `approved` / `changes-requested`; unrecognized → `queued`.

### Review completion (ticket-review, pr-review)
- **`reviewItemView()` EXTENDS the existing item shape** (`{ issue_number, title, url, pr_number, status, progress, label }`) with `review_state` + `approvals`. Progress map: `queued→0`, `in-review→20`, `in-review (1/2)→50`, `approved→100`, `changes-requested→0` (label `"changes requested"`). `pr_number` is set for **pr-review** and **omitted for ticket-review** (frontend type is `pr_number?: number` — never set to `null`). `title`/`url` resolved from `GITHUB.md` via a file-read index — **no `gh` call**.
- **`getOrComputeBatchProgress` branches on `batch_type`:** review → queue-only path; `complete` = every current Active item is `approved`; **`completeConfirmed = complete`** (deliberately NOT routed through `evalBatchCompleteConfirmed`, whose two-cycle distinct-`generatedAt` guard never advances without a GraphQL fetch a review batch never makes). Code → existing merge path, untouched. The displayed type is determined **up front** so review batches **skip the `gh` snapshot-freshness check** entirely.

### Persisted-snapshot option (not bypass)
`resolveDisplayedBatch` + the extracted `pickDisplayedSource` now carry `batch_type` + `reviewItems` in the batch snapshot **additively**. So when HEAD archives a completed review batch to `## Done` (the live `**Batch type:**` is gone), it **keeps rendering from the snapshot with no GitHub calls and is never reinterpreted as `code`** — exactly as completed code batches stay sticky today. Existing `{ batchNumber, issueNumbers }` snapshot fields remain back-compatible. `liveActiveBatchCleared` (#864) is unchanged as the lifecycle signal, so `/api/batch-active` still follows the operator's explicit clear.

## Verification
- **`server/routes.reviewBatch.test.js` — 42/42 pass:**
  - marker parse (incl. unrecognized→code, marker outside Active Batch ignored) + Active-Batch scoping;
  - 3-item review, 1 approved → **not complete**, correct per-item progress (100 / 50 / 0); ticket-review keeps `issue_number`, omits `pr_number`;
  - all approved → **`complete` && `completeConfirmed`**; pr-review sets `pr_number = n`;
  - **Done-scoping:** old `approved` items in `## Done` don't count toward the current batch;
  - **Archive interaction:** completed review batch moved to Done → renders from the snapshot, makes **ZERO `gh` calls** (asserted via a counting `child_process` stub), never reverts to code merge-progress, `liveActiveBatchCleared` → not active;
  - **code-batch regression:** code batch still resolves merged via the snapshot path, carries `batch_type:"code"`, has no `review_state`.
- Existing **`batchActiveCompletion` (43), `batchProgressSnapshot` (45), `batchProgress` (6), `parseActiveBatch` (6)** all still pass.
- `npm test` → **34 passed, 0 failed, 2 skipped**.
- `npm run build` → green.

## Dependencies
- None (foundation). A-2 / A-3 depend on this.

Closes #870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)