### PR TITLE
[#893] Reviewer rate-limit badge: resolve custom reviewer-token paths via the reseed resolver

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -67,13 +67,16 @@ const _searchRateLimit = {
   resetAt: 0,        // epoch ms
   updatedAt: 0,      // epoch ms when we last fetched
 };
-// #886: the reviewer-token account is a SEPARATE, per-account GitHub rate-limit
-// budget (reviewers run gh as `reviewer_github_user`). Polled with the reviewer
-// token in a second exempt `rate_limit` call. Null until a reviewer token is
-// configured + resolves — single-account setups stay null and the badge shows
-// nothing extra. Shape: { login, core, graphql, search } where each bucket is
-// { limit, remaining, resetAt(ms) }, plus updatedAt/error.
-let _reviewerRateLimit = null;
+// #886/#893: the reviewer-token account is a SEPARATE, per-account GitHub
+// rate-limit budget (reviewers run gh as a different account). #893 makes this
+// project-aware: the reviewer token path is resolved per project from that
+// project's reviewer worktree AGENTS.md (the path reseed preserves), so a custom
+// per-worktree token is monitored — not just cfg/default. Polled on demand from
+// the /api/github/rate-limit endpoint and cached PER TOKEN PATH (exempt
+// rate_limit call → zero billable cost). Entry shape:
+// { ts, login, core, graphql, search, error } where each bucket is
+// { limit, remaining, resetAt(ms) }.
+const _reviewerRateLimitByPath = new Map(); // tokenPath → entry
 const RATE_LIMIT_POLL_MS = 60_000;       // refresh every 60s
 const RATE_LIMIT_LOW_THRESHOLD = 200;    // below this → back off
 const RATE_LIMIT_CRITICAL = 50;          // below this → stop all infra gh calls
@@ -111,29 +114,50 @@ async function refreshRateLimit() {
     _rateLimit.error = err.message;
     _rateLimit.updatedAt = Date.now();
   }
-  // #886: also poll the reviewer-token account (separate budget). Independent
-  // try/catch inside — a reviewer failure never affects the main poll above.
-  await refreshReviewerRateLimit();
+  // #893: the reviewer-token poll is no longer on the timer — it is project-
+  // aware and driven on demand from the /api/github/rate-limit endpoint.
 }
 
-// #886: second exempt `rate_limit` poll as the reviewer-token account, so the
-// dashboard covers BOTH GitHub budgets (per-account, not aggregated). Resolves
-// the reviewer token path the same way reseed does (configured path → default
-// ~/.quadwork/reviewer-token); no token → clears the reviewer state (omitted
-// from the payload, single-account behavior unchanged). `rate_limit` is exempt,
-// so this adds zero billable cost.
-async function refreshReviewerRateLimit() {
+// #893: resolve the reviewer token path for a request. For a known project,
+// the worktree-extracted path WINS (matches reseed's preservation order — it is
+// the actual path that project's reviewer agents currently use): re1's worktree
+// AGENTS.md first, then re2's. Falls back to cfg.reviewer_token_path → default
+// for a no-project / unknown-project request (backward compatible with #886).
+// Returns { path, source: "worktree" | "config" | "default" }.
+function _resolveReviewerTokenPath(projectId) {
   let cfg = {};
-  try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { /* default-config / unreadable → use {} */ }
-  const tokenPath = cfg.reviewer_token_path || path.join(os.homedir(), ".quadwork", "reviewer-token");
+  try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { /* default-config / unreadable */ }
+  const defaultPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
+  const project = projectId ? (cfg.projects || []).find((p) => p.id === projectId) : null;
+  if (project) {
+    const targets = _resolveReseedTargets(project); // [{ canonical, wtDir }, ...]
+    for (const role of ["re1", "re2"]) {
+      const t = targets.find((x) => x.canonical === role);
+      if (!t) continue;
+      try {
+        const agentsMd = fs.readFileSync(path.join(t.wtDir, "AGENTS.md"), "utf-8");
+        const extracted = _extractReviewerTokenPath(agentsMd);
+        if (extracted) return { path: extracted, source: "worktree" };
+      } catch { /* worktree / AGENTS.md missing → try next role */ }
+    }
+  }
+  if (cfg.reviewer_token_path) return { path: cfg.reviewer_token_path, source: "config" };
+  return { path: defaultPath, source: "default" };
+}
+
+// #886/#893: poll one reviewer token path (exempt `rate_limit` call as that
+// token's account) and cache the result keyed by path. No/empty token → drop
+// the cache entry (omitted from the payload). `login` is the label to attach
+// (null when it can't be proven to match a custom token — see getReviewerRateLimit).
+async function refreshReviewerForPath(tokenPath, login) {
   let token = "";
   try {
     token = fs.readFileSync(tokenPath, "utf-8").trim();
   } catch {
-    _reviewerRateLimit = null; // no reviewer token configured → single-account
+    _reviewerRateLimitByPath.delete(tokenPath); // no reviewer token here → omit
     return;
   }
-  if (!token) { _reviewerRateLimit = null; return; }
+  if (!token) { _reviewerRateLimitByPath.delete(tokenPath); return; }
   try {
     const { stdout } = await _execFileAsync("gh", [
       "api", "rate_limit", "--jq",
@@ -141,22 +165,56 @@ async function refreshReviewerRateLimit() {
     ], { encoding: "utf-8", timeout: 10000, env: { ...process.env, GH_TOKEN: token } });
     const data = JSON.parse(stdout);
     const toBucket = (b) => ({ limit: b.limit, remaining: b.remaining, resetAt: b.reset * 1000 });
-    _reviewerRateLimit = {
-      login: cfg.reviewer_github_user || null,
+    _reviewerRateLimitByPath.set(tokenPath, {
+      ts: Date.now(),
+      login: login || null,
       core: data.core ? toBucket(data.core) : null,
       graphql: data.graphql ? toBucket(data.graphql) : null,
       search: data.search ? toBucket(data.search) : null,
-      updatedAt: Date.now(),
       error: null,
-    };
+    });
   } catch (err) {
-    // Preserve prior bucket data if any; just flag the error + timestamp.
-    _reviewerRateLimit = {
-      ...(_reviewerRateLimit || { login: cfg.reviewer_github_user || null, core: null, graphql: null, search: null }),
-      updatedAt: Date.now(),
+    const prev = _reviewerRateLimitByPath.get(tokenPath);
+    _reviewerRateLimitByPath.set(tokenPath, {
+      ...(prev || { core: null, graphql: null, search: null }),
+      ts: Date.now(),
+      login: login || null,
       error: err.message,
-    };
+    });
   }
+}
+
+// #893: resolve the reviewer token path for `projectId`, (re)poll it if the
+// per-path cache is stale, and return the cache entry (or null). Login: only
+// trust cfg.reviewer_github_user for the cfg/default sources — a custom
+// worktree token may be a DIFFERENT account, so omit the label there rather than
+// show a stale/mismatched login.
+async function getReviewerRateLimit(projectId) {
+  const { path: tokenPath, source } = _resolveReviewerTokenPath(projectId);
+  let login = null;
+  if (source !== "worktree") {
+    try { login = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")).reviewer_github_user || null; } catch { /* none */ }
+  }
+  const cached = _reviewerRateLimitByPath.get(tokenPath);
+  if (!cached || Date.now() - cached.ts >= RATE_LIMIT_POLL_MS) {
+    await refreshReviewerForPath(tokenPath, login);
+  } else if (cached.login !== login) {
+    // Path unchanged but the label resolution changed — update without re-polling.
+    _reviewerRateLimitByPath.set(tokenPath, { ...cached, login });
+  }
+  return _reviewerRateLimitByPath.get(tokenPath) || null;
+}
+
+// #886/#893: build the reviewer block from a cache entry, or null when there's
+// no token / no bucket data (key omitted → single-account view unchanged).
+function reviewerRateLimitPayload(entry) {
+  if (!entry || (!entry.core && !entry.graphql && !entry.search)) return null;
+  const out = {};
+  if (entry.login) out.login = entry.login;
+  if (entry.core) out.core = bucketView(entry.core);
+  if (entry.graphql) out.graphql = bucketView(entry.graphql);
+  if (entry.search) out.search = bucketView(entry.search);
+  return out;
 }
 
 function startRateLimitPolling() {
@@ -1012,24 +1070,18 @@ function bucketView(b) {
   };
 }
 
-// #886: build the reviewer-account block for the response, or null when no
-// reviewer token is configured / no bucket data yet (single-account setups →
-// key omitted, badge unchanged).
-function reviewerRateLimitPayload() {
-  const r = _reviewerRateLimit;
-  if (!r || (!r.core && !r.graphql && !r.search)) return null;
-  const out = {};
-  if (r.login) out.login = r.login;
-  if (r.core) out.core = bucketView(r.core);
-  if (r.graphql) out.graphql = bucketView(r.graphql);
-  if (r.search) out.search = bucketView(r.search);
-  return out;
-}
-
-router.get("/api/github/rate-limit", (_req, res) => {
+router.get("/api/github/rate-limit", async (req, res) => {
   const resetIn = _rateLimit.resetAt > Date.now()
     ? Math.ceil((_rateLimit.resetAt - Date.now()) / 60000)
     : 0;
+  // #893: project-aware reviewer budget. `?project=<id>` resolves the reviewer
+  // token from that project's reviewer worktree (custom paths included); no /
+  // unknown project → cfg/default (back-compatible with #886).
+  const projectId = typeof req.query.project === "string" ? req.query.project : null;
+  let reviewer = null;
+  try {
+    reviewer = reviewerRateLimitPayload(await getReviewerRateLimit(projectId));
+  } catch { /* reviewer block is best-effort; never fail the core response */ }
   res.json({
     // Top-level fields are core (REST), kept for the existing alert banner.
     limit: _rateLimit.limit,
@@ -1044,8 +1096,9 @@ router.get("/api/github/rate-limit", (_req, res) => {
     core: bucketView(_rateLimit),
     graphql: bucketView(_graphqlRateLimit),
     search: bucketView(_searchRateLimit),
-    // #886: reviewer-token account (separate budget), present only when configured.
-    ...(reviewerRateLimitPayload() ? { reviewer: reviewerRateLimitPayload() } : {}),
+    // #886/#893: reviewer-token account (separate budget), present only when a
+    // reviewer token resolves for the requested project (or cfg/default).
+    ...(reviewer ? { reviewer } : {}),
   });
 });
 
@@ -4254,8 +4307,10 @@ module.exports._canonicalAgentSlug = _canonicalAgentSlug;
 // #854: expose the GH_TOKEN path extractor so the parse forms (`export`,
 // double-quoted, inner-quoted, etc.) are exercisable without a temp fs.
 module.exports._extractReviewerTokenPath = _extractReviewerTokenPath;
-// #886: expose the reviewer-account rate-limit poll + payload builder for tests.
-module.exports.refreshReviewerRateLimit = refreshReviewerRateLimit;
+// #886/#893: expose the project-aware reviewer rate-limit resolver/poll/payload
+// for tests.
+module.exports._resolveReviewerTokenPath = _resolveReviewerTokenPath;
+module.exports.getReviewerRateLimit = getReviewerRateLimit;
 module.exports.reviewerRateLimitPayload = reviewerRateLimitPayload;
 // #856: expose the auto-reseed startup hook + supporting state/version
 // helpers. server/index.js calls `autoReseedOnStartup` after config is

--- a/server/routes.reviewerRateLimit.test.js
+++ b/server/routes.reviewerRateLimit.test.js
@@ -1,10 +1,10 @@
-// #886: reviewer-token rate-limit poll tests. Verifies the second exempt
-// `gh api rate_limit` poll runs as the reviewer token, exposes a `reviewer`
-// payload (separate per-account budget), and is omitted on single-account
-// setups. Plain node:assert script (run with `node ...`).
+// #886/#893: project-aware reviewer rate-limit tests. #893 resolves the reviewer
+// token path from the selected project's reviewer worktree AGENTS.md (custom
+// paths), with worktree winning over cfg, and omits a stale login for a custom
+// token. Plain node:assert-style script.
 //
-// Stubs child_process.execFile (so the gh call is observable + the GH_TOKEN env
-// is captured) and fs.readFileSync (config + token file) BEFORE require.
+// Stubs child_process.execFile (custom-promisify, captures GH_TOKEN) and
+// fs.readFileSync (config + AGENTS.md + token files) BEFORE require.
 
 const cp = require("child_process");
 const fs = require("fs");
@@ -13,7 +13,7 @@ const path = require("path");
 const util = require("util");
 
 const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
-const FAKE_TOKEN_PATH = "/tmp/__reviewer_token_test__";
+const DEFAULT_PATH = path.join(os.homedir(), ".quadwork", "reviewer-token");
 
 const nowSec = Math.floor(Date.now() / 1000);
 const RATE_JSON = JSON.stringify({
@@ -23,16 +23,9 @@ const RATE_JSON = JSON.stringify({
 });
 
 let capturedEnvToken = null;
-let reviewerPollCalls = 0; // counts ONLY reviewer polls (those carrying GH_TOKEN)
 function handleGh(file, args, options) {
-  // Serves any `gh api rate_limit` (incl. the module-load main poll). Counts
-  // only the reviewer poll, distinguished by the GH_TOKEN env it sets — the
-  // main poll carries no env, so it never affects reviewerPollCalls.
   if (file === "gh" && Array.isArray(args) && args.includes("rate_limit")) {
-    if (options && options.env && options.env.GH_TOKEN) {
-      reviewerPollCalls++;
-      capturedEnvToken = options.env.GH_TOKEN;
-    }
+    if (options && options.env && options.env.GH_TOKEN) capturedEnvToken = options.env.GH_TOKEN;
     return { stdout: RATE_JSON, stderr: "" };
   }
   return null;
@@ -41,92 +34,124 @@ const realExecFile = cp.execFile;
 function stub(file, args, opts, cb) {
   const done = typeof opts === "function" ? opts : cb;
   const options = typeof opts === "function" ? {} : opts || {};
-  const res = handleGh(file, args, options);
-  if (res) return done(null, res.stdout, res.stderr);
+  const r = handleGh(file, args, options);
+  if (r) return done(null, r.stdout, r.stderr);
   return realExecFile.apply(this, arguments);
 }
-// routes.js uses util.promisify(execFile), which resolves via execFile's custom
-// promisify symbol to { stdout, stderr }. Replicate that so the awaited result
-// destructures `stdout` correctly (a plain callback stub would resolve to a
-// bare string and break JSON.parse).
 stub[util.promisify.custom] = (file, args, options) => {
-  const res = handleGh(file, args, options);
-  if (res) return Promise.resolve(res);
-  return Promise.reject(new Error(`unexpected execFile in test: ${file} ${(args || []).join(" ")}`));
+  const r = handleGh(file, args, options);
+  return r ? Promise.resolve(r) : Promise.reject(new Error(`unexpected execFile: ${file}`));
 };
 cp.execFile = stub;
 
-// fs stubs are swapped per-scenario via these mutable refs.
+// fs fixtures — mutable per scenario.
 let configJson = "{}";
-let tokenFileContent = null; // null → ENOENT
+const files = new Map(); // absolute path → content; absent AGENTS.md/token → ENOENT
 const realRead = fs.readFileSync;
 fs.readFileSync = function stubRead(p, ...rest) {
   if (p === CONFIG_PATH) return configJson;
-  if (p === FAKE_TOKEN_PATH || (typeof p === "string" && p.endsWith("reviewer-token"))) {
-    if (tokenFileContent === null) {
-      const err = new Error("ENOENT (test stub)");
-      err.code = "ENOENT";
-      throw err;
-    }
-    return tokenFileContent;
+  if (typeof p === "string" && files.has(p)) return files.get(p);
+  if (typeof p === "string" && (p.endsWith("AGENTS.md") || p.endsWith("reviewer-token"))) {
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
   }
   return realRead(p, ...rest);
 };
 
-const { refreshReviewerRateLimit, reviewerRateLimitPayload } = require("./routes");
+const { _resolveReviewerTokenPath, getReviewerRateLimit, reviewerRateLimitPayload } = require("./routes");
 
 let passed = 0, failed = 0;
 const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
 
-(async () => {
-  console.log("\n--- #886 reviewer-account rate-limit tests ---\n");
+// A project with re1/re2 worktrees at /wt/<p>-re1 etc.
+const PROJECT = { id: "p", working_dir: "/wt/p", agents: { re1: { cwd: "/wt/p-re1" }, re2: { cwd: "/wt/p-re2" } } };
+const RE1_AGENTS = "/wt/p-re1/AGENTS.md";
+const RE2_AGENTS = "/wt/p-re2/AGENTS.md";
+const ghTokenLine = (p) => `export GH_TOKEN=$(cat ${p})\n`;
 
-  // Let the module-load startRateLimitPolling() → refreshRateLimit() chain
-  // (kicked off with the initial EMPTY config, so it fires no reviewer poll)
-  // fully settle before we mutate the fixtures — otherwise its trailing
-  // refreshReviewerRateLimit could read scenario A's token and race the counter.
+function reset() {
+  files.clear();
+  capturedEnvToken = null;
+}
+
+(async () => {
+  console.log("\n--- #893 project-aware reviewer rate-limit tests ---\n");
+
+  // Let the module-load main poll settle (it makes no reviewer call now).
   await new Promise((r) => setTimeout(r, 100));
 
-  // ── A. Reviewer token configured → polled as the reviewer, payload present ─
-  {
-    capturedEnvToken = null;
-    reviewerPollCalls = 0;
-    configJson = JSON.stringify({ reviewer_token_path: FAKE_TOKEN_PATH, reviewer_github_user: "project7-interns" });
-    tokenFileContent = "ghp_reviewerfaketoken\n";
+  // ── Resolution (pure _resolveReviewerTokenPath — no gh, no cache) ────────
 
-    await refreshReviewerRateLimit();
-    const payload = reviewerRateLimitPayload();
+  // custom worktree path (re1) wins
+  reset();
+  configJson = JSON.stringify({ reviewer_github_user: "interns", projects: [PROJECT] });
+  files.set(RE1_AGENTS, ghTokenLine("/custom/reviewer-token"));
+  let r = _resolveReviewerTokenPath("p");
+  ok(r.path === "/custom/reviewer-token" && r.source === "worktree", "resolves custom worktree token path (re1) with source=worktree");
 
-    ok(reviewerPollCalls === 1, `A: ran exactly one reviewer rate_limit poll (got ${reviewerPollCalls})`);
-    ok(capturedEnvToken === "ghp_reviewerfaketoken", "A: poll used the reviewer token via GH_TOKEN env (trimmed)");
-    ok(payload !== null, "A: reviewer payload present when a token is configured");
-    ok(payload.login === "project7-interns", "A: payload login from cfg.reviewer_github_user");
-    ok(payload.graphql && payload.graphql.remaining === 37, "A: reviewer graphql bucket surfaced (the at-risk budget)");
-    ok(payload.core && payload.core.remaining === 4000, "A: reviewer core bucket surfaced");
-    ok(typeof payload.graphql.resetInMinutes === "number", "A: bucketView shape (resetInMinutes) applied");
-  }
+  // worktree wins over cfg.reviewer_token_path
+  reset();
+  configJson = JSON.stringify({ reviewer_token_path: "/cfg/reviewer-token", projects: [PROJECT] });
+  files.set(RE1_AGENTS, ghTokenLine("/wtwins/reviewer-token"));
+  r = _resolveReviewerTokenPath("p");
+  ok(r.path === "/wtwins/reviewer-token" && r.source === "worktree", "worktree path WINS over cfg.reviewer_token_path (reseed preservation order)");
 
-  // ── B. No reviewer token (file missing) → payload null (single-account) ───
-  {
-    reviewerPollCalls = 0;
-    configJson = "{}";
-    tokenFileContent = null; // ENOENT
+  // re2 fallback when re1 AGENTS.md has no GH_TOKEN line
+  reset();
+  configJson = JSON.stringify({ projects: [PROJECT] });
+  files.set(RE1_AGENTS, "no token here\n");
+  files.set(RE2_AGENTS, ghTokenLine("/re2/reviewer-token"));
+  r = _resolveReviewerTokenPath("p");
+  ok(r.path === "/re2/reviewer-token" && r.source === "worktree", "falls back to re2 worktree when re1 has no GH_TOKEN line");
 
-    await refreshReviewerRateLimit();
-    ok(reviewerRateLimitPayload() === null, "B: no reviewer token → payload null (single-account, no regression)");
-    ok(reviewerPollCalls === 0, "B: no reviewer token → NO second gh poll fired");
-  }
+  // no project → cfg.reviewer_token_path
+  reset();
+  configJson = JSON.stringify({ reviewer_token_path: "/cfg/reviewer-token", projects: [PROJECT] });
+  r = _resolveReviewerTokenPath(null);
+  ok(r.path === "/cfg/reviewer-token" && r.source === "config", "no project → cfg.reviewer_token_path (source=config)");
 
-  // ── C. Empty token file → treated as not configured ──────────────────────
-  {
-    reviewerPollCalls = 0;
-    configJson = JSON.stringify({ reviewer_token_path: FAKE_TOKEN_PATH });
-    tokenFileContent = "   \n";
+  // no project + no cfg → default
+  reset();
+  configJson = JSON.stringify({ projects: [PROJECT] });
+  r = _resolveReviewerTokenPath(null);
+  ok(r.path === DEFAULT_PATH && r.source === "default", "no project + no cfg → default ~/.quadwork/reviewer-token");
 
-    await refreshReviewerRateLimit();
-    ok(reviewerRateLimitPayload() === null, "C: empty token file → payload null");
-    ok(reviewerPollCalls === 0, "C: empty token → NO gh poll");
-  }
+  // unknown project → cfg/default fallback (validated, not arbitrary project)
+  reset();
+  configJson = JSON.stringify({ reviewer_token_path: "/cfg/reviewer-token", projects: [PROJECT] });
+  files.set(RE1_AGENTS, ghTokenLine("/should-not-be-used/reviewer-token"));
+  r = _resolveReviewerTokenPath("ghost");
+  ok(r.path === "/cfg/reviewer-token" && r.source === "config", "unknown project → cfg/default fallback (does not sample project 'p')");
+
+  // ── Poll + payload + login (getReviewerRateLimit + reviewerRateLimitPayload) ─
+
+  // custom worktree token → polled with that token; login OMITTED (stale-login guard)
+  reset();
+  configJson = JSON.stringify({ reviewer_github_user: "interns", projects: [PROJECT] });
+  files.set(RE1_AGENTS, ghTokenLine("/customA/reviewer-token"));
+  files.set("/customA/reviewer-token", "ghp_customA\n");
+  let payload = reviewerRateLimitPayload(await getReviewerRateLimit("p"));
+  ok(capturedEnvToken === "ghp_customA", "polls the CUSTOM worktree token via GH_TOKEN");
+  ok(payload && payload.graphql && payload.graphql.remaining === 37, "custom-path reviewer payload surfaced (graphql bucket)");
+  ok(payload && !("login" in payload), "custom worktree token → login OMITTED (no stale cfg.reviewer_github_user)");
+
+  // default path → login = cfg.reviewer_github_user
+  reset();
+  configJson = JSON.stringify({ reviewer_github_user: "mainacct", projects: [] });
+  files.set(DEFAULT_PATH, "ghp_default\n");
+  payload = reviewerRateLimitPayload(await getReviewerRateLimit(null));
+  ok(payload && payload.login === "mainacct", "default/config source → login = cfg.reviewer_github_user");
+  ok(payload && payload.core && payload.core.remaining === 4000, "default-path reviewer payload surfaced (core bucket)");
+
+  // no token (custom path, token file absent) → payload null
+  reset();
+  capturedEnvToken = null;
+  configJson = JSON.stringify({ projects: [PROJECT] });
+  files.set(RE1_AGENTS, ghTokenLine("/notoken/reviewer-token")); // token file NOT added → ENOENT
+  payload = reviewerRateLimitPayload(await getReviewerRateLimit("p"));
+  ok(payload === null, "no reviewer token at resolved path → payload null (omitted)");
+  ok(capturedEnvToken === null, "no token → NO reviewer gh poll fired");
 
   console.log(`\n${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);

--- a/src/components/GitHubRateLimitBadge.tsx
+++ b/src/components/GitHubRateLimitBadge.tsx
@@ -66,13 +66,18 @@ function bucketSpans(items: { label: string; b?: Bucket }[]) {
     ));
 }
 
-export default function GitHubRateLimitBadge() {
+export default function GitHubRateLimitBadge({ projectId }: { projectId?: string }) {
   const [data, setData] = useState<RateLimitResponse | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    // #893: pass the current project so the reviewer budget resolves from THIS
+    // project's reviewer worktree token (custom paths), not an arbitrary one.
+    const url = projectId
+      ? `/api/github/rate-limit?project=${encodeURIComponent(projectId)}`
+      : "/api/github/rate-limit";
     const load = () => {
-      fetch("/api/github/rate-limit")
+      fetch(url)
         .then((r) => (r.ok ? r.json() : null))
         .then((d) => {
           if (!cancelled && d) setData(d);
@@ -85,7 +90,7 @@ export default function GitHubRateLimitBadge() {
       cancelled = true;
       clearInterval(id);
     };
-  }, []);
+  }, [projectId]);
 
   // Degrade gracefully: render nothing until we have data.
   const mainSpans = data

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -322,7 +322,8 @@ export default function ProjectDashboard({ projectId }: ProjectDashboardProps) {
             </InfoTooltip>
           }>
             {/* #866: always-on rate-limit status badge, top-right of the GITHUB header */}
-            <GitHubRateLimitBadge />
+            {/* #893: pass projectId so the reviewer budget resolves per project */}
+            <GitHubRateLimitBadge projectId={projectId} />
           </PanelHeader>
           <div className="flex-1 min-h-0">
             <GitHubPanel projectId={projectId} idle={idle} />


### PR DESCRIPTION
## Summary
Follow-up to #886. Closes the remaining slice of the #866 monitoring blind spot. `refreshReviewerRateLimit()` resolved the reviewer token path only as `cfg.reviewer_token_path || ~/.quadwork/reviewer-token`, so a project whose reviewer token lives at a **custom path** recorded only in its reviewer worktree `AGENTS.md` (the path reseed preserves via `_extractReviewerTokenPath`) was monitored on the **wrong token or no token**. Default-path setups (e.g. the current VPS) worked, which is why this wasn't caught at runtime.

## Fix — make the reviewer lookup project-aware + on-demand
- **Frontend** `GitHubRateLimitBadge` takes a `projectId` prop and fetches `/api/github/rate-limit?project=<id>` (passed from `ProjectDashboard`).
- **Backend** `_resolveReviewerTokenPath(projectId)`: for a known project the **worktree-extracted path WINS** (matches reseed's preservation order — it's the path that project's reviewer agents actually use): `re1` worktree `AGENTS.md` first, then `re2`; falls back to `cfg.reviewer_token_path` → default for a no-project / unknown-project request (back-compatible with #886). Reuses `_resolveReseedTargets` (`project.agents[role].cwd`) + `_extractReviewerTokenPath`.
  ```
  _extractReviewerTokenPath(<re1.cwd>/AGENTS.md) || _extractReviewerTokenPath(<re2.cwd>/AGENTS.md)
    || cfg.reviewer_token_path || ~/.quadwork/reviewer-token
  ```
- The reviewer budget is polled **on demand from the endpoint and cached per token path** (exempt `rate_limit` → zero billable cost); the timer-based global poll is removed.
- **Login:** only trust `cfg.reviewer_github_user` for the cfg/default sources — a custom worktree token may be a **different account**, so the login label is **omitted** for a worktree-resolved path rather than showing a stale/mismatched login.
- No reviewer token at the resolved path → entry dropped → `reviewer` block omitted (single-account view unchanged). Unknown project → cfg/default fallback (does **not** sample an arbitrary configured project).

## Verification
- **`routes.reviewerRateLimit.test.js` — 13/13** (rewritten for the project-aware API): custom-path resolution, **worktree-wins-over-config**, re2 fallback, no-project→config, no-project→default, **unknown-project→config**; poll uses the custom token via `GH_TOKEN`; **login omitted for a custom token** (stale-login guard); login from cfg for default/config; **no-token → null payload + no gh poll**.
- `npm test` → **37 passed, 0 failed, 2 skipped** (incl. existing `reviewBatch` etc.).
- `npm run build` → green; `GitHubRateLimitBadge.tsx` lints clean (the 2 `ProjectDashboard` lint errors are pre-existing `setIdle` effects, untouched).

## Dependencies
- #886 (merged) — the reviewer badge baseline.

Closes #893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)