### PR TITLE
[#886] Rate-limit badge: also show the reviewer-token account

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -67,6 +67,13 @@ const _searchRateLimit = {
   resetAt: 0,        // epoch ms
   updatedAt: 0,      // epoch ms when we last fetched
 };
+// #886: the reviewer-token account is a SEPARATE, per-account GitHub rate-limit
+// budget (reviewers run gh as `reviewer_github_user`). Polled with the reviewer
+// token in a second exempt `rate_limit` call. Null until a reviewer token is
+// configured + resolves — single-account setups stay null and the badge shows
+// nothing extra. Shape: { login, core, graphql, search } where each bucket is
+// { limit, remaining, resetAt(ms) }, plus updatedAt/error.
+let _reviewerRateLimit = null;
 const RATE_LIMIT_POLL_MS = 60_000;       // refresh every 60s
 const RATE_LIMIT_LOW_THRESHOLD = 200;    // below this → back off
 const RATE_LIMIT_CRITICAL = 50;          // below this → stop all infra gh calls
@@ -103,6 +110,52 @@ async function refreshRateLimit() {
   } catch (err) {
     _rateLimit.error = err.message;
     _rateLimit.updatedAt = Date.now();
+  }
+  // #886: also poll the reviewer-token account (separate budget). Independent
+  // try/catch inside — a reviewer failure never affects the main poll above.
+  await refreshReviewerRateLimit();
+}
+
+// #886: second exempt `rate_limit` poll as the reviewer-token account, so the
+// dashboard covers BOTH GitHub budgets (per-account, not aggregated). Resolves
+// the reviewer token path the same way reseed does (configured path → default
+// ~/.quadwork/reviewer-token); no token → clears the reviewer state (omitted
+// from the payload, single-account behavior unchanged). `rate_limit` is exempt,
+// so this adds zero billable cost.
+async function refreshReviewerRateLimit() {
+  let cfg = {};
+  try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { /* default-config / unreadable → use {} */ }
+  const tokenPath = cfg.reviewer_token_path || path.join(os.homedir(), ".quadwork", "reviewer-token");
+  let token = "";
+  try {
+    token = fs.readFileSync(tokenPath, "utf-8").trim();
+  } catch {
+    _reviewerRateLimit = null; // no reviewer token configured → single-account
+    return;
+  }
+  if (!token) { _reviewerRateLimit = null; return; }
+  try {
+    const { stdout } = await _execFileAsync("gh", [
+      "api", "rate_limit", "--jq",
+      "{core: (.resources.core | {limit,remaining,reset}), graphql: (.resources.graphql | {limit,remaining,reset}), search: (.resources.search | {limit,remaining,reset})}",
+    ], { encoding: "utf-8", timeout: 10000, env: { ...process.env, GH_TOKEN: token } });
+    const data = JSON.parse(stdout);
+    const toBucket = (b) => ({ limit: b.limit, remaining: b.remaining, resetAt: b.reset * 1000 });
+    _reviewerRateLimit = {
+      login: cfg.reviewer_github_user || null,
+      core: data.core ? toBucket(data.core) : null,
+      graphql: data.graphql ? toBucket(data.graphql) : null,
+      search: data.search ? toBucket(data.search) : null,
+      updatedAt: Date.now(),
+      error: null,
+    };
+  } catch (err) {
+    // Preserve prior bucket data if any; just flag the error + timestamp.
+    _reviewerRateLimit = {
+      ...(_reviewerRateLimit || { login: cfg.reviewer_github_user || null, core: null, graphql: null, search: null }),
+      updatedAt: Date.now(),
+      error: err.message,
+    };
   }
 }
 
@@ -959,6 +1012,20 @@ function bucketView(b) {
   };
 }
 
+// #886: build the reviewer-account block for the response, or null when no
+// reviewer token is configured / no bucket data yet (single-account setups →
+// key omitted, badge unchanged).
+function reviewerRateLimitPayload() {
+  const r = _reviewerRateLimit;
+  if (!r || (!r.core && !r.graphql && !r.search)) return null;
+  const out = {};
+  if (r.login) out.login = r.login;
+  if (r.core) out.core = bucketView(r.core);
+  if (r.graphql) out.graphql = bucketView(r.graphql);
+  if (r.search) out.search = bucketView(r.search);
+  return out;
+}
+
 router.get("/api/github/rate-limit", (_req, res) => {
   const resetIn = _rateLimit.resetAt > Date.now()
     ? Math.ceil((_rateLimit.resetAt - Date.now()) / 60000)
@@ -977,6 +1044,8 @@ router.get("/api/github/rate-limit", (_req, res) => {
     core: bucketView(_rateLimit),
     graphql: bucketView(_graphqlRateLimit),
     search: bucketView(_searchRateLimit),
+    // #886: reviewer-token account (separate budget), present only when configured.
+    ...(reviewerRateLimitPayload() ? { reviewer: reviewerRateLimitPayload() } : {}),
   });
 });
 
@@ -4185,6 +4254,9 @@ module.exports._canonicalAgentSlug = _canonicalAgentSlug;
 // #854: expose the GH_TOKEN path extractor so the parse forms (`export`,
 // double-quoted, inner-quoted, etc.) are exercisable without a temp fs.
 module.exports._extractReviewerTokenPath = _extractReviewerTokenPath;
+// #886: expose the reviewer-account rate-limit poll + payload builder for tests.
+module.exports.refreshReviewerRateLimit = refreshReviewerRateLimit;
+module.exports.reviewerRateLimitPayload = reviewerRateLimitPayload;
 // #856: expose the auto-reseed startup hook + supporting state/version
 // helpers. server/index.js calls `autoReseedOnStartup` after config is
 // loaded; the helpers are exposed for unit tests + the integration test

--- a/server/routes.reviewBatch.test.js
+++ b/server/routes.reviewBatch.test.js
@@ -48,6 +48,14 @@ fs.readFileSync = function stubReadFileSync(p, ...rest) {
     err.code = "ENOENT";
     throw err;
   }
+  // #886: the module-load startRateLimitPolling() now also polls the reviewer
+  // account, which reads the reviewer-token file. Force ENOENT so no reviewer
+  // gh poll fires and races a gh call into the ZERO-gh-call assertions below.
+  if (typeof p === "string" && p.endsWith("reviewer-token")) {
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
+  }
   return real.readFileSync(p, ...rest);
 };
 // Capture snapshot writes so we can assert batch_type/reviewItems are persisted.

--- a/server/routes.reviewerRateLimit.test.js
+++ b/server/routes.reviewerRateLimit.test.js
@@ -1,0 +1,133 @@
+// #886: reviewer-token rate-limit poll tests. Verifies the second exempt
+// `gh api rate_limit` poll runs as the reviewer token, exposes a `reviewer`
+// payload (separate per-account budget), and is omitted on single-account
+// setups. Plain node:assert script (run with `node ...`).
+//
+// Stubs child_process.execFile (so the gh call is observable + the GH_TOKEN env
+// is captured) and fs.readFileSync (config + token file) BEFORE require.
+
+const cp = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const util = require("util");
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+const FAKE_TOKEN_PATH = "/tmp/__reviewer_token_test__";
+
+const nowSec = Math.floor(Date.now() / 1000);
+const RATE_JSON = JSON.stringify({
+  core: { limit: 5000, remaining: 4000, reset: nowSec + 3600 },
+  graphql: { limit: 5000, remaining: 37, reset: nowSec + 3600 },
+  search: { limit: 30, remaining: 30, reset: nowSec + 60 },
+});
+
+let capturedEnvToken = null;
+let reviewerPollCalls = 0; // counts ONLY reviewer polls (those carrying GH_TOKEN)
+function handleGh(file, args, options) {
+  // Serves any `gh api rate_limit` (incl. the module-load main poll). Counts
+  // only the reviewer poll, distinguished by the GH_TOKEN env it sets — the
+  // main poll carries no env, so it never affects reviewerPollCalls.
+  if (file === "gh" && Array.isArray(args) && args.includes("rate_limit")) {
+    if (options && options.env && options.env.GH_TOKEN) {
+      reviewerPollCalls++;
+      capturedEnvToken = options.env.GH_TOKEN;
+    }
+    return { stdout: RATE_JSON, stderr: "" };
+  }
+  return null;
+}
+const realExecFile = cp.execFile;
+function stub(file, args, opts, cb) {
+  const done = typeof opts === "function" ? opts : cb;
+  const options = typeof opts === "function" ? {} : opts || {};
+  const res = handleGh(file, args, options);
+  if (res) return done(null, res.stdout, res.stderr);
+  return realExecFile.apply(this, arguments);
+}
+// routes.js uses util.promisify(execFile), which resolves via execFile's custom
+// promisify symbol to { stdout, stderr }. Replicate that so the awaited result
+// destructures `stdout` correctly (a plain callback stub would resolve to a
+// bare string and break JSON.parse).
+stub[util.promisify.custom] = (file, args, options) => {
+  const res = handleGh(file, args, options);
+  if (res) return Promise.resolve(res);
+  return Promise.reject(new Error(`unexpected execFile in test: ${file} ${(args || []).join(" ")}`));
+};
+cp.execFile = stub;
+
+// fs stubs are swapped per-scenario via these mutable refs.
+let configJson = "{}";
+let tokenFileContent = null; // null → ENOENT
+const realRead = fs.readFileSync;
+fs.readFileSync = function stubRead(p, ...rest) {
+  if (p === CONFIG_PATH) return configJson;
+  if (p === FAKE_TOKEN_PATH || (typeof p === "string" && p.endsWith("reviewer-token"))) {
+    if (tokenFileContent === null) {
+      const err = new Error("ENOENT (test stub)");
+      err.code = "ENOENT";
+      throw err;
+    }
+    return tokenFileContent;
+  }
+  return realRead(p, ...rest);
+};
+
+const { refreshReviewerRateLimit, reviewerRateLimitPayload } = require("./routes");
+
+let passed = 0, failed = 0;
+const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+(async () => {
+  console.log("\n--- #886 reviewer-account rate-limit tests ---\n");
+
+  // Let the module-load startRateLimitPolling() → refreshRateLimit() chain
+  // (kicked off with the initial EMPTY config, so it fires no reviewer poll)
+  // fully settle before we mutate the fixtures — otherwise its trailing
+  // refreshReviewerRateLimit could read scenario A's token and race the counter.
+  await new Promise((r) => setTimeout(r, 100));
+
+  // ── A. Reviewer token configured → polled as the reviewer, payload present ─
+  {
+    capturedEnvToken = null;
+    reviewerPollCalls = 0;
+    configJson = JSON.stringify({ reviewer_token_path: FAKE_TOKEN_PATH, reviewer_github_user: "project7-interns" });
+    tokenFileContent = "ghp_reviewerfaketoken\n";
+
+    await refreshReviewerRateLimit();
+    const payload = reviewerRateLimitPayload();
+
+    ok(reviewerPollCalls === 1, `A: ran exactly one reviewer rate_limit poll (got ${reviewerPollCalls})`);
+    ok(capturedEnvToken === "ghp_reviewerfaketoken", "A: poll used the reviewer token via GH_TOKEN env (trimmed)");
+    ok(payload !== null, "A: reviewer payload present when a token is configured");
+    ok(payload.login === "project7-interns", "A: payload login from cfg.reviewer_github_user");
+    ok(payload.graphql && payload.graphql.remaining === 37, "A: reviewer graphql bucket surfaced (the at-risk budget)");
+    ok(payload.core && payload.core.remaining === 4000, "A: reviewer core bucket surfaced");
+    ok(typeof payload.graphql.resetInMinutes === "number", "A: bucketView shape (resetInMinutes) applied");
+  }
+
+  // ── B. No reviewer token (file missing) → payload null (single-account) ───
+  {
+    reviewerPollCalls = 0;
+    configJson = "{}";
+    tokenFileContent = null; // ENOENT
+
+    await refreshReviewerRateLimit();
+    ok(reviewerRateLimitPayload() === null, "B: no reviewer token → payload null (single-account, no regression)");
+    ok(reviewerPollCalls === 0, "B: no reviewer token → NO second gh poll fired");
+  }
+
+  // ── C. Empty token file → treated as not configured ──────────────────────
+  {
+    reviewerPollCalls = 0;
+    configJson = JSON.stringify({ reviewer_token_path: FAKE_TOKEN_PATH });
+    tokenFileContent = "   \n";
+
+    await refreshReviewerRateLimit();
+    ok(reviewerRateLimitPayload() === null, "C: empty token file → payload null");
+    ok(reviewerPollCalls === 0, "C: empty token → NO gh poll");
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})().catch((err) => { console.error(err); process.exit(1); });

--- a/src/components/GitHubRateLimitBadge.tsx
+++ b/src/components/GitHubRateLimitBadge.tsx
@@ -7,6 +7,9 @@ import { useEffect, useState } from "react";
 // GitHubPanel and renders all three buckets (core / graphql / search) inline,
 // each colored independently by its OWN remaining %. Reuses the existing
 // exempt `gh api rate_limit` poll (#554/#802) — no new billable API calls.
+// #886: also renders a second group for the reviewer-token account when the
+// response includes a `reviewer` block (two-account setups), since GitHub
+// budgets are per-account, not aggregated.
 
 interface Bucket {
   limit: number;
@@ -14,17 +17,19 @@ interface Bucket {
   resetInMinutes: number;
 }
 
-interface RateLimitResponse {
+interface ReviewerBlock {
+  login?: string;
   core?: Bucket;
   graphql?: Bucket;
   search?: Bucket;
 }
 
-const BUCKETS: { key: keyof RateLimitResponse; label: string }[] = [
-  { key: "core", label: "core" },
-  { key: "graphql", label: "gql" },
-  { key: "search", label: "search" },
-];
+interface RateLimitResponse {
+  core?: Bucket;
+  graphql?: Bucket;
+  search?: Bucket;
+  reviewer?: ReviewerBlock;
+}
 
 // Per-bucket color by its own remaining %: green ≥50% healthy, red ≤5% (or 0)
 // gone, orange in between (warning). search is a small bucket (30/min) so its
@@ -35,6 +40,30 @@ function bucketColor(b: Bucket): string {
   if (b.remaining === 0 || pct <= 0.05) return "text-error";
   if (pct >= 0.5) return "text-accent";
   return "text-warning";
+}
+
+// Render the colored span for each present bucket. Skips any bucket the
+// endpoint didn't return rather than crashing.
+function bucketSpans(items: { label: string; b?: Bucket }[]) {
+  return items
+    .filter((it): it is { label: string; b: Bucket } =>
+      !!it.b && typeof it.b.remaining === "number" && typeof it.b.limit === "number",
+    )
+    .map(({ label, b }) => (
+      <span
+        key={label}
+        className="flex items-center gap-1 whitespace-nowrap"
+        title={`${label}: ${b.remaining}/${b.limit} remaining · resets in ${b.resetInMinutes}m`}
+      >
+        <span className={bucketColor(b)} aria-hidden>
+          ●
+        </span>
+        <span>{label}</span>
+        <span>
+          {b.remaining}/{b.limit}
+        </span>
+      </span>
+    ));
 }
 
 export default function GitHubRateLimitBadge() {
@@ -58,36 +87,41 @@ export default function GitHubRateLimitBadge() {
     };
   }, []);
 
-  // Degrade gracefully: render nothing until we have data, and skip any bucket
-  // the endpoint didn't return rather than crashing.
-  const visible = data
-    ? BUCKETS.filter(({ key }) => {
-        const b = data[key];
-        return b && typeof b.remaining === "number" && typeof b.limit === "number";
-      })
+  // Degrade gracefully: render nothing until we have data.
+  const mainSpans = data
+    ? bucketSpans([
+        { label: "core", b: data.core },
+        { label: "gql", b: data.graphql },
+        { label: "search", b: data.search },
+      ])
     : [];
-  if (visible.length === 0) return null;
+  if (mainSpans.length === 0) return null;
+
+  // #886: reviewer account — graphql is the at-risk budget (review discovery),
+  // so show it (plus core/search when present). Absent on single-account setups.
+  const reviewer = data?.reviewer;
+  const reviewerSpans = reviewer
+    ? bucketSpans([
+        { label: "gql", b: reviewer.graphql },
+        { label: "core", b: reviewer.core },
+        { label: "search", b: reviewer.search },
+      ])
+    : [];
 
   return (
     <div className="flex items-center gap-2 text-[10px] font-mono text-text-muted">
-      {visible.map(({ key, label }) => {
-        const b = data![key]!;
-        return (
-          <span
-            key={key}
-            className="flex items-center gap-1 whitespace-nowrap"
-            title={`${label}: ${b.remaining}/${b.limit} remaining · resets in ${b.resetInMinutes}m`}
-          >
-            <span className={bucketColor(b)} aria-hidden>
-              ●
-            </span>
-            <span>{label}</span>
-            <span>
-              {b.remaining}/{b.limit}
-            </span>
+      {mainSpans}
+      {reviewerSpans.length > 0 && (
+        <>
+          <span className="text-border" aria-hidden>
+            |
           </span>
-        );
-      })}
+          <span className="flex items-center gap-1.5 whitespace-nowrap">
+            <span className="opacity-70">{reviewer?.login || "reviewer"}:</span>
+            {reviewerSpans}
+          </span>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Closes the #866 monitoring blind spot. The rate-limit badge only watched the **server's** gh account (head/dev token). In a two-account setup the **reviewer account** — historically the riskiest for the GraphQL budget (review discovery used to mean `gh pr list`) — was invisible, and GitHub rate limits are **per-account, not aggregated**. So a regressed reviewer seed could drain the reviewer GraphQL budget while the badge stayed all-green.

Additive follow-up to #866. **No new billable cost** — `rate_limit` is exempt.

## Backend (`server/routes.js`)
- **`refreshReviewerRateLimit()`** — a **second exempt** `gh api rate_limit` poll run as the **reviewer token** (`GH_TOKEN` env), called from `refreshRateLimit` each cycle in its own try/catch so a reviewer failure never affects the main poll. Resolves the token path the same way reseed does (`cfg.reviewer_token_path` → default `~/.quadwork/reviewer-token`); **no/empty token → reviewer state cleared** (key omitted).
- `_reviewerRateLimit` holds `{ login, core, graphql, search }` (buckets in ms); `login` from `cfg.reviewer_github_user` (no extra API call).
- `/api/github/rate-limit` adds a **`reviewer`** key (reusing `bucketView`) **only when a reviewer token resolves**; single-account setups omit it entirely.

## Frontend (`src/components/GitHubRateLimitBadge.tsx`)
- When the response has a `reviewer` block, render a **second labeled group** (`<login>: ● gql … ● core … ● search …`) after a divider, per-bucket colored by the same thresholds — `graphql` first (the at-risk budget). Absent → renders exactly as today.
- Refactored bucket rendering into a shared `bucketSpans()` helper.

## Verification
- **`server/routes.reviewerRateLimit.test.js` — 11/11:** reviewer poll uses the reviewer token via `GH_TOKEN`; payload present with `login` + buckets when configured; **null + no second poll** when the token file is missing/empty (single-account, no regression). (Stubs execFile's custom-promisify; settles the module-load poll for determinism.)
- `reviewBatch.test.js` updated: stub the reviewer-token path to ENOENT so the new module-load reviewer poll can't race a gh call into its ZERO-gh-call assertions — still **42/42**.
- Endpoint verified live: single-account (no token) → **`reviewer` key omitted**, core/graphql/search unchanged.
- `npm test` → **35 passed, 0 failed, 2 skipped**; `npm run build` → green; badge lints clean.

## Dependencies
- #866 (merged) — the badge + `bucketView` + exempt poll.

Closes #886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)