### PR TITLE
[#794] Operator MCP: batch execution (start_batch, trigger_now, stop_batch)

### DIFF
--- a/server/mcp-operator/tools/triggers.js
+++ b/server/mcp-operator/tools/triggers.js
@@ -1,0 +1,94 @@
+"use strict";
+
+// #794: batch-execution tools (Tier 2 — act). start/stop the scheduled trigger
+// that drives a batch, and fire a single pulse on demand. set_batch/append_batch
+// (#793) DEFINE the work; these RUN it. New file under tools/ — additive,
+// auto-merged by #790's loader, no edits to existing modules.
+//
+// Validate-first: POST /api/triggers/:project/start creates a setInterval for
+// ANY :project string (the backend doesn't reject unknown ids), and send-now
+// can create a stray ~/.quadwork/<id>/ chat file. So every tool calls
+// assertKnownProject(project) BEFORE its HTTP call — unknown id → clean error,
+// no request, no timer.
+
+const IDLE_REJECTION = (project) =>
+  new Error(`Project "${project}" is inactive (idle). Un-idle it first, then retry.`);
+
+const BATCH_ACTIVE_CAVEAT =
+  "Trigger-lifecycle decisions depend on /api/batch-active, which (pre-#864) can still report active:true after Head clears the queue — don't treat it as authoritative for 'work remaining'.";
+
+module.exports = {
+  defs: [
+    {
+      name: "start_batch",
+      description:
+        "Start the SCHEDULED trigger that drives a project's batch — fires a trigger message every `interval_min` minutes (default 30), optionally auto-stopping after `duration_min` minutes (default 0 = run indefinitely). The first pulse is at T+interval, not immediately (use trigger_now for an immediate one). Define the batch first with set_batch/append_batch (#793). Only the fields you pass are persisted to the project: an omitted interval/duration/message is NOT saved — later pulses reuse the project's existing trigger_message / interval. Rejected if the project is idle (un-idle it first). " +
+        BATCH_ACTIVE_CAVEAT,
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+          interval_min: { type: "number", description: "Minutes between trigger pulses (default 30)." },
+          duration_min: { type: "number", description: "Auto-stop after this many minutes (default 0 = indefinite)." },
+          message: { type: "string", description: "Trigger message to send each pulse (persisted; defaults to the project's existing message)." },
+        },
+        required: ["project"],
+      },
+    },
+    {
+      name: "trigger_now",
+      description:
+        "Fire ONE trigger pulse immediately for a project (a single send-now, separate from the scheduled cadence). Use after defining a batch when you want to kick it off right away instead of waiting for start_batch's first interval. Rejected if the project is idle. " +
+        BATCH_ACTIVE_CAVEAT,
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+        },
+        required: ["project"],
+      },
+    },
+    {
+      name: "stop_batch",
+      description:
+        "Stop a project's scheduled trigger (clears the interval timer). The batch definition in the queue is untouched — only the cadence stops.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+        },
+        required: ["project"],
+      },
+    },
+  ],
+
+  handlers: {
+    start_batch: async (params, ctx) => {
+      const { project, interval_min, duration_min, message } = params;
+      await ctx.assertKnownProject(project);
+      // Map tool field names → endpoint body fields (the endpoint expects
+      // interval/duration/message, NOT *_min). Send only provided fields.
+      const body = {};
+      if (interval_min != null) body.interval = interval_min;
+      if (duration_min != null) body.duration = duration_min;
+      if (message != null) body.message = message;
+      const res = await ctx.httpRequest("POST", `/api/triggers/${encodeURIComponent(project)}/start`, body);
+      if (res && res.idle === true) throw IDLE_REJECTION(project);
+      return res;
+    },
+
+    trigger_now: async (params, ctx) => {
+      const { project } = params;
+      await ctx.assertKnownProject(project);
+      const res = await ctx.httpRequest("POST", `/api/triggers/${encodeURIComponent(project)}/send-now`);
+      if (res && res.idle === true) throw IDLE_REJECTION(project);
+      return res;
+    },
+
+    stop_batch: async (params, ctx) => {
+      const { project } = params;
+      await ctx.assertKnownProject(project);
+      return ctx.httpRequest("POST", `/api/triggers/${encodeURIComponent(project)}/stop`);
+    },
+  },
+};

--- a/server/mcp-operator/tools/triggers.js
+++ b/server/mcp-operator/tools/triggers.js
@@ -14,8 +14,12 @@
 const IDLE_REJECTION = (project) =>
   new Error(`Project "${project}" is inactive (idle). Un-idle it first, then retry.`);
 
-const BATCH_ACTIVE_CAVEAT =
-  "Trigger-lifecycle decisions depend on /api/batch-active, which (pre-#864) can still report active:true after Head clears the queue — don't treat it as authoritative for 'work remaining'.";
+// #794/#880: post-#864, batch-active is authoritative — it follows the live
+// `## Active Batch` lifecycle (once Head clears the queue it reads not-active);
+// batch-progress may still render a just-completed batch (sticky display). Use
+// batch_status to gauge whether work remains before starting/stopping.
+const BATCH_STATUS_NOTE =
+  "Use batch_status to gauge whether work remains: `active` follows the live Active Batch lifecycle (cleared queue → not active) and is authoritative; `progress` may still show a just-completed batch (sticky display).";
 
 module.exports = {
   defs: [
@@ -23,7 +27,7 @@ module.exports = {
       name: "start_batch",
       description:
         "Start the SCHEDULED trigger that drives a project's batch — fires a trigger message every `interval_min` minutes (default 30), optionally auto-stopping after `duration_min` minutes (default 0 = run indefinitely). The first pulse is at T+interval, not immediately (use trigger_now for an immediate one). Define the batch first with set_batch/append_batch (#793). Only the fields you pass are persisted to the project: an omitted interval/duration/message is NOT saved — later pulses reuse the project's existing trigger_message / interval. Rejected if the project is idle (un-idle it first). " +
-        BATCH_ACTIVE_CAVEAT,
+        BATCH_STATUS_NOTE,
       inputSchema: {
         type: "object",
         properties: {
@@ -39,7 +43,7 @@ module.exports = {
       name: "trigger_now",
       description:
         "Fire ONE trigger pulse immediately for a project (a single send-now, separate from the scheduled cadence). Use after defining a batch when you want to kick it off right away instead of waiting for start_batch's first interval. Rejected if the project is idle. " +
-        BATCH_ACTIVE_CAVEAT,
+        BATCH_STATUS_NOTE,
       inputSchema: {
         type: "object",
         properties: {

--- a/server/mcp-operator/tools/triggers.test.js
+++ b/server/mcp-operator/tools/triggers.test.js
@@ -1,0 +1,164 @@
+"use strict";
+
+// #794: tests for the batch-execution tools. Fake backend records method/path/
+// body so we can assert the renamed fields (interval/duration, not *_min), that
+// unknown projects make NO request (no timer/orphan), and that idle responses
+// surface a clear rejection. (Per the ticket's safety note: NEVER exercise the
+// real :8400 — these mutate live state; the fake server is disposable.)
+
+const http = require("http");
+const { createContext } = require("../context");
+const triggers = require("./triggers");
+
+const handlers = triggers.handlers;
+
+const FAKE_CONFIG = {
+  projects: [{ id: "plotlink", name: "PlotLink", repo: "realproject7/plotlink", agents: { head: {}, dev: {} } }],
+};
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log(`  PASS: ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+// `idleProjects` is a set of project ids the fake backend treats as idle.
+function startServer(idleProjects = new Set()) {
+  const requests = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        let body;
+        try {
+          body = raw ? JSON.parse(raw) : undefined;
+        } catch {
+          body = undefined;
+        }
+        requests.push({ method: req.method, url: req.url, body });
+        const send = (obj, status = 200) => {
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(obj));
+        };
+        if (req.method === "GET" && req.url.startsWith("/api/config")) return send(FAKE_CONFIG);
+        const m = req.url.match(/^\/api\/triggers\/([^/]+)\/(start|send-now|stop)$/);
+        if (req.method === "POST" && m) {
+          const project = decodeURIComponent(m[1]);
+          const action = m[2];
+          const idle = idleProjects.has(project);
+          if (action === "start") {
+            if (idle) return send({ ok: false, idle: true, enabled: false });
+            return send({ ok: true, enabled: true, interval: 1800000, nextAt: 1, expiresAt: null });
+          }
+          if (action === "send-now") {
+            if (idle) return send({ ok: false, idle: true, sent: false });
+            return send({ ok: true, sent: true });
+          }
+          if (action === "stop") return send({ ok: true, enabled: false });
+        }
+        return send({ error: "not found" }, 404);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests }));
+  });
+}
+
+async function expectThrows(fn) {
+  try {
+    await fn();
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function runTests() {
+  console.log("\n--- MCP Operator Batch-Execution Tests (#794) ---\n");
+
+  // ── start_batch: field rename + only-provided fields ────────────────────
+  {
+    const { server, port, requests } = await startServer();
+    const ctx = createContext(port);
+    requests.length = 0;
+    const res = await handlers.start_batch({ project: "plotlink", interval_min: 15, duration_min: 180 }, ctx);
+    assert(res && res.enabled === true, "start_batch returns the enabled trigger info");
+    const post = requests.find((r) => r.method === "POST" && r.url.endsWith("/start"));
+    assert(post && post.url === "/api/triggers/plotlink/start", "start_batch POSTs to /api/triggers/<project>/start");
+    assert(post.body.interval === 15 && post.body.duration === 180, "start_batch maps interval_min→interval, duration_min→duration");
+    assert(!("interval_min" in post.body) && !("duration_min" in post.body), "start_batch does NOT send *_min keys");
+    assert(!("message" in post.body), "start_batch omits absent fields (no message key)");
+    server.close();
+  }
+
+  // ── start_batch: only message provided → body has message only ──────────
+  {
+    const { server, port, requests } = await startServer();
+    const ctx = createContext(port);
+    requests.length = 0;
+    await handlers.start_batch({ project: "plotlink", message: "@head go" }, ctx);
+    const post = requests.find((r) => r.method === "POST" && r.url.endsWith("/start"));
+    assert(post.body.message === "@head go" && !("interval" in post.body) && !("duration" in post.body), "start_batch sends only the provided message field");
+    server.close();
+  }
+
+  // ── trigger_now + stop_batch happy paths ────────────────────────────────
+  {
+    const { server, port, requests } = await startServer();
+    const ctx = createContext(port);
+    requests.length = 0;
+    const fired = await handlers.trigger_now({ project: "plotlink" }, ctx);
+    assert(fired && fired.sent === true, "trigger_now fires a pulse (sent:true)");
+    assert(requests.some((r) => r.method === "POST" && r.url === "/api/triggers/plotlink/send-now"), "trigger_now POSTs to /send-now");
+
+    const stopped = await handlers.stop_batch({ project: "plotlink" }, ctx);
+    assert(stopped && stopped.enabled === false, "stop_batch returns enabled:false");
+    assert(requests.some((r) => r.method === "POST" && r.url === "/api/triggers/plotlink/stop"), "stop_batch POSTs to /stop");
+    server.close();
+  }
+
+  // ── idle handling: start_batch + trigger_now surface a clear rejection ──
+  {
+    const { server, port } = await startServer(new Set(["plotlink"]));
+    const ctx = createContext(port);
+    const startErr = await expectThrows(() => handlers.start_batch({ project: "plotlink" }, ctx));
+    assert(startErr && /inactive \(idle\)/i.test(startErr.message), "start_batch on idle project throws the inactive rejection");
+    const fireErr = await expectThrows(() => handlers.trigger_now({ project: "plotlink" }, ctx));
+    assert(fireErr && /inactive \(idle\)/i.test(fireErr.message), "trigger_now on idle project throws the inactive rejection");
+    server.close();
+  }
+
+  // ── unknown project → error, NO request (no timer / orphan) ──────────────
+  {
+    const { server, port, requests } = await startServer();
+    const ctx = createContext(port);
+    for (const [name, fn] of [
+      ["start_batch", () => handlers.start_batch({ project: "ghost" }, ctx)],
+      ["trigger_now", () => handlers.trigger_now({ project: "ghost" }, ctx)],
+      ["stop_batch", () => handlers.stop_batch({ project: "ghost" }, ctx)],
+    ]) {
+      requests.length = 0;
+      const err = await expectThrows(fn);
+      assert(
+        err && err.message === "Unknown project: ghost. Use list_projects to see valid ids.",
+        `${name} on unknown project throws the clean error`
+      );
+      assert(!requests.some((r) => r.url.includes("/triggers/")), `${name} on unknown project makes NO trigger request (no timer)`);
+    }
+    server.close();
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds the batch-execution tools — start/stop the scheduled trigger that drives a batch, and fire a single pulse on demand. `set_batch`/`append_batch` (#793) **define** the work; these **run** it. Parent epic #789, Tier 2 (act). Builds on the #790 scaffold.

New file **`server/mcp-operator/tools/triggers.js`** — auto-merged by #790's loader, **no edits to existing tool files**.

## Validate-first (the backend does NOT)
`POST /api/triggers/:project/start` creates a `setInterval` for **any** `:project` string (it doesn't reject unknown ids), and `send-now` can create a stray `~/.quadwork/<id>/` chat file. So **every tool calls `assertKnownProject(project)` before its HTTP call** — unknown id → clean error, **no request, no timer**.

## Tools
- **`start_batch` `{ project, interval_min?, duration_min?, message? }`** — maps tool fields → endpoint body (`interval_min→interval`, `duration_min→duration`, `message→message`), sends **only the provided (renamed) fields**. Detects the idle response (`{idle:true, enabled:false}`) and throws a clear **"project inactive (idle) — un-idle first"** rejection (not a generic success/failure). Description documents the defaults (`interval` 30, `duration` 0 = indefinite), that **omitted fields are NOT persisted**, and the #864 batch-active caveat. Returns `{ ok, enabled, interval, nextAt, expiresAt }`.
- **`trigger_now` `{ project }`** — `POST /send-now` (one immediate pulse); same idle rejection (`{idle:true, sent:false}`). Returns `{ ok, sent }`.
- **`stop_batch` `{ project }`** — `POST /stop` → `{ ok, enabled:false }`.
- `:project` is `encodeURIComponent`'d throughout.

## Verification
- **`triggers.test.js` — 18/18 pass**, against a **disposable fake server** (never the live `:8400`, per the ticket's safety note): field rename + only-provided-fields (incl. message-only); `trigger_now`/`stop_batch` paths; **idle rejection** for `start_batch` + `trigger_now`; and **unknown-project → error with NO trigger request** (no timer) for all three.
- `npm test` → **36 passed, 0 failed, 2 skipped**.
- `npm run build` → green.
- `tools/list` over stdio registers all 12 operator tools (`start_batch, stop_batch, trigger_now` added) — no edit to `mcp-operator.js`.

## Dependencies
- Requires #790 (merged). #864 for trustworthy batch-lifecycle accuracy — shipped with the documented caveat until it lands.

Closes #794.

🤖 Generated with [Claude Code](https://claude.com/claude-code)