### PR TITLE
[#894] Package docs/operator-mcp.md in the npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "!server/**/*.test.js",
     "!server/__tests__/",
     "templates/",
-    "out/"
+    "out/",
+    "docs/operator-mcp.md"
   ],
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
Follow-up to #796. `README.md` links **[Operator MCP](docs/operator-mcp.md)**, but `package.json`'s `files` whitelist had no `docs/` entry, so `npm pack` excluded the file — a **dead link for global-install users** (the README ships, the linked doc didn't).

## Fix
Added the single file to the `files` whitelist:
```json
"files": [ "bin/", "server/", "!server/**/*.test.js", "!server/__tests__/", "templates/", "out/", "docs/operator-mcp.md" ]
```
Scoped to `docs/operator-mcp.md` (not all of `docs/`) per the ticket — the install/troubleshooting docs are repo-setup guides, not package content.

## Verification
- `npm pack --dry-run` now includes **exactly one** `docs/` entry — `docs/operator-mcp.md` (5.2kB) — and no other docs files leaked in.
- `package.json` is still valid JSON; `npm run build` green.

One-line change, trivial/low risk — worth landing before the 2.3.0 publish so global-install users get the working Operator MCP docs.

Closes #894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)