### PR TITLE
[#795] Operator MCP: agent control (agent_control, interrupt_all)

### DIFF
--- a/server/mcp-operator/tools/agents.js
+++ b/server/mcp-operator/tools/agents.js
@@ -1,0 +1,70 @@
+"use strict";
+
+// #795: non-destructive agent lifecycle control (Tier 2 — act). start / stop /
+// restart / interrupt an individual agent, and interrupt a whole project. New
+// file under tools/ — additive, auto-merged by #790's loader, no edits to
+// existing modules. Destructive ops (full_reset, reset, raw PTY write) are
+// intentionally OUT of scope — the action allow-list keeps those endpoints
+// unreachable from this tool.
+
+// The ONLY actions agent_control will route. The path is built from this
+// validated value — never from arbitrary input — so `full-reset` / `reset` /
+// `write` can't be reached.
+const ACTIONS = ["start", "stop", "restart", "interrupt"];
+const ACTION_SET = new Set(ACTIONS);
+
+module.exports = {
+  defs: [
+    {
+      name: "agent_control",
+      description:
+        "Control a single agent's lifecycle. action is one of: start (spawn the PTY session), stop (terminate the PTY session), restart (stop + start), interrupt (send Ctrl+C — does NOT kill the process, just interrupts what it's doing). Non-destructive only — reset / full-reset / raw writes are not available here. Returns the endpoint response ({ ok, state, pid } for start/restart; { ok } for interrupt).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+          agent: { type: "string", description: "Agent id (head/dev/re1/re2 — from list_agents)." },
+          action: { type: "string", enum: ACTIONS, description: "start | stop | restart | interrupt." },
+        },
+        required: ["project", "agent", "action"],
+      },
+    },
+    {
+      name: "interrupt_all",
+      description:
+        "Send Ctrl+C to EVERY running agent in a project (interrupts what they're doing; does not kill the sessions). Returns { ok, interrupted } — the count of agents interrupted.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string", description: "Project id (from list_projects)." },
+        },
+        required: ["project"],
+      },
+    },
+  ],
+
+  handlers: {
+    agent_control: async (params, ctx) => {
+      const { project, agent, action } = params;
+      // Validate in order, all BEFORE the action HTTP call. The backend does
+      // NOT validate the agent (stop returns ok for any string; interrupt only
+      // checks runtime sessions), so assertKnownAgent is load-bearing.
+      await ctx.assertKnownProject(project);
+      await ctx.assertKnownAgent(project, agent);
+      if (!ACTION_SET.has(action)) {
+        throw new Error(`Invalid action: ${action}. Must be one of: ${ACTIONS.join(", ")}.`);
+      }
+      // Path built only from the validated allow-list action + encoded params.
+      return ctx.httpRequest(
+        "POST",
+        `/api/agents/${encodeURIComponent(project)}/${encodeURIComponent(agent)}/${action}`,
+      );
+    },
+
+    interrupt_all: async (params, ctx) => {
+      const { project } = params;
+      await ctx.assertKnownProject(project);
+      return ctx.httpRequest("POST", `/api/agents/${encodeURIComponent(project)}/interrupt-all`);
+    },
+  },
+};

--- a/server/mcp-operator/tools/agents.test.js
+++ b/server/mcp-operator/tools/agents.test.js
@@ -1,0 +1,132 @@
+"use strict";
+
+// #795: tests for the agent-control tools. Fake backend records method/path so
+// we can assert each valid action hits the right path, destructive actions are
+// rejected before any HTTP call, and unknown agent/project make NO request.
+// (Per the ticket's safety note: NEVER the live :8400 — these mutate live agent
+// state; the fake server is disposable.)
+
+const http = require("http");
+const { createContext } = require("../context");
+const agents = require("./agents");
+
+const handlers = agents.handlers;
+
+const FAKE_CONFIG = {
+  projects: [{ id: "plotlink", name: "PlotLink", repo: "realproject7/plotlink", agents: { head: {}, dev: {}, re1: {}, re2: {} } }],
+};
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log(`  PASS: ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+function startServer() {
+  const requests = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        requests.push({ method: req.method, url: req.url });
+        const send = (obj, status = 200) => {
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(obj));
+        };
+        if (req.method === "GET" && req.url.startsWith("/api/config")) return send(FAKE_CONFIG);
+        if (req.method === "POST" && /^\/api\/agents\/[^/]+\/[^/]+\/(start|restart)$/.test(req.url)) {
+          return send({ ok: true, state: "running", pid: 4242 });
+        }
+        if (req.method === "POST" && /^\/api\/agents\/[^/]+\/[^/]+\/stop$/.test(req.url)) {
+          return send({ ok: true, state: "stopped" });
+        }
+        if (req.method === "POST" && /^\/api\/agents\/[^/]+\/[^/]+\/interrupt$/.test(req.url)) {
+          return send({ ok: true });
+        }
+        if (req.method === "POST" && /^\/api\/agents\/[^/]+\/interrupt-all$/.test(req.url)) {
+          return send({ ok: true, interrupted: 3 });
+        }
+        return send({ error: "not found" }, 404);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests }));
+  });
+}
+
+async function expectThrows(fn) {
+  try {
+    await fn();
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function runTests() {
+  console.log("\n--- MCP Operator Agent-Control Tests (#795) ---\n");
+
+  const { server, port, requests } = await startServer();
+  const ctx = createContext(port);
+
+  // ── agent_control: each valid action hits the right path ────────────────
+  for (const action of ["start", "stop", "restart", "interrupt"]) {
+    requests.length = 0;
+    const res = await handlers.agent_control({ project: "plotlink", agent: "dev", action }, ctx);
+    const post = requests.find((r) => r.method === "POST" && r.url.includes("/api/agents/"));
+    assert(post && post.url === `/api/agents/plotlink/dev/${action}`, `agent_control '${action}' POSTs to /api/agents/plotlink/dev/${action}`);
+    assert(res && res.ok === true, `agent_control '${action}' returns the endpoint response`);
+  }
+
+  // ── invalid action → rejected BEFORE any HTTP call ──────────────────────
+  for (const bad of ["full-reset", "reset", "write", "destroy", ""]) {
+    requests.length = 0;
+    const err = await expectThrows(() => handlers.agent_control({ project: "plotlink", agent: "dev", action: bad }, ctx));
+    assert(err && /Invalid action/.test(err.message), `invalid action '${bad}' → tool error`);
+    assert(!requests.some((r) => r.method === "POST"), `invalid action '${bad}' → NO HTTP call (destructive endpoint unreachable)`);
+  }
+
+  // ── unknown agent (valid project) → rejected via assertKnownAgent, NO call ─
+  {
+    requests.length = 0;
+    const err = await expectThrows(() => handlers.agent_control({ project: "plotlink", agent: "ghost", action: "stop" }, ctx));
+    assert(err && err.message === "Unknown agent: ghost in plotlink.", "unknown agent → clean assertKnownAgent error");
+    assert(!requests.some((r) => r.method === "POST"), "unknown agent → NO HTTP call");
+  }
+
+  // ── unknown project → rejected, NO call ─────────────────────────────────
+  {
+    requests.length = 0;
+    const err = await expectThrows(() => handlers.agent_control({ project: "ghost", agent: "dev", action: "stop" }, ctx));
+    assert(err && err.message === "Unknown project: ghost. Use list_projects to see valid ids.", "unknown project → clean error");
+    assert(!requests.some((r) => r.method === "POST"), "unknown project → NO HTTP call");
+  }
+
+  // ── interrupt_all ───────────────────────────────────────────────────────
+  {
+    requests.length = 0;
+    const res = await handlers.interrupt_all({ project: "plotlink" }, ctx);
+    assert(res && res.interrupted === 3, "interrupt_all returns { ok, interrupted }");
+    assert(requests.some((r) => r.method === "POST" && r.url === "/api/agents/plotlink/interrupt-all"), "interrupt_all POSTs to /api/agents/<project>/interrupt-all");
+
+    requests.length = 0;
+    const err = await expectThrows(() => handlers.interrupt_all({ project: "ghost" }, ctx));
+    assert(err && /Unknown project/.test(err.message), "interrupt_all unknown project → error");
+    assert(!requests.some((r) => r.method === "POST"), "interrupt_all unknown project → NO HTTP call");
+  }
+
+  server.close();
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds **non-destructive** agent lifecycle control — start/stop/restart/interrupt an individual agent, and interrupt a whole project. Destructive ops (`full_reset`, `reset`, raw PTY `write`) are intentionally **out of scope** and kept unreachable. Parent epic #789, Tier 2 (act). Builds on the #790 scaffold.

New file **`server/mcp-operator/tools/agents.js`** — auto-merged by #790's loader, **no edits to existing tool files**.

## Tools
- **`agent_control` `{ project, agent, action }`** — validates **in order, all before the action HTTP call**:
  1. `assertKnownProject(project)`
  2. `assertKnownAgent(project, agent)` — **load-bearing**: the backend's `stop` returns `{ok:true,state:"stopped"}` for *any* `:agent` string (`index.js:750`) and `interrupt` only checks runtime sessions, so the configured `project.agents` keys are the source of truth.
  3. `action` against the exact allow-list `start | stop | restart | interrupt`.
  The path is built **only from the validated allow-list action** (+ `encodeURIComponent`'d params), so `full-reset` / `reset` / `write` can't be reached. Returns the endpoint response (`{ ok, state, pid }` for start/restart; `{ ok }` for interrupt).
- **`interrupt_all` `{ project }`** — `assertKnownProject` → `POST /api/agents/:project/interrupt-all` (Ctrl+C to every running agent). Returns `{ ok, interrupted }`.

Descriptions clarify: `interrupt` = Ctrl+C (does not kill the process), `stop` = terminate the PTY session, `restart` = stop + start.

## Verification
- **`agents.test.js` — 26/26 pass**, against a **disposable fake server** (never the live `:8400`, per the ticket's safety note): each valid action → correct path; **invalid action** (`full-reset`/`reset`/`write`/arbitrary/empty) → error with **NO HTTP call** (destructive endpoints unreachable); **unknown agent** (valid project) → clean `assertKnownAgent` error, **NO call**; unknown project → error, no call; `interrupt_all` path + unknown-project guard.
- `npm test` → **37 passed, 0 failed, 2 skipped**.
- `npm run build` → green.
- `tools/list` over stdio registers all **14** operator tools (`agent_control, interrupt_all` added) — no edit to `mcp-operator.js`.

## Dependencies
- Requires #790 (merged) — scaffold, `httpRequest`, `assertKnownProject`, `assertKnownAgent`.

Closes #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)