### PR TITLE
[#887] pr-review seeds: fetch the PR's linked ticket, not issues/<pr-number>

### DIFF
--- a/templates/seeds/dev.AGENTS.md
+++ b/templates/seeds/dev.AGENTS.md
@@ -153,16 +153,17 @@ Per assigned ticket #<n>:
 For a `pr-review` batch you review **already-merged PRs** — output is a **review-summary comment + follow-up fix tickets**, never a revert or code change.
 
 Per assigned PR #<n>:
-1. **Read context from `GITHUB.md` first.** For the live merged diff + linked issue, use **REST**:
-   - `gh api repos/<repo>/pulls/<n>`
-   - `gh api repos/<repo>/pulls/<n>/files`
-   - `gh api repos/<repo>/issues/<n>` (the linked issue)
+1. **Read context from `GITHUB.md` first.** For the live merged diff, use **REST**:
+   - `gh api repos/<repo>/pulls/<n>` — the merged PR
+   - `gh api repos/<repo>/pulls/<n>/files` — its diff
+2. **Derive the linked TICKET number**, then fetch the ticket — this is the spec the PR was supposed to satisfy. Do **NOT** use `gh api repos/<repo>/issues/<n>` with the PR number: for a PR number that endpoint returns the PR itself (PRs are issues in GitHub's data model), not the ticket. Find the ticket number from `GITHUB.md`, the PR title (`[#<issue>]` convention), or the PR body (`Fixes #<issue>` / `Closes #<issue>`), then:
+   - `gh api repos/<repo>/issues/<linked-ticket>` (+ `/comments` if needed) — the original ticket + acceptance criteria
 
    `git pull` to read the merged code locally. **Do NOT use `gh pr view --json`, `gh pr list`, or `gh issue view --json`** (GraphQL — defeats the API-budget goal).
-2. Post a SINGLE message **@re1 @re2 review merged PR #<n>** with focus points: correctness, regressions, missed edge cases, follow-ups.
-3. Aggregate both verdicts, then:
+3. Post a SINGLE message **@re1 @re2 review merged PR #<n>** with focus points: correctness, regressions, missed edge cases, follow-ups.
+4. Aggregate both verdicts, then:
    - File any follow-up **fix tickets** via REST: `gh api --method POST repos/<repo>/issues -f title='...' -F body=@<file> -f 'labels[]=agent/dev'`.
-   - Post a **review-summary comment** on the PR via REST: `gh api --method POST repos/<repo>/issues/<n>/comments -F body=@<file>` (PR comments use the issues/comments endpoint).
+   - Post a **review-summary comment** on the PR via REST: `gh api --method POST repos/<repo>/issues/<n>/comments -F body=@<file>` (PR comments use the issues/comments endpoint — `<n>` is the PR number here, which is correct).
    - Report `@head PR #<n> review complete — findings captured`.
 
 **Completion differs from ticket-review:** a merged PR is already in `main` and **cannot be "fixed before completion"**. So **REQUEST CHANGES does NOT mean "fix the PR"** — it means **follow-up fix tickets are required**. The item reaches `approved` when **both reviewers agree the findings/follow-ups are captured** (tickets filed + summary comment posted), NOT a claim the merged PR was clean. A clean PR (no findings) also reaches `approved` once both reviewers sign off. **Never revert or push code** in a pr-review batch.

--- a/templates/seeds/re1.AGENTS.md
+++ b/templates/seeds/re1.AGENTS.md
@@ -172,7 +172,7 @@ When @dev asks `@re1 @re2 please review ticket #<n>`, you are reviewing a GitHub
 ### pr-review batches (merged PRs)
 When @dev asks `@re1 @re2 review merged PR #<n>`, the PR is **already merged into `main`** — you assess the landed change, you do not block a merge.
 
-1. Read via REST `gh api repos/<repo>/pulls/<n>`, `.../pulls/<n>/files`, and `gh api repos/<repo>/issues/<n>` (the linked issue). `git pull` to read the merged code locally.
+1. Read the merged PR + diff via REST `gh api repos/<repo>/pulls/<n>` and `.../pulls/<n>/files`. Then **derive the linked TICKET number** (from `GITHUB.md`, the PR title's `[#<issue>]`, or the PR body's `Fixes #<issue>` / `Closes #<issue>`) and fetch that ticket: `gh api repos/<repo>/issues/<linked-ticket>` (+ `/comments` if needed) — the spec/acceptance criteria to judge the change against. Do NOT use `issues/<pr-number>`: for a PR number that returns the PR itself, not the ticket. `git pull` to read the merged code locally.
 2. Assess against a **merged-PR rubric**: does it do what the ticket asked? regressions introduced? security issues? tests adequate for the change?
 3. Deliver findings to @dev, **line-referenced**. Findings become **follow-up fix tickets** (Dev files them) — there is no "fix this PR" step; the PR is already in `main`. Sign off (APPROVE) once you've assessed the change and any findings are captured as follow-ups.
 

--- a/templates/seeds/re2.AGENTS.md
+++ b/templates/seeds/re2.AGENTS.md
@@ -172,7 +172,7 @@ When @dev asks `@re1 @re2 please review ticket #<n>`, you are reviewing a GitHub
 ### pr-review batches (merged PRs)
 When @dev asks `@re1 @re2 review merged PR #<n>`, the PR is **already merged into `main`** — you assess the landed change, you do not block a merge.
 
-1. Read via REST `gh api repos/<repo>/pulls/<n>`, `.../pulls/<n>/files`, and `gh api repos/<repo>/issues/<n>` (the linked issue). `git pull` to read the merged code locally.
+1. Read the merged PR + diff via REST `gh api repos/<repo>/pulls/<n>` and `.../pulls/<n>/files`. Then **derive the linked TICKET number** (from `GITHUB.md`, the PR title's `[#<issue>]`, or the PR body's `Fixes #<issue>` / `Closes #<issue>`) and fetch that ticket: `gh api repos/<repo>/issues/<linked-ticket>` (+ `/comments` if needed) — the spec/acceptance criteria to judge the change against. Do NOT use `issues/<pr-number>`: for a PR number that returns the PR itself, not the ticket. `git pull` to read the merged code locally.
 2. Assess against a **merged-PR rubric**: does it do what the ticket asked? regressions introduced? security issues? tests adequate for the change?
 3. Deliver findings to @dev, **line-referenced**. Findings become **follow-up fix tickets** (Dev files them) — there is no "fix this PR" step; the PR is already in `main`. Sign off (APPROVE) once you've assessed the change and any findings are captured as follow-ups.
 


### PR DESCRIPTION
## Summary
Fixes a wrong-review-context bug in the **pr-review** seed sections (introduced by #873's wording). **Templates only — no code change**; propagates via the existing reseed path.

## The bug
The pr-review sections told reviewers to read the merged PR's "linked issue" via `gh api repos/<repo>/issues/<n>` where `<n>` is the **PR number**. In GitHub's REST API, `GET /repos/<repo>/issues/<pr-number>` returns the **PR itself** (PRs are issues in the data model) — **not** the ticket the PR fixed. So pr-review agents re-fetched the PR thread they already had from `pulls/<n>` and **missed the original ticket/spec/acceptance-criteria**, defeating the core pr-review check ("does it do what the ticket asked?").

## Fix (dev / re1 / re2 pr-review sections)
Replace the `issues/<pr-number>` step with: **derive the linked ticket number, then fetch that ticket.**
1. Read the PR via REST `gh api repos/<repo>/pulls/<n>` (+ `/files`) — unchanged.
2. **Derive the linked TICKET number** from `GITHUB.md`, the PR title (`[#<issue>]`), or the PR body (`Fixes #<issue>` / `Closes #<issue>`).
3. Fetch the ticket: `gh api repos/<repo>/issues/<linked-ticket>` (+ `/comments`) — REST only.

Each section also states explicitly that `issues/<pr-number>` returns the PR, not the ticket.

## Unchanged (per the ticket's "do not change")
- **ticket-review** sections — there `<n>` IS the ticket number, so `issues/<n>` is correct.
- The **PR summary-comment POST** `gh api … repos/<repo>/issues/<n>/comments` (dev) — posting a PR comment genuinely uses `issues/<pr-number>/comments`. Left intact; added an inline note that `<n>` is correctly the PR number there.

## Verification
- All three pr-review sections now fetch `issues/<linked-ticket>`; ticket-review `issues/<n>` lines and the summary-comment POST line confirmed unchanged (grep).
- RE1 vs RE2 `## Review batches` content **byte-identical**.
- Still GITHUB.md-first + REST-only (no `gh pr view --json` / `gh pr list` / `gh issue view --json`).
- `npm test` → **34 passed**; `npm run build` → green.

## Dependencies
- #873 (same seed files, merged).

Closes #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)