### PR TITLE
[#880] Operator MCP: remove stale #864 caveat from batch_status tool description

### DIFF
--- a/server/mcp-operator/tools/read.js
+++ b/server/mcp-operator/tools/read.js
@@ -29,7 +29,7 @@ module.exports = {
     {
       name: "batch_status",
       description:
-        "Get a project's overnight-batch status as { active, progress }, merged from /api/batch-active and /api/batch-progress. CAVEAT (#864): `active:true` can persist after Head clears the queue (preserved-snapshot / duplicate-PR edge); do NOT treat active:true as authoritative for 'work remaining' until #864 lands.",
+        "Get a project's overnight-batch status as { active, progress }, merged from /api/batch-active and /api/batch-progress. `active` reflects the live `## Active Batch` lifecycle — once Head clears the queue, active drops to false — so it is authoritative for 'work remaining'. `progress` may keep rendering a just-completed batch (sticky display) even after active is false.",
       inputSchema: {
         type: "object",
         properties: {


### PR DESCRIPTION
## Summary
Updates the `batch_status` tool description in `server/mcp-operator/tools/read.js` (shipped by #791) to drop the now-stale `#864` caveat. **Description-only — no logic change.**

## Why
**#864 is merged and closed** — it added `liveActiveBatchCleared` so a cleared `## Active Batch` drops `/api/batch-active` to `active:false`, and made the duplicate-PR picker state-aware. The old description still told the operator agent:

> CAVEAT (#864): `active:true` can persist after Head clears the queue … do NOT treat active:true as authoritative for 'work remaining' until #864 lands.

MCP tool descriptions are fed to the operator agent as guidance, so this actively steered it to distrust a signal that is now reliable.

## Fix
New description:

> Get a project's overnight-batch status as `{ active, progress }`, merged from `/api/batch-active` and `/api/batch-progress`. `active` reflects the live `## Active Batch` lifecycle — once Head clears the queue, active drops to false — so it is authoritative for 'work remaining'. `progress` may keep rendering a just-completed batch (sticky display) even after active is false.

(The "sticky progress" note reflects the preserved-snapshot behavior that's also now extended for review batches in #870.)

## Verification
- No `#864` / "until … lands" caveat remains in the file (grep clean).
- `server/mcp-operator/tools/read.test.js` → **16/16 pass**.
- `npm run build` → green.

Closes #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)