### PR TITLE
[#796] Operator MCP: error handling, tests, registration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Step-by-step guides for setting up QuadWork, designed for both humans and AI cod
 - **[Windows Installation](docs/install-windows.md)** — local setup via WSL2 (Windows Subsystem for Linux)
 - **[VPS Installation](docs/install-vps.md)** — remote server (Hetzner/Ubuntu) with domain + SSL
 - **[Troubleshooting](docs/troubleshooting.md)** — common issues and fixes
+- **[Operator MCP](docs/operator-mcp.md)** — drive QuadWork from a Claude agent (`claude mcp add quadwork -- quadwork-mcp-operator --port 8400`)
 
 > **For AI agents:** These guides contain complete step-by-step instructions. When your operator asks you to install or troubleshoot QuadWork, read the relevant guide and follow it.
 

--- a/docs/operator-mcp.md
+++ b/docs/operator-mcp.md
@@ -1,0 +1,89 @@
+# Drive QuadWork from a Claude agent (Operator MCP)
+
+QuadWork ships an **MCP operator server** — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that lets a Claude agent (Claude Code or Claude Desktop) **observe and drive** a running QuadWork instance: read team chat and batch progress, define and run overnight batches, and control individual agents.
+
+It is the same surface a human operator uses from the dashboard, exposed as tools. It talks to the QuadWork backend over `http://127.0.0.1:<port>` (default **8400**) and is launched by the MCP client, **not** by QuadWork itself.
+
+> **The MCP client must run on the same machine as QuadWork.** The server only reaches `127.0.0.1:<port>` — see [Remote / VPS](#remote--vps-registration) below.
+
+## Registration
+
+The package installs a dedicated bin, `quadwork-mcp-operator`. Always register with the bin (never a `<quadwork-dir>/server/...` path — that breaks on global/VPS installs).
+
+### Claude Code (local install)
+
+```bash
+claude mcp add quadwork -- quadwork-mcp-operator --port 8400
+```
+
+Then, in a Claude Code session, the `list_projects`, `batch_status`, `start_batch`, … tools are available. Verify with `list_projects` — it should return your configured projects.
+
+### Claude Desktop
+
+Add this to your `claude_desktop_config.json` (Settings → Developer → Edit Config):
+
+```json
+{
+  "mcpServers": {
+    "quadwork": {
+      "command": "quadwork-mcp-operator",
+      "args": ["--port", "8400"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The QuadWork tools appear under the 🔌 tools menu.
+
+### Remote / VPS registration
+
+The operator server speaks to `127.0.0.1:8400` — the loopback of **whatever machine the MCP client runs on**. If QuadWork runs on a VPS, a Claude Desktop registration on your laptop reaches **your laptop's** `127.0.0.1`, not the VPS. Two ways to register correctly:
+
+1. **Run Claude Code over SSH on the VPS host** — register there with the same command; it reaches the VPS's local QuadWork directly.
+   ```bash
+   ssh you@your-vps
+   claude mcp add quadwork -- quadwork-mcp-operator --port 8400
+   ```
+2. **SSH-forward the port to your local machine**, then register against the forwarded port:
+   ```bash
+   ssh -L 8400:127.0.0.1:8400 you@your-vps
+   # in another local shell, register against the forwarded localhost port:
+   claude mcp add quadwork -- quadwork-mcp-operator --port 8400
+   ```
+
+> ⚠️ **A local Claude Desktop registration reaches THIS device's `127.0.0.1`, not the VPS.** Use SSH or a port-forward so the client and QuadWork share a loopback.
+
+## Tool reference
+
+### Tier 1 — read / observe (no state change)
+
+| Tool | Input | Does |
+|------|-------|------|
+| `list_projects` | — | List configured projects (`id`, `name`, `repo`). |
+| `read_chat` | `project`, `since_id?`, `limit?` | Read a project's team chat (messages with `id`, `sender`, `text`, ISO `ts`). |
+| `batch_status` | `project` | Overnight-batch status `{ active, progress }` (merged batch-active + batch-progress). |
+| `read_queue` | `project` | Read the project's `OVERNIGHT-QUEUE.md` markdown. |
+| `list_agents` | `project?` | List every configured agent (config ∪ runtime) with state `running`/`stopped`/`missing`. |
+
+### Tier 2 — act
+
+| Tool | Input | Does |
+|------|-------|------|
+| `send_message` | `project`, `text` | Post to the team chat **as the operator** (see security note). |
+| `set_batch` | `project`, `content` | Replace `OVERNIGHT-QUEUE.md` (full overwrite). |
+| `append_batch` | `project`, `content` | Append to the queue (read-then-write). |
+| `ensure_batch` | `project` | Create the queue from template if absent (idempotent). |
+| `start_batch` | `project`, `interval_min?`, `duration_min?`, `message?` | Start the scheduled trigger that drives the batch. |
+| `trigger_now` | `project` | Fire one trigger pulse immediately. |
+| `stop_batch` | `project` | Stop the scheduled trigger. |
+| `agent_control` | `project`, `agent`, `action` | Non-destructive lifecycle: `start` / `stop` / `restart` / `interrupt` (Ctrl+C). |
+| `interrupt_all` | `project` | Send Ctrl+C to every running agent in the project. |
+
+Typical flow: `set_batch` / `append_batch` to define the work → `start_batch` for a scheduled cadence, or `trigger_now` for a single immediate pulse → `batch_status` to watch progress.
+
+## Security
+
+- **stdio + localhost only, no auth by design.** The server trusts the local machine, exactly like the agent chat shim. **Do not expose this server (or the QuadWork backend port) over a network without adding authentication** — that's a future epic.
+- **`send_message` acts as the human operator.** Messages post with sender `user`, which **resets the chat loop guard** (same as typing in the dashboard). Use it deliberately — `@head do X` wakes Head via the dispatcher.
+- **Destructive operations are intentionally NOT exposed** in this epic: no full reset, no agent-config reset, no raw PTY writes. `agent_control` is limited to the `start`/`stop`/`restart`/`interrupt` allow-list.
+- Unknown project / agent ids are rejected client-side **before** any HTTP call, so a typo can't create stray `~/.quadwork/<id>/` state or a runaway trigger timer.

--- a/server/mcp-operator.test.js
+++ b/server/mcp-operator.test.js
@@ -86,6 +86,56 @@ function sendJsonRpc(proc, msg) {
   proc.stdin.write(JSON.stringify(msg) + "\n");
 }
 
+// #796: a fake QuadWork that serves every endpoint the tools hit and records
+// { method, path, url, headers } per request — for the consolidated table-driven
+// cross-tool pass below.
+function startFullServer() {
+  const requests = [];
+  const CONFIG = { projects: [{ id: "p", name: "P", repo: "o/r", agents: { dev: {} } }] };
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        const pathOnly = req.url.split("?")[0];
+        requests.push({ method: req.method, path: pathOnly, url: req.url, headers: req.headers });
+        const send = (obj, status = 200) => {
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(obj));
+        };
+        if (req.method === "GET" && pathOnly === "/api/config") return send(CONFIG);
+        if (pathOnly === "/api/chat") return req.method === "GET" ? send([]) : send({ ok: true, message: { id: 1, sender: "user" } });
+        if (pathOnly === "/api/batch-active") return send({ active: false });
+        if (pathOnly === "/api/batch-progress") return send({ items: [] });
+        if (pathOnly === "/api/queue") {
+          if (req.method === "GET") return send({ ok: true, exists: true, content: "x" });
+          if (req.method === "PUT") return send({ ok: true });
+          if (req.method === "POST") return send({ ok: true, existed: true });
+        }
+        if (req.method === "GET" && pathOnly === "/api/agents") return send({});
+        if (req.method === "POST" && /^\/api\/triggers\/[^/]+\/start$/.test(pathOnly)) return send({ ok: true, enabled: true });
+        if (req.method === "POST" && /^\/api\/triggers\/[^/]+\/send-now$/.test(pathOnly)) return send({ ok: true, sent: true });
+        if (req.method === "POST" && /^\/api\/triggers\/[^/]+\/stop$/.test(pathOnly)) return send({ ok: true, enabled: false });
+        if (req.method === "POST" && /^\/api\/agents\/[^/]+\/interrupt-all$/.test(pathOnly)) return send({ ok: true, interrupted: 0 });
+        if (req.method === "POST" && /^\/api\/agents\/[^/]+\/[^/]+\/(start|stop|restart|interrupt)$/.test(pathOnly)) return send({ ok: true, state: "running" });
+        return send({ error: "not found" }, 404);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests }));
+  });
+}
+
+// #796: serve a fixed status + body for the error-mapping cases.
+function startStatusServer(status, body, contentType = "application/json") {
+  return new Promise((resolve) => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(status, { "Content-Type": contentType });
+      res.end(typeof body === "string" ? body : JSON.stringify(body));
+    });
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port }));
+  });
+}
+
 function readResponse(proc) {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error("Timeout waiting for response")), 5000);
@@ -219,6 +269,94 @@ async function runTests() {
   );
 
   cfg2.close();
+
+  // ── 6. Consolidated cross-tool pass (#796) ──────────────────────────────
+  // Every tool proxies to the right endpoint+method; error mapping; and every
+  // ACTING tool rejects an unknown project before any acting HTTP call.
+  const HANDLERS = Object.assign(
+    {},
+    ...["projects", "read", "chat-send", "batch", "triggers", "agents"].map((m) => require(`./mcp-operator/tools/${m}`).handlers),
+  );
+  const full = await startFullServer();
+  const fctx = createContext(full.port);
+  const reqs = full.requests;
+  const actionReqs = () => reqs.filter((r) => r.path !== "/api/config"); // exclude assert*/getConfiguredProjects reads
+
+  const CASES = [
+    { tool: "list_projects", args: {}, expect: [["GET", "/api/config"]] },
+    { tool: "read_chat", args: { project: "p", since_id: 1, limit: 5 }, expect: [["GET", "/api/chat"]] },
+    { tool: "batch_status", args: { project: "p" }, expect: [["GET", "/api/batch-active"], ["GET", "/api/batch-progress"]] },
+    { tool: "read_queue", args: { project: "p" }, expect: [["GET", "/api/queue"]] },
+    { tool: "list_agents", args: { project: "p" }, expect: [["GET", "/api/agents"]] },
+    { tool: "send_message", args: { project: "p", text: "hi" }, expect: [["POST", "/api/chat"]] },
+    { tool: "set_batch", args: { project: "p", content: "x" }, expect: [["PUT", "/api/queue"]] },
+    { tool: "append_batch", args: { project: "p", content: "x" }, expect: [["GET", "/api/queue"], ["PUT", "/api/queue"]] },
+    { tool: "ensure_batch", args: { project: "p" }, expect: [["POST", "/api/queue"]] },
+    { tool: "start_batch", args: { project: "p" }, expect: [["POST", "/api/triggers/p/start"]] },
+    { tool: "trigger_now", args: { project: "p" }, expect: [["POST", "/api/triggers/p/send-now"]] },
+    { tool: "stop_batch", args: { project: "p" }, expect: [["POST", "/api/triggers/p/stop"]] },
+    { tool: "agent_control", args: { project: "p", agent: "dev", action: "restart" }, expect: [["POST", "/api/agents/p/dev/restart"]] },
+    { tool: "interrupt_all", args: { project: "p" }, expect: [["POST", "/api/agents/p/interrupt-all"]] },
+  ];
+  for (const c of CASES) {
+    reqs.length = 0;
+    await HANDLERS[c.tool](c.args, fctx);
+    // Full request list here — list_projects' own action IS /api/config; for
+    // other tools an extra /api/config (assertKnownProject) is harmless since we
+    // only assert the expected action paths are PRESENT.
+    const got = reqs.map((r) => `${r.method} ${r.path}`);
+    const want = c.expect.map(([m, p]) => `${m} ${p}`);
+    assert(want.every((w) => got.includes(w)), `${c.tool} proxies to ${want.join(" + ")} (got: ${got.join(", ") || "none"})`);
+  }
+
+  // list_projects returns only id/name/repo (no token/other-field leakage)
+  const projOut = await HANDLERS.list_projects({}, fctx);
+  assert(Object.keys(projOut[0]).sort().join(",") === "id,name,repo", "list_projects returns only id/name/repo (no leakage)");
+
+  // send_message sends no sender header (records as operator "user")
+  reqs.length = 0;
+  await HANDLERS.send_message({ project: "p", text: "hi" }, fctx);
+  const sendReq = reqs.find((r) => r.method === "POST" && r.path === "/api/chat");
+  assert(sendReq && !("x-chat-sender" in sendReq.headers) && !("x-bridge-sender" in sendReq.headers), "send_message sends no x-chat-sender / x-bridge-sender header");
+
+  // agent_control rejects out-of-allow-list action with NO HTTP call
+  reqs.length = 0;
+  const badAction = await expectThrows(() => HANDLERS.agent_control({ project: "p", agent: "dev", action: "full-reset" }, fctx));
+  assert(badAction && /Invalid action/.test(badAction.message), "agent_control rejects an out-of-allow-list action");
+  assert(!actionReqs().some((r) => r.path.startsWith("/api/agents/p/dev")), "agent_control invalid action makes NO agent HTTP call");
+
+  // Every acting tool rejects an unknown project (assert*) with no acting call
+  const ACTING = [
+    ["read_chat", { project: "ghost" }],
+    ["batch_status", { project: "ghost" }],
+    ["read_queue", { project: "ghost" }],
+    ["send_message", { project: "ghost", text: "x" }],
+    ["set_batch", { project: "ghost", content: "x" }],
+    ["append_batch", { project: "ghost", content: "x" }],
+    ["ensure_batch", { project: "ghost" }],
+    ["start_batch", { project: "ghost" }],
+    ["trigger_now", { project: "ghost" }],
+    ["stop_batch", { project: "ghost" }],
+    ["agent_control", { project: "ghost", agent: "dev", action: "stop" }],
+    ["interrupt_all", { project: "ghost" }],
+  ];
+  for (const [name, args] of ACTING) {
+    reqs.length = 0;
+    const err = await expectThrows(() => HANDLERS[name](args, fctx));
+    assert(err && /Unknown (project|agent)/.test(err.message) && actionReqs().length === 0, `${name} rejects unknown project (assert*) with NO acting HTTP call`);
+  }
+  full.server.close();
+
+  // ── 7. Error mapping: non-2xx with {error} and without JSON ─────────────
+  const srv404 = await startStatusServer(404, { error: "boom from server" });
+  const e1 = await expectThrows(() => createContext(srv404.port).httpRequest("GET", "/x"));
+  assert(e1 && e1.message === "boom from server", "non-2xx with JSON {error} surfaces the error text");
+  srv404.server.close();
+
+  const srvHtml = await startStatusServer(404, "not json", "text/plain");
+  const e2 = await expectThrows(() => createContext(srvHtml.port).httpRequest("GET", "/y"));
+  assert(e2 && e2.message === "GET /y failed: HTTP 404", "non-2xx without JSON maps to '<method> <path> failed: HTTP <status>'");
+  srvHtml.server.close();
 
   console.log(`\n${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Final item of the operator-MCP epic (#789) — a consolidated cross-tool test pass and operator-facing registration docs. Core request hardening (5s timeout, ECONNREFUSED/timeout/non-2xx mapping) already shipped in #790, so this verifies + fills gaps and writes the docs.

## Error handling (verified + gap-filled)
Confirmed across all tools (baseline in #790), and **added the missing non-2xx mapping cases**:
- ECONNREFUSED → `"QuadWork is not running on port <port>. Start it first."` (covered)
- 5s `AbortSignal` timeout → clean message (covered)
- **non-2xx with JSON `{error}` → surfaces `error`** ✅ (added)
- **non-2xx without JSON → `"<method> <path> failed: HTTP <status>"`** ✅ (added)
- `assertKnownProject` consistent across every acting tool ✅
- a rejected handler never crashes the stdio loop ✅ (covered)

## Tests (`server/mcp-operator.test.js` — consolidated, **50 assertions pass**)
- **Table-driven:** all **14 tools** proxy to the correct endpoint + method (incl. `append_batch`'s read-then-PUT and `batch_status`'s two GETs).
- `list_projects` returns only `id/name/repo` (no token/other-field leakage).
- `send_message` sends **no** `x-chat-sender`/`x-bridge-sender` header.
- `agent_control` rejects out-of-allow-list actions with **no HTTP call**.
- **Every acting tool** (12) rejects an unknown project via `assertKnownProject` with **no acting HTTP call**.
- Error mapping: 404-with-`{error}`, 404-without-JSON, ECONNREFUSED, timeout.

(The focused per-tool tests — `read`/`chat-send`/`batch`/`triggers`/`agents`/`projects` — remain and still pass; this adds a single consolidated entrypoint over all of them.)

## Docs (`docs/operator-mcp.md` + README pointer)
"**Drive QuadWork from a Claude agent**" — uses the packaged **`quadwork-mcp-operator` bin** throughout (never a `<quadwork-dir>/server/...` path):
- **Claude Code:** `claude mcp add quadwork -- quadwork-mcp-operator --port 8400`
- **Claude Desktop:** the equivalent `mcpServers` JSON block.
- **VPS / remote:** run Claude Code over SSH on the host, **or** `ssh -L 8400:127.0.0.1:8400`, with the explicit warning that a local Claude Desktop registration reaches **this device's** `127.0.0.1`, not the VPS.
- **Tier 1 + Tier 2 tool reference tables** (14 tools, one-line each).
- **Security note:** stdio + localhost only, no auth by design, don't expose over a network; `send_message` acts as the operator + resets the loop guard; destructive ops intentionally not exposed.

README links it from the Installation Guides list for discoverability.

## Verification
- `node server/mcp-operator.test.js` → **50 passed, 0 failed**.
- `npm test` → **37 passed, 0 failed, 2 skipped**.
- `npm run build` → green.
- Docs grep: only the bin form is used (the single `<quadwork-dir>` mention is the warning *against* it).

## Dependencies
- Requires #790–#795 (all merged).

Closes #796. This completes the operator-MCP epic (#789).

🤖 Generated with [Claude Code](https://claude.com/claude-code)