### PR TITLE
[#897] Reviewer rate-limit: expand ~ in reviewer token path (P1 regression from #893)

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -124,6 +124,18 @@ async function refreshRateLimit() {
 // AGENTS.md first, then re2's. Falls back to cfg.reviewer_token_path → default
 // for a no-project / unknown-project request (backward compatible with #886).
 // Returns { path, source: "worktree" | "config" | "default" }.
+// #897: expand a leading `~/` (and bare `~`) to os.homedir(). The setup wizard
+// seeds the literal `~/.quadwork/reviewer-token` into reviewer AGENTS.md, and
+// _extractReviewerTokenPath returns it raw (reseed depends on the raw value).
+// Node's fs does NOT expand `~`, so the resolver must normalize before reading /
+// caching — otherwise the default-seeded path ENOENTs and the badge vanishes.
+function _expandTilde(p) {
+  if (typeof p !== "string") return p;
+  if (p === "~") return os.homedir();
+  if (p.startsWith("~/")) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
 function _resolveReviewerTokenPath(projectId) {
   let cfg = {};
   try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { /* default-config / unreadable */ }
@@ -137,12 +149,14 @@ function _resolveReviewerTokenPath(projectId) {
       try {
         const agentsMd = fs.readFileSync(path.join(t.wtDir, "AGENTS.md"), "utf-8");
         const extracted = _extractReviewerTokenPath(agentsMd);
-        if (extracted) return { path: extracted, source: "worktree" };
+        // #897: expand `~` here (not in _extractReviewerTokenPath — reseed needs
+        // the raw value) so the read + cache key use an absolute path.
+        if (extracted) return { path: _expandTilde(extracted), source: "worktree" };
       } catch { /* worktree / AGENTS.md missing → try next role */ }
     }
   }
-  if (cfg.reviewer_token_path) return { path: cfg.reviewer_token_path, source: "config" };
-  return { path: defaultPath, source: "default" };
+  if (cfg.reviewer_token_path) return { path: _expandTilde(cfg.reviewer_token_path), source: "config" };
+  return { path: defaultPath, source: "default" }; // already absolute
 }
 
 // #886/#893: poll one reviewer token path (exempt `rate_limit` call as that

--- a/server/routes.reviewerRateLimit.test.js
+++ b/server/routes.reviewerRateLimit.test.js
@@ -124,14 +124,43 @@ function reset() {
   r = _resolveReviewerTokenPath("ghost");
   ok(r.path === "/cfg/reviewer-token" && r.source === "config", "unknown project → cfg/default fallback (does not sample project 'p')");
 
+  // #897: default-seeded `~/.quadwork/reviewer-token` (tilde) → expanded to abs
+  reset();
+  configJson = JSON.stringify({ projects: [PROJECT] });
+  files.set(RE1_AGENTS, ghTokenLine("~/.quadwork/reviewer-token"));
+  r = _resolveReviewerTokenPath("p");
+  ok(r.path === DEFAULT_PATH && r.source === "worktree", "#897: default-seeded ~/.quadwork/reviewer-token expands to the absolute homedir path");
+
+  // #897: ~/ and bare ~ expanded for the config source too; absolute unchanged
+  reset();
+  configJson = JSON.stringify({ reviewer_token_path: "~/cfg-token", projects: [] });
+  ok(_resolveReviewerTokenPath(null).path === path.join(os.homedir(), "cfg-token"), "#897: ~/ in cfg.reviewer_token_path expanded");
+  reset();
+  configJson = JSON.stringify({ reviewer_token_path: "~", projects: [] });
+  ok(_resolveReviewerTokenPath(null).path === os.homedir(), "#897: bare ~ in cfg path expands to homedir");
+  reset();
+  configJson = JSON.stringify({ reviewer_token_path: "/abs/reviewer-token", projects: [] });
+  ok(_resolveReviewerTokenPath(null).path === "/abs/reviewer-token", "#897: absolute cfg path passes through unchanged (no regression)");
+
   // ── Poll + payload + login (getReviewerRateLimit + reviewerRateLimitPayload) ─
+
+  // #897 (P1 regression): a project seeded with the DEFAULT `~/.quadwork/
+  // reviewer-token` shows the badge — the tilde is expanded so the real file is
+  // read, instead of ENOENT → no badge.
+  reset();
+  configJson = JSON.stringify({ reviewer_github_user: "interns", projects: [PROJECT] });
+  files.set(RE1_AGENTS, ghTokenLine("~/.quadwork/reviewer-token"));
+  files.set(DEFAULT_PATH, "ghp_default_seeded\n"); // real file at the EXPANDED path
+  let payload = reviewerRateLimitPayload(await getReviewerRateLimit("p"));
+  ok(capturedEnvToken === "ghp_default_seeded", "#897: polls the token at the EXPANDED default path");
+  ok(payload && payload.graphql && payload.graphql.remaining === 37, "#897: reviewer badge SHOWS for a default-seeded ~/ path (regression fixed)");
 
   // custom worktree token → polled with that token; login OMITTED (stale-login guard)
   reset();
   configJson = JSON.stringify({ reviewer_github_user: "interns", projects: [PROJECT] });
   files.set(RE1_AGENTS, ghTokenLine("/customA/reviewer-token"));
   files.set("/customA/reviewer-token", "ghp_customA\n");
-  let payload = reviewerRateLimitPayload(await getReviewerRateLimit("p"));
+  payload = reviewerRateLimitPayload(await getReviewerRateLimit("p"));
   ok(capturedEnvToken === "ghp_customA", "polls the CUSTOM worktree token via GH_TOKEN");
   ok(payload && payload.graphql && payload.graphql.remaining === 37, "custom-path reviewer payload surfaced (graphql bucket)");
   ok(payload && !("login" in payload), "custom worktree token → login OMITTED (no stale cfg.reviewer_github_user)");


### PR DESCRIPTION
## Summary
**P1 regression fix — blocks 2.3.0.** #893's project-aware resolver broke the **common default** reviewer-token case.

The setup wizard seeds the literal string `~/.quadwork/reviewer-token` (with a tilde) into reviewer `AGENTS.md` by default. #893's resolver reads that worktree `AGENTS.md`, gets the **raw** `~/...` string back from `_extractReviewerTokenPath` (which strips quotes but not the tilde), and returns it as `{ path: extracted, source: "worktree" }` — which wins **before** the absolute default fallback. **Node's `fs` does not expand `~`** → `ENOENT` → the cache entry is dropped → the reviewer badge is **omitted for every default-seeded project** (even though `~/.quadwork/reviewer-token` exists). The old #886 code worked only because its default was an already-absolute `path.join(os.homedir(), ...)`.

## Fix
- Add `_expandTilde()` — leading `~/` and bare `~` → `os.homedir()`; everything else passes through.
- Apply it to the **resolver's returned path** for the `worktree` and `config` sources (`default` is already absolute). This normalizes both the read path and the `_reviewerRateLimitByPath` **cache key** (so `~/…` vs `/home/…/…` for the same file aren't two entries).
- **`_extractReviewerTokenPath` is intentionally unchanged** — reseed depends on its raw return value; expansion happens only in the rate-limit resolver.

## Verification
- **`routes.reviewerRateLimit.test.js` — +6 → 19/19:**
  - default-seeded `~/.quadwork/reviewer-token` resolves to the **absolute homedir path** (source `worktree`), and **the badge SHOWS** — it polls the token at the expanded path (the regression case the old tests missed);
  - `~/` and bare `~` expanded for the `config` source;
  - **absolute paths pass through unchanged** (custom-absolute path still works — no regression);
  - no-token still omits the reviewer block.
- `_extractReviewerTokenPath` confirmed unchanged (not in the diff) → reseed unaffected.
- `npm test` → **37 passed, 0 failed, 2 skipped**; `npm run build` → green.

## Note
Login follows #893's source rule unchanged: omitted for a `worktree`-resolved path (a custom token may be a different account). For a default-seeded project the badge shows the generic `reviewer:` label — strictly better than the bug (no badge at all), and the bucket monitoring (the point of #886/#893) is restored.

## Dependencies
- #893 (merged) — introduced the resolver this fixes.

Closes #897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)