### PR TITLE
[#901] README: add Operator MCP + Review batches sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,64 @@ Head: merges, picks the next issue
 - 🛑 **Sender lockdown** — chat POSTs can't impersonate an agent (`head`, `dev`, …) from the UI
 - 🗄️ **Auto-snapshot** of chat history to `~/.quadwork/{project}/history-snapshots/` with an in-dashboard **Restore** button
 
+## ─ Operator MCP
+
+Drive QuadWork from an **external Claude agent** — Claude Code or Claude
+Desktop — instead of clicking the dashboard. QuadWork ships a stdio
+[Model Context Protocol](https://modelcontextprotocol.io) server that exposes
+the same operator surface as tools: read team chat and batch progress, define
+and run overnight batches, and control individual agents.
+
+Register it with the bundled bin (one line):
+
+```bash
+claude mcp add quadwork -- quadwork-mcp-operator --port 8400
+```
+
+The tools come in two tiers:
+
+- **Read / observe** — `list_projects`, `read_chat`, `batch_status`, `read_queue`, `list_agents` (no state change).
+- **Act** — `send_message`, `set_batch` / `append_batch` / `ensure_batch`, `start_batch` / `trigger_now` / `stop_batch`, `agent_control`, `interrupt_all`.
+
+A typical flow: `set_batch` to define the work → `start_batch` for a scheduled
+cadence → `batch_status` to watch progress.
+
+> **Security boundary:** the server is **localhost-only with no auth by design**
+> — it talks to `127.0.0.1:8400` and the MCP client must run on the same machine
+> as QuadWork. Don't expose the backend port over a network without adding
+> authentication.
+
+Full tool reference, Claude Desktop config, and remote/VPS registration:
+**[docs/operator-mcp.md](docs/operator-mcp.md)**.
+
+## ─ Review batches
+
+The same Head → Dev → RE1/RE2 → Head loop, but in **review-only** mode — the
+team reviews work instead of building it. **No code, no PRs, no merges.** There
+are two batch types, selected by a `**Batch type:**` marker in
+`OVERNIGHT-QUEUE.md`:
+
+- **`ticket-review`** — review issue specs before they're built.
+- **`pr-review`** — review already-merged PRs and capture findings as follow-up tickets.
+
+**How to use** — ask Head in chat, just like a code batch:
+
+```
+@head review tickets #12 #15 #18
+@head review merged PRs #40 #41
+```
+
+Reviewers assess each item against a rubric; Dev edits issue bodies and files
+follow-up fix tickets via REST; Head marks items approved in the queue. The
+**Current Batch Progress** panel shows review states (*queued · in review · 1 of
+2 approvals · approved*) rather than merge language.
+
+> **GraphQL budget:** review discovery reads the server-authored `GITHUB.md` and
+> the GitHub **REST** API — never the GraphQL-backed `gh pr list` / `gh … view
+> --json` — so a review batch barely touches your hourly API budget.
+
+Queue contract and full state vocabulary: **[docs/review-batches.md](docs/review-batches.md)**.
+
 ## ─ External Tools
 
 QuadWork stands on top of some great open-source work. Explicit thanks:

--- a/docs/review-batches.md
+++ b/docs/review-batches.md
@@ -1,0 +1,85 @@
+# Review batches
+
+A **review batch** runs the same Head → Dev → RE1/RE2 → Head loop as a normal
+code batch, but in **review-only** mode: the team reviews GitHub *tickets* or
+*merged PRs* instead of building code. A review batch **never opens a PR and
+never merges or lands code** — its output is review verdicts, edited issue
+bodies, and follow-up tickets.
+
+There are two batch types:
+
+- **`ticket-review`** — review issue specs (scope, acceptance criteria, clarity) *before* they're built.
+- **`pr-review`** — review already-merged PRs after the fact; capture findings as follow-up fix tickets.
+
+## How to start one
+
+Ask Head in chat, exactly as you'd start a code batch:
+
+- **Tickets:** `@head review tickets #12 #15 #18`
+- **Merged PRs:** `@head review merged PRs #40 #41`
+
+Head writes the work into `OVERNIGHT-QUEUE.md` the normal way (next sequential
+`**Batch:** N`), with one extra marker line and per-item state annotations.
+
+## The queue contract
+
+The only structural difference from a code batch is a **`**Batch type:**`**
+line right after `**Batch:** N`, plus an in-place state annotation on each item.
+The marker is scoped to the `## Active Batch` section.
+
+```markdown
+## Active Batch
+
+**Batch:** 7
+**Batch type:** ticket-review
+**Started:** 2026-06-01 02:10
+
+- #12 — queued
+- #15 — in-review (1/2)
+- #18 — approved
+```
+
+For `pr-review`, the marker is `**Batch type:** pr-review` and the items are PR
+numbers. Each item is `- #<n> — <state>` (dash, space, `#`, number, space,
+em-dash, space, state). The accepted markers are `code` (the default — absent or
+unrecognized markers fall back to `code`), `ticket-review`, and `pr-review`.
+
+### Item-state vocabulary (must match exactly)
+
+| State | Meaning |
+|-------|---------|
+| `queued` | Not yet picked up |
+| `in-review` | Dev requested review; reviewers working |
+| `in-review (N/2)` | `N` of 2 reviewers have approved (e.g. `in-review (1/2)`) |
+| `approved` | Both reviewers approved (terminal) |
+| `changes-requested` | A reviewer asked for changes |
+
+These exact strings are what the dashboard's **Current Batch Progress** panel
+parses — it shows review states (*queued · in review · 1 of 2 approvals ·
+approved*), never merge language. Items stay in `## Active Batch` with their
+annotation (updated **in place**) until the **whole** batch is `approved`, then
+Head archives the block to `## Done`, preserving the `**Batch:** N` and
+`**Batch type:**` lines.
+
+## What each agent does
+
+| Agent | In a review batch |
+|-------|-------------------|
+| **Head** | Assigns each item to Dev; updates item states in place; archives the block when every item is `approved`. No merge step. |
+| **Dev** | Reviews the ticket spec / merged diff, requests review from RE1 + RE2, edits issue bodies and files follow-up fix tickets **via REST**. |
+| **RE1 / RE2** | Assess the ticket or merged diff against a rubric and report their verdict to Dev. |
+
+For `ticket-review`, `approved` means both reviewers signed off on the spec
+(after any edits). For `pr-review`, the PR is already in `main`, so `approved`
+means **the findings were captured** — follow-up tickets filed and a summary
+comment posted — not that the PR was reverted or re-merged.
+
+## GraphQL-budget property
+
+Review discovery is deliberately cheap on the GitHub API. Progress is computed
+entirely from the queue's `## Active Batch` annotations — **zero** GitHub calls.
+For live ticket bodies and diffs, Dev reads the server-authored
+`~/.quadwork/<project>/GITHUB.md` first, then uses **REST** `gh api` endpoints
+(`gh api repos/<repo>/issues/<n>`, `.../pulls/<n>/files`, …). It avoids the
+GraphQL-backed `gh issue view --json` / `gh pr view --json` / `gh pr list`,
+which would burn the hourly GraphQL points the review batch is meant to conserve.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "!server/__tests__/",
     "templates/",
     "out/",
-    "docs/operator-mcp.md"
+    "docs/operator-mcp.md",
+    "docs/review-batches.md"
   ],
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Fixes #901.

Documents two 2.3.0 features that shipped without README coverage.

## Operator MCP (tightened)
The README previously had only a one-line install-guide link. Added a real **Operator MCP** section: what it is (drive QuadWork from an external Claude agent via stdio MCP), the one-line registration (`claude mcp add quadwork -- quadwork-mcp-operator --port 8400`), the read/act tool tiers, the **localhost-only / no-auth** security boundary, and a pointer to `docs/operator-mcp.md` for the full reference.

## Review batches (new)
No prior README/docs coverage. Added a **Review batches** section: the two batch types (`ticket-review` / `pr-review`), how to invoke (`@head review tickets #X #Y` / `@head review merged PRs #X #Y`), what to expect (reviewers assess vs a rubric; Dev edits issue bodies + files follow-up tickets via REST; Head marks items approved; progress shows review states, not merge language), and the GraphQL-budget note (discovery via `GITHUB.md` + REST, never `gh pr list`).

Also added **`docs/review-batches.md`** (queue contract + exact state vocabulary, mirroring the `operator-mcp.md` pattern) and whitelisted it in `package.json` `files` so it ships in the npm tarball (per #894).

State vocabulary and the `**Batch type:**` marker were verified verbatim against `server/routes.js` (parse regex `/\*\*Batch type:\*\*\s*(code|ticket-review|pr-review)\b/i`) and `templates/seeds/head.AGENTS.md`.

## Acceptance criteria
- [x] README has a real Operator MCP section (what/why/register/tiers/security + docs link)
- [x] README has a Review batches section (two types, invoke, expect, GITHUB.md/REST budget note)
- [x] Matches existing README tone/structure; links resolve (both `docs/*.md` exist)
- [x] `docs/review-batches.md` added → included in `package.json` `files`
- [x] `npm run build` passes

## Verification
- `npm run build` → exit 0.
- `npm pack --dry-run` → exactly two `docs/` entries: `docs/operator-mcp.md` (5.2kB) + `docs/review-batches.md` (3.8kB), no other docs leaked.
- `package.json` still valid JSON; both README links resolve to existing files.
- Docs-only change — no server/frontend code touched.

> Note: absorbs the docs portion of #874 (its dogfood + reseed-verification parts are already satisfied) — #874 can be closed/repointed accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)