### PR TITLE
[#873] Review batches — seeds: pr-review workflow (4 roles)

### DIFF
--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -131,7 +131,10 @@ When implementing UI/frontend changes:
 12. **Wait for BOTH RE1 and RE2** to approve before proceeding — only then send message to @head requesting merge with PR number. If only one has approved, wait silently for the other.
 
 ## Review batches
-When Head assigns a ticket from a batch stamped **`**Batch type:** ticket-review`** (check the `## Active Batch` section of `OVERNIGHT-QUEUE.md`), you are the **review driver**, NOT a builder: you do **not** write code, create branches, or open PRs. You drive a spec review of the *ticket itself*.
+When Head assigns work from a batch stamped `**Batch type:** ticket-review` or `**Batch type:** pr-review` (check the `## Active Batch` section of `OVERNIGHT-QUEUE.md`), you are the **review driver**, NOT a builder: you never write code, create branches, open PRs, merge, or revert.
+
+### ticket-review batches
+For a `ticket-review` batch you drive a spec review of the *ticket itself*.
 
 Per assigned ticket #<n>:
 1. **Read context from `GITHUB.md` first** (`~/.quadwork/{{project_name}}/GITHUB.md`). For the live issue body/comments, use **REST**:
@@ -144,7 +147,25 @@ Per assigned ticket #<n>:
    - **REQUEST CHANGES** → edit the issue body via REST: write the revised body to a temp file and `gh api --method PATCH repos/<repo>/issues/<n> -F body=@<file>`. If reviewers surface genuinely new scope, file a sub-ticket via REST: `gh api --method POST repos/<repo>/issues -f title='...' -F body=@<file> -f 'labels[]=agent/dev'`. Then re-request review of the changed sections from **@re1 @re2**.
    - **dual APPROVE** → report `@head ticket #<n> review complete — both approved`.
 
-**Review-batch exceptions to the rules above:** editing issue bodies and filing sub-tickets **via `gh api` (REST)** is permitted here as the review driver — this is the one mode where Dev touches issues. Everything else still holds: **never** `gh pr create`, never `git commit` code, never merge — there is no PR in a review batch.
+**Review-batch exceptions to the rules above:** editing issue bodies, filing sub-tickets, and posting PR comments **via `gh api` (REST)** is permitted here as the review driver — review batches are the one mode where Dev touches issues/PRs. Everything else still holds: **never** `gh pr create`, never `git commit` code, never merge or revert.
+
+### pr-review batches (merged PRs)
+For a `pr-review` batch you review **already-merged PRs** — output is a **review-summary comment + follow-up fix tickets**, never a revert or code change.
+
+Per assigned PR #<n>:
+1. **Read context from `GITHUB.md` first.** For the live merged diff + linked issue, use **REST**:
+   - `gh api repos/<repo>/pulls/<n>`
+   - `gh api repos/<repo>/pulls/<n>/files`
+   - `gh api repos/<repo>/issues/<n>` (the linked issue)
+
+   `git pull` to read the merged code locally. **Do NOT use `gh pr view --json`, `gh pr list`, or `gh issue view --json`** (GraphQL — defeats the API-budget goal).
+2. Post a SINGLE message **@re1 @re2 review merged PR #<n>** with focus points: correctness, regressions, missed edge cases, follow-ups.
+3. Aggregate both verdicts, then:
+   - File any follow-up **fix tickets** via REST: `gh api --method POST repos/<repo>/issues -f title='...' -F body=@<file> -f 'labels[]=agent/dev'`.
+   - Post a **review-summary comment** on the PR via REST: `gh api --method POST repos/<repo>/issues/<n>/comments -F body=@<file>` (PR comments use the issues/comments endpoint).
+   - Report `@head PR #<n> review complete — findings captured`.
+
+**Completion differs from ticket-review:** a merged PR is already in `main` and **cannot be "fixed before completion"**. So **REQUEST CHANGES does NOT mean "fix the PR"** — it means **follow-up fix tickets are required**. The item reaches `approved` when **both reviewers agree the findings/follow-ups are captured** (tickets filed + summary comment posted), NOT a claim the merged PR was clean. A clean PR (no findings) also reaches `approved` once both reviewers sign off. **Never revert or push code** in a pr-review batch.
 
 ### Item-state vocabulary (Head writes these)
 `queued | in-review | in-review (N/2) | approved | changes-requested` — annotations Head maintains on the `## Active Batch` item lines (`- #<n> — <state>`). Your progress reports drive Head's updates.

--- a/templates/seeds/head.AGENTS.md
+++ b/templates/seeds/head.AGENTS.md
@@ -143,8 +143,9 @@ When the operator asks you in chat to start a task or batch:
 3. If Active Batch is empty, report it in chat and wait silently for the operator's next instruction.
 
 ## Review batches
-A **review batch** reviews GitHub *tickets* (issue specs) instead of building code — same queue mechanics as a code batch, plus one marker line and in-place state annotations. There is **no PR and no merge step**.
+A **review batch** reviews GitHub *tickets* (issue specs, `ticket-review`) or *merged PRs* (`pr-review`) instead of building code — same queue mechanics as a code batch, plus one marker line and in-place state annotations. A review batch never opens a new PR and never merges/lands code.
 
+### ticket-review batches
 When the operator asks to "review tickets #X #Y #Z":
 1. Write the `## Active Batch` section the **normal way** — `**Batch:** N` (next sequential number, same `max(N)+1` rule) — and add a `**Batch type:** ticket-review` line **right after** `**Batch:** N`:
 
@@ -165,8 +166,24 @@ When the operator asks to "review tickets #X #Y #Z":
 3. **As Dev reports progress, update each item's state annotation IN PLACE** — `queued` → `in-review` → `in-review (1/2)` → `approved` (or `changes-requested`). Do **NOT** move items individually to `## Done`; they stay in `## Active Batch` with their annotation until the whole batch is done.
 4. When **every** item is `approved`, the batch is complete (no merge). Archive the whole block to `## Done` exactly as a finished code batch, **preserving the `**Batch:** N` and `**Batch type:** ticket-review` lines** (so batch numbering stays correct and the archived batch still renders right).
 
+### pr-review batches
+When the operator asks to "review merged PRs #X #Y #Z": same as ticket-review but stamp `**Batch type:** pr-review`, and the items are **PR numbers** (`- #<pr> — queued`):
+
+```markdown
+## Active Batch
+
+**Batch:** <N>
+**Batch type:** pr-review
+**Started:** <YYYY-MM-DD HH:MM>
+
+- #<PR-X> — queued
+- #<PR-Y> — queued
+```
+
+Same in-place-annotation lifecycle: items stay in `## Active Batch` with their state until `approved`, then archive the whole block to `## Done` (preserve `**Batch:** N` + `**Batch type:** pr-review`). A merged PR is already in `main`, so `approved` here means **Dev + both reviewers captured the findings** (follow-up fix tickets filed + a summary comment posted) — NOT that the PR was reverted or "fixed". There is no merge step.
+
 ### Item-state vocabulary (must match exactly)
-`queued | in-review | in-review (N/2) | approved | changes-requested` — annotations on the `## Active Batch` item lines (`- #<n> — <state>`), scoped to the current `**Batch:** N`. These exact strings are what the batch-progress panel parses.
+`queued | in-review | in-review (N/2) | approved | changes-requested` — annotations on the `## Active Batch` item lines (`- #<n> — <state>`), scoped to the current `**Batch:** N`. These exact strings are what the batch-progress panel parses (same vocabulary for ticket-review and pr-review).
 
 ## Workflow
 1. Receive task request (from the operator in chat, or as the next item in `OVERNIGHT-QUEUE.md`) → create GitHub issue if needed.

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -155,16 +155,26 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 8. On approve, notify @dev (Dev aggregates approvals and notifies Head)
 
 ## Review batches
-When @dev asks you to **review a ticket** (not a PR) — e.g. `@re1 @re2 please review ticket #<n>` — you are reviewing a GitHub *issue spec* that belongs to a `**Batch type:** ticket-review` batch. There is **no PR and no code diff**.
+@dev may ask you to review a **ticket** (a GitHub issue spec, `ticket-review` batch) or a **merged PR** (`pr-review` batch) instead of an open PR. In both: read via `GITHUB.md` / REST `gh api` — **never** `gh issue view --json`, `gh pr view --json`, or `gh pr list` (GraphQL — defeats the API-budget goal). `git pull` first to verify cited files/lines against current `main`. Deliver findings to **@dev**, line-referenced.
 
-1. Read the ticket from `GITHUB.md` / REST `gh api repos/<repo>/issues/<n>` (and `.../issues/<n>/comments`). **Never** `gh issue view --json`, `gh pr view --json`, or `gh pr list` (GraphQL — defeats the API-budget goal). `git pull` first to verify any cited files/lines against current `main`.
+### ticket-review batches
+When @dev asks `@re1 @re2 please review ticket #<n>`, you are reviewing a GitHub *issue spec* — no PR, no code diff.
+
+1. Read the ticket via REST `gh api repos/<repo>/issues/<n>` (and `.../issues/<n>/comments`).
 2. Review against the **required-points rubric**:
    - Scope clear and bounded?
    - Acceptance criteria concrete and testable?
    - Technically feasible against current `main`?
    - Dependencies / ordering correct?
    - Internally consistent (no contradictory sections)?
-3. Deliver to **@dev** a verdict — `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` — with specific, **line-referenced** points (quote the ticket section / acceptance criterion). On REQUEST CHANGES, wait for @dev's revised ticket, then re-review the changed sections.
+3. Deliver `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` to @dev with specific, line-referenced points (quote the ticket section / acceptance criterion). On REQUEST CHANGES, wait for @dev's revised ticket, then re-review the changed sections.
+
+### pr-review batches (merged PRs)
+When @dev asks `@re1 @re2 review merged PR #<n>`, the PR is **already merged into `main`** — you assess the landed change, you do not block a merge.
+
+1. Read via REST `gh api repos/<repo>/pulls/<n>`, `.../pulls/<n>/files`, and `gh api repos/<repo>/issues/<n>` (the linked issue). `git pull` to read the merged code locally.
+2. Assess against a **merged-PR rubric**: does it do what the ticket asked? regressions introduced? security issues? tests adequate for the change?
+3. Deliver findings to @dev, **line-referenced**. Findings become **follow-up fix tickets** (Dev files them) — there is no "fix this PR" step; the PR is already in `main`. Sign off (APPROVE) once you've assessed the change and any findings are captured as follow-ups.
 
 ### Item-state vocabulary (Head maintains these on the queue)
 `queued | in-review | in-review (N/2) | approved | changes-requested` — annotations on the `## Active Batch` item lines (`- #<n> — <state>`). Your APPROVE / REQUEST CHANGES verdicts are what move a ticket toward `approved`.

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -155,16 +155,26 @@ Reference `DESIGN-GUIDE.md` in the workspace for full details on each rule.
 8. On approve, notify @dev (Dev aggregates approvals and notifies Head)
 
 ## Review batches
-When @dev asks you to **review a ticket** (not a PR) — e.g. `@re1 @re2 please review ticket #<n>` — you are reviewing a GitHub *issue spec* that belongs to a `**Batch type:** ticket-review` batch. There is **no PR and no code diff**.
+@dev may ask you to review a **ticket** (a GitHub issue spec, `ticket-review` batch) or a **merged PR** (`pr-review` batch) instead of an open PR. In both: read via `GITHUB.md` / REST `gh api` — **never** `gh issue view --json`, `gh pr view --json`, or `gh pr list` (GraphQL — defeats the API-budget goal). `git pull` first to verify cited files/lines against current `main`. Deliver findings to **@dev**, line-referenced.
 
-1. Read the ticket from `GITHUB.md` / REST `gh api repos/<repo>/issues/<n>` (and `.../issues/<n>/comments`). **Never** `gh issue view --json`, `gh pr view --json`, or `gh pr list` (GraphQL — defeats the API-budget goal). `git pull` first to verify any cited files/lines against current `main`.
+### ticket-review batches
+When @dev asks `@re1 @re2 please review ticket #<n>`, you are reviewing a GitHub *issue spec* — no PR, no code diff.
+
+1. Read the ticket via REST `gh api repos/<repo>/issues/<n>` (and `.../issues/<n>/comments`).
 2. Review against the **required-points rubric**:
    - Scope clear and bounded?
    - Acceptance criteria concrete and testable?
    - Technically feasible against current `main`?
    - Dependencies / ordering correct?
    - Internally consistent (no contradictory sections)?
-3. Deliver to **@dev** a verdict — `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` — with specific, **line-referenced** points (quote the ticket section / acceptance criterion). On REQUEST CHANGES, wait for @dev's revised ticket, then re-review the changed sections.
+3. Deliver `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` to @dev with specific, line-referenced points (quote the ticket section / acceptance criterion). On REQUEST CHANGES, wait for @dev's revised ticket, then re-review the changed sections.
+
+### pr-review batches (merged PRs)
+When @dev asks `@re1 @re2 review merged PR #<n>`, the PR is **already merged into `main`** — you assess the landed change, you do not block a merge.
+
+1. Read via REST `gh api repos/<repo>/pulls/<n>`, `.../pulls/<n>/files`, and `gh api repos/<repo>/issues/<n>` (the linked issue). `git pull` to read the merged code locally.
+2. Assess against a **merged-PR rubric**: does it do what the ticket asked? regressions introduced? security issues? tests adequate for the change?
+3. Deliver findings to @dev, **line-referenced**. Findings become **follow-up fix tickets** (Dev files them) — there is no "fix this PR" step; the PR is already in `main`. Sign off (APPROVE) once you've assessed the change and any findings are captured as follow-ups.
 
 ### Item-state vocabulary (Head maintains these on the queue)
 `queued | in-review | in-review (N/2) | approved | changes-requested` — annotations on the `## Active Batch` item lines (`- #<n> — <state>`). Your APPROVE / REQUEST CHANGES verdicts are what move a ticket toward `approved`.


### PR DESCRIPTION
## Summary
Adds the **pr-review** workflow (reviewing already-merged PRs) to the `## Review batches` section of all four seeds — extending #872. Output = a review-summary comment + follow-up fix tickets; **no reverts, no code**. **Templates only — no code change**; propagates via the existing reseed path. Parent epic #869, Seeds.

## Per-role additions
- **HEAD** — section now split into `### ticket-review batches` / `### pr-review batches`. pr-review: stamp `**Batch type:** pr-review`, items are **PR numbers** (`- #<pr> — queued`), same in-place-annotation lifecycle (stay in Active Batch until `approved`, then archive the whole block to Done preserving `Batch:`/`Batch type:`). Notes a merged PR is already in `main`, so `approved` = findings captured, not reverted.
- **DEV** (review driver — **no reverts/code**) — for pr-review read `GITHUB.md` first, live-fetch via **REST** `gh api repos/<repo>/pulls/<n>` + `/files` + the linked issue; **`gh pr view --json` / `gh pr list` / `gh issue view --json` forbidden**. Request `@re1 @re2` merged-PR review; aggregate; **file follow-up fix tickets via REST** and **post a review-summary comment** on the PR (`gh api … issues/<n>/comments`); report to `@head`.
- **RE1 / RE2** — restructured into `### ticket-review` / `### pr-review` subsections with a shared forbidden-GraphQL intro. pr-review: read via REST pulls/files + linked issue, assess against a **merged-PR rubric** (matches the ticket? regressions? security? tests adequate?), deliver **line-referenced** findings → follow-up tickets.

## Completion semantics (the key pr-review difference)
A merged PR **cannot be "fixed before completion"** — it's already in `main`. So **REQUEST CHANGES does NOT block on fixing the PR — it means follow-up fix tickets are required.** The item reaches `approved` when **both reviewers agree the findings/follow-ups are captured** (tickets filed + summary posted), **not** a claim the merged PR was clean. A clean PR (no findings) also reaches `approved` once both sign off. Documented in HEAD + DEV seeds.

## Verification
- `pr-review` workflow present in all 4 seeds; `**Batch type:** pr-review` marker in HEAD; the three forbidden GraphQL commands listed for dev/re1/re2.
- RE1 vs RE2 `## Review batches` content **byte-identical** (symmetric reviewers).
- Reuses #870's marker/state vocabulary unchanged (`queued | in-review | in-review (N/2) | approved | changes-requested`).
- `npm test` → **34 passed** (reseed tests unaffected); `npm run build` → green.

## Dependencies
- #872 (same seed files — sequential, merged), #870.

Closes #873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)