### PR TITLE
[#872] Review batches — seeds: ticket-review workflow (4 roles)

### DIFF
--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -130,6 +130,25 @@ When implementing UI/frontend changes:
 11. Send message to **@re1 AND @re2** (NOT @head): "Fixes pushed for PR #<number>, please re-review"
 12. **Wait for BOTH RE1 and RE2** to approve before proceeding — only then send message to @head requesting merge with PR number. If only one has approved, wait silently for the other.
 
+## Review batches
+When Head assigns a ticket from a batch stamped **`**Batch type:** ticket-review`** (check the `## Active Batch` section of `OVERNIGHT-QUEUE.md`), you are the **review driver**, NOT a builder: you do **not** write code, create branches, or open PRs. You drive a spec review of the *ticket itself*.
+
+Per assigned ticket #<n>:
+1. **Read context from `GITHUB.md` first** (`~/.quadwork/{{project_name}}/GITHUB.md`). For the live issue body/comments, use **REST**:
+   - `gh api repos/<repo>/issues/<n>`
+   - `gh api repos/<repo>/issues/<n>/comments`
+
+   `git pull` to read any cited code/files locally against current `main`. **Do NOT run `gh issue view --json`, `gh pr view --json`, or `gh pr list`** — those are GraphQL-backed and drain the API budget this workflow exists to protect.
+2. Post a SINGLE message **@re1 @re2 please review ticket #<n>** with the key points to check: scope clear? acceptance criteria testable? technically feasible vs current `main`? dependencies/ordering correct? internally consistent (no contradictory sections)?
+3. Aggregate both verdicts:
+   - **REQUEST CHANGES** → edit the issue body via REST: write the revised body to a temp file and `gh api --method PATCH repos/<repo>/issues/<n> -F body=@<file>`. If reviewers surface genuinely new scope, file a sub-ticket via REST: `gh api --method POST repos/<repo>/issues -f title='...' -F body=@<file> -f 'labels[]=agent/dev'`. Then re-request review of the changed sections from **@re1 @re2**.
+   - **dual APPROVE** → report `@head ticket #<n> review complete — both approved`.
+
+**Review-batch exceptions to the rules above:** editing issue bodies and filing sub-tickets **via `gh api` (REST)** is permitted here as the review driver — this is the one mode where Dev touches issues. Everything else still holds: **never** `gh pr create`, never `git commit` code, never merge — there is no PR in a review batch.
+
+### Item-state vocabulary (Head writes these)
+`queued | in-review | in-review (N/2) | approved | changes-requested` — annotations Head maintains on the `## Active Batch` item lines (`- #<n> — <state>`). Your progress reports drive Head's updates.
+
 ## Error Recovery
 - **Network failures** (DNS, GitHub API, git push/pull): retry automatically up to 5 times with 30-second intervals. Do NOT ask the user — just retry silently.
 - **Build failures**: fix the issue and retry. If stuck after 3 attempts, report blocker to @head.

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -142,6 +142,32 @@ When the operator asks you in chat to start a task or batch:
 2. Read the next Active Batch item and assign it to `@dev`.
 3. If Active Batch is empty, report it in chat and wait silently for the operator's next instruction.
 
+## Review batches
+A **review batch** reviews GitHub *tickets* (issue specs) instead of building code — same queue mechanics as a code batch, plus one marker line and in-place state annotations. There is **no PR and no merge step**.
+
+When the operator asks to "review tickets #X #Y #Z":
+1. Write the `## Active Batch` section the **normal way** — `**Batch:** N` (next sequential number, same `max(N)+1` rule) — and add a `**Batch type:** ticket-review` line **right after** `**Batch:** N`:
+
+   ```markdown
+   ## Active Batch
+
+   **Batch:** <N>
+   **Batch type:** ticket-review
+   **Started:** <YYYY-MM-DD HH:MM>
+
+   - #<X> — queued
+   - #<Y> — queued
+   - #<Z> — queued
+   ```
+
+   Each item is `- #<n> — <state>` (dash, space, `#`, number, space, em-dash, space, state). The `#` must be the first token after the list marker, exactly as for code batches.
+2. Confirm in chat, then use the normal "Batch N is ready … Say @head Start" kickoff. On Start, assign the first ticket to `@dev`.
+3. **As Dev reports progress, update each item's state annotation IN PLACE** — `queued` → `in-review` → `in-review (1/2)` → `approved` (or `changes-requested`). Do **NOT** move items individually to `## Done`; they stay in `## Active Batch` with their annotation until the whole batch is done.
+4. When **every** item is `approved`, the batch is complete (no merge). Archive the whole block to `## Done` exactly as a finished code batch, **preserving the `**Batch:** N` and `**Batch type:** ticket-review` lines** (so batch numbering stays correct and the archived batch still renders right).
+
+### Item-state vocabulary (must match exactly)
+`queued | in-review | in-review (N/2) | approved | changes-requested` — annotations on the `## Active Batch` item lines (`- #<n> — <state>`), scoped to the current `**Batch:** N`. These exact strings are what the batch-progress panel parses.
+
 ## Workflow
 1. Receive task request (from the operator in chat, or as the next item in `OVERNIGHT-QUEUE.md`) → create GitHub issue if needed.
 2. @dev to assign implementation — then **wait silently**. Do NOT route to reviewers; Dev handles that.

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -154,6 +154,21 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 7. If changes requested, wait for Dev fixes, then re-review
 8. On approve, notify @dev (Dev aggregates approvals and notifies Head)
 
+## Review batches
+When @dev asks you to **review a ticket** (not a PR) — e.g. `@re1 @re2 please review ticket #<n>` — you are reviewing a GitHub *issue spec* that belongs to a `**Batch type:** ticket-review` batch. There is **no PR and no code diff**.
+
+1. Read the ticket from `GITHUB.md` / REST `gh api repos/<repo>/issues/<n>` (and `.../issues/<n>/comments`). **Never** `gh issue view --json`, `gh pr view --json`, or `gh pr list` (GraphQL — defeats the API-budget goal). `git pull` first to verify any cited files/lines against current `main`.
+2. Review against the **required-points rubric**:
+   - Scope clear and bounded?
+   - Acceptance criteria concrete and testable?
+   - Technically feasible against current `main`?
+   - Dependencies / ordering correct?
+   - Internally consistent (no contradictory sections)?
+3. Deliver to **@dev** a verdict — `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` — with specific, **line-referenced** points (quote the ticket section / acceptance criterion). On REQUEST CHANGES, wait for @dev's revised ticket, then re-review the changed sections.
+
+### Item-state vocabulary (Head maintains these on the queue)
+`queued | in-review | in-review (N/2) | approved | changes-requested` — annotations on the `## Active Batch` item lines (`- #<n> — <state>`). Your APPROVE / REQUEST CHANGES verdicts are what move a ticket toward `approved`.
+
 ## Error Recovery
 - **Network failures** (`gh` API errors, DNS issues): retry the `gh` command automatically up to 5 times with 30-second intervals. Do NOT ask the user — just retry silently. If still failing after 5 retries, post your review verdict via chat message to @dev instead (so the loop isn't blocked).
 

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -154,6 +154,21 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 7. If changes requested, wait for Dev fixes, then re-review
 8. On approve, notify @dev (Dev aggregates approvals and notifies Head)
 
+## Review batches
+When @dev asks you to **review a ticket** (not a PR) — e.g. `@re1 @re2 please review ticket #<n>` — you are reviewing a GitHub *issue spec* that belongs to a `**Batch type:** ticket-review` batch. There is **no PR and no code diff**.
+
+1. Read the ticket from `GITHUB.md` / REST `gh api repos/<repo>/issues/<n>` (and `.../issues/<n>/comments`). **Never** `gh issue view --json`, `gh pr view --json`, or `gh pr list` (GraphQL — defeats the API-budget goal). `git pull` first to verify any cited files/lines against current `main`.
+2. Review against the **required-points rubric**:
+   - Scope clear and bounded?
+   - Acceptance criteria concrete and testable?
+   - Technically feasible against current `main`?
+   - Dependencies / ordering correct?
+   - Internally consistent (no contradictory sections)?
+3. Deliver to **@dev** a verdict — `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` — with specific, **line-referenced** points (quote the ticket section / acceptance criterion). On REQUEST CHANGES, wait for @dev's revised ticket, then re-review the changed sections.
+
+### Item-state vocabulary (Head maintains these on the queue)
+`queued | in-review | in-review (N/2) | approved | changes-requested` — annotations on the `## Active Batch` item lines (`- #<n> — <state>`). Your APPROVE / REQUEST CHANGES verdicts are what move a ticket toward `approved`.
+
 ## Error Recovery
 - **Network failures** (`gh` API errors, DNS issues): retry the `gh` command automatically up to 5 times with 30-second intervals. Do NOT ask the user — just retry silently. If still failing after 5 retries, post your review verdict via chat message to @dev instead (so the loop isn't blocked).
 


### PR DESCRIPTION
## Summary
Teaches all four agent seeds the **ticket-review** batch workflow + the queue marker/state contract from #870. **Templates only — no code change**; distributed to existing worktrees by the existing reseed path. Parent epic #869, Seeds.

Adds a `## Review batches` section to `templates/seeds/{head,dev,re1,re2}.AGENTS.md`.

## Per-role content
- **HEAD** — on "review tickets #X #Y": write `## Active Batch` the normal way (`**Batch:** N`, `max(N)+1`) plus a `**Batch type:** ticket-review` line **right after** it; items as `- #<n> — queued`. As Dev reports, update each item's state annotation **in place** (`queued` → `in-review` → `in-review (1/2)` → `approved` / `changes-requested`) — do **not** move items individually to Done. When **every** item is `approved` (no merge step), archive the whole block to `## Done` **preserving** the `Batch:`/`Batch type:` lines.
- **DEV** (review driver — **never writes code or opens PRs** in a review batch) — read context from `GITHUB.md` first, live-fetch via **REST** `gh api repos/<repo>/issues/<n>` + `/comments` only; **`gh issue view --json` / `gh pr view --json` / `gh pr list` explicitly forbidden** (GraphQL). Request `@re1 @re2` ticket review; on REQUEST CHANGES edit the issue body via `gh api --method PATCH … -F body=@file` and file sub-tickets via REST (the one mode Dev touches issues); on dual APPROVE report to `@head`.
- **RE1 / RE2** — read the ticket via `GITHUB.md` / REST `gh api` (same forbidden-GraphQL rule), `git pull` to verify cited files against `main`, review against the **required-points rubric** (scope clear / acceptance criteria testable / feasible vs `main` / dependencies / internal consistency), and deliver `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` to `@dev` with **line-referenced** points.
- **Shared item-state vocabulary** in all 4, matching #870's parser **exactly**: `queued | in-review | in-review (N/2) | approved | changes-requested` (annotations on `- #<n> — <state>`, scoped to the current `**Batch:** N`).

## Verification
- `## Review batches` section present in all 4 seeds; the three forbidden GraphQL commands explicitly listed in dev/re1/re2.
- State vocabulary matches #870's `parseReviewState` (the em-dash separator is handled by the parser's leading-separator strip).
- `npm test` → **34 passed** (reseed tests — autoReseed / reseedAgentsMd / reseedTokenPreservation — unaffected).
- `npm run build` → green.

## Dependencies
- #870 (merged) — marker + state contract. Sequential **before #873 (A-4)** — same seed files.

Closes #872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)