### PR TITLE
[#905] Complete Gemini CLI agent support — model flag + wizard provider option

### DIFF
--- a/server/agentArgs.gemini.test.js
+++ b/server/agentArgs.gemini.test.js
@@ -1,0 +1,99 @@
+"use strict";
+
+// #905: buildAgentArgs must forward a Gemini agent's configured model on the
+// spawned command (the model-arg block previously branched only for codex /
+// claude, silently dropping a gemini agent's model). These tests assert the
+// `--model <slug>` flag IS present for gemini, falls back to the CLI default
+// when unset, and that claude / codex are unaffected (no regression).
+//
+// QUADWORK_SKIP_LISTEN + a temp HOME let us require the server module for its
+// exported pure helper without starting the server / binding the port. HOME is
+// set BEFORE any require so config.js resolves CONFIG_PATH into the temp dir.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const TMP_HOME = path.join(os.tmpdir(), `quadwork-gemini-test-${process.pid}`);
+process.env.HOME = TMP_HOME;
+process.env.QUADWORK_SKIP_LISTEN = "1";
+
+const cfgDir = path.join(TMP_HOME, ".quadwork");
+fs.mkdirSync(cfgDir, { recursive: true });
+fs.writeFileSync(
+  path.join(cfgDir, "config.json"),
+  JSON.stringify({
+    port: 8400,
+    projects: [
+      {
+        id: "p1",
+        working_dir: "/tmp/p1",
+        agents: {
+          gemini_model: { command: "gemini", model: "gemini-2.5-pro" },
+          gemini_default: { command: "gemini" },
+          codex_agent: { command: "codex", model: "gpt-5" },
+          claude_agent: { command: "claude", model: "opus" },
+        },
+      },
+    ],
+  }),
+);
+
+const { buildAgentArgs } = require("./index");
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log(`  PASS: ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+// args is a flat array like ["--yolo", "--model", "<slug>", ...]; the model
+// value is the token right after the "--model" flag.
+function modelArg(args) {
+  const i = args.indexOf("--model");
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+async function runTests() {
+  {
+    const { args } = await buildAgentArgs("p1", "gemini_model");
+    assert(args.includes("--model"), "gemini with model → --model flag present");
+    assert(modelArg(args) === "gemini-2.5-pro", "gemini forwards the configured model slug");
+    assert(args.includes("--yolo"), "gemini still gets its --yolo permission flag");
+  }
+
+  {
+    const { args } = await buildAgentArgs("p1", "gemini_default");
+    assert(!args.includes("--model"), "gemini without model → no --model (CLI default)");
+    assert(args.includes("--yolo"), "gemini-default still gets --yolo");
+  }
+
+  {
+    // No regression: codex keeps its -c model="…" form, not --model.
+    const { args } = await buildAgentArgs("p1", "codex_agent");
+    assert(args.includes("-c") && args.some((a) => a === 'model="gpt-5"'), "codex still uses -c model=\"…\"");
+    assert(!args.includes("--model"), "codex does NOT use --model");
+  }
+
+  {
+    // No regression: claude keeps --model <slug>.
+    const { args } = await buildAgentArgs("p1", "claude_agent");
+    assert(modelArg(args) === "opus", "claude still forwards --model <slug>");
+  }
+
+  try { fs.rmSync(TMP_HOME, { recursive: true, force: true }); } catch {}
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  try { fs.rmSync(TMP_HOME, { recursive: true, force: true }); } catch {}
+  console.error(err);
+  process.exit(1);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -379,6 +379,8 @@ async function buildAgentArgs(projectId, agentId) {
   // Claude: --model <slug>
   //   reasoning_effort is not wired for Claude — Anthropic's CLI
   //   doesn't expose an equivalent flag.
+  // Gemini: --model <slug> (the Gemini CLI's -m / --model flag)
+  //   reasoning_effort has no Gemini equivalent — model only.
   if (cliBase === "codex") {
     if (agentCfg.model && typeof agentCfg.model === "string") {
       args.push("-c", `model="${agentCfg.model}"`);
@@ -387,6 +389,10 @@ async function buildAgentArgs(projectId, agentId) {
       args.push("-c", `model_reasoning_effort="${agentCfg.reasoning_effort}"`);
     }
   } else if (cliBase === "claude") {
+    if (agentCfg.model && typeof agentCfg.model === "string") {
+      args.push("--model", agentCfg.model);
+    }
+  } else if (cliBase === "gemini") {
     if (agentCfg.model && typeof agentCfg.model === "string") {
       args.push("--model", agentCfg.model);
     }
@@ -1774,7 +1780,14 @@ async function autoStopPollingTick() {
   }
 }
 
-setInterval(autoStopPollingTick, AUTO_STOP_POLL_INTERVAL_MS);
+// QUADWORK_SKIP_LISTEN lets a test `require("./index")` to reach the exported
+// pure helpers (e.g. buildAgentArgs) WITHOUT starting the server, its pollers,
+// or binding the port. Production never sets it; `quadwork start` requires this
+// module for its side effects, so the guard must be an explicit env var (not
+// require.main, which is the bin, not this file).
+if (!process.env.QUADWORK_SKIP_LISTEN) {
+  setInterval(autoStopPollingTick, AUTO_STOP_POLL_INTERVAL_MS);
+}
 
 // #422 / quadwork#310: auto-continue after loop guard.
 //
@@ -1878,7 +1891,7 @@ function runStartupMigrations(cfg) {
 
 }
 
-server.listen(PORT, "127.0.0.1", async () => {
+if (!process.env.QUADWORK_SKIP_LISTEN) server.listen(PORT, "127.0.0.1", async () => {
   console.log(`QuadWork server listening on http://127.0.0.1:${PORT}`);
   syncTriggersFromConfig();
   const startupCfg = readConfig();
@@ -1948,4 +1961,4 @@ function shutdown() {
   }
 }
 
-module.exports = { shutdown };
+module.exports = { shutdown, buildAgentArgs, buildAgentEnv };

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -188,6 +188,7 @@ const COPY = {
 const BACKENDS: { value: string; label: string }[] = [
   { value: "claude", label: "Claude Code" },
   { value: "codex", label: "Codex" },
+  { value: "gemini", label: "Gemini CLI" },
 ];
 
 const AGENTS = [
@@ -329,7 +330,7 @@ export default function SetupWizard() {
   const [loading, setLoading] = useState(false);
   const [workspaceLog, setWorkspaceLog] = useState<string[]>([]);
   const [launchStatus, setLaunchStatus] = useState<"idle" | "running" | "done" | "error">("idle");
-  const [cliStatus, setCliStatus] = useState<{ claude: boolean; codex: boolean } | null>(null);
+  const [cliStatus, setCliStatus] = useState<{ claude: boolean; codex: boolean; gemini: boolean } | null>(null);
 
   useEffect(() => {
     setSteps((prev) => [
@@ -346,16 +347,15 @@ export default function SetupWizard() {
   useEffect(() => {
     fetch("/api/cli-status")
       .then((r) => r.json())
-      .then((status: { claude: boolean; codex: boolean }) => {
+      .then((status: { claude: boolean; codex: boolean; gemini: boolean }) => {
         setCliStatus(status);
-        // Default all agents to the available CLI when only one is installed
-        const availableCli = status.claude && !status.codex ? "claude"
-          : !status.claude && status.codex ? "codex"
-          : null;
-        if (availableCli) {
-          setBackends({ head: availableCli, re1: availableCli, re2: availableCli, dev: availableCli });
+        // Default all agents to the available CLI when exactly one is installed
+        const installed = (["claude", "codex", "gemini"] as const).filter((c) => status[c]);
+        if (installed.length === 1) {
+          const only = installed[0];
+          setBackends({ head: only, re1: only, re2: only, dev: only });
         } else if (status.claude && status.codex) {
-          // Both available — use mixed defaults for review diversity
+          // Both Claude + Codex available — mixed defaults for review diversity
           setBackends({ head: "codex", dev: "claude", re1: "codex", re2: "claude" });
         }
       })
@@ -1004,7 +1004,7 @@ export default function SetupWizard() {
                     <div key={agent.key} className="flex items-center justify-between px-3 py-1.5 border-b border-border/50 last:border-b-0">
                       <span className="text-[11px] text-text font-semibold">{agent.label}</span>
                       <span className="text-[10px] text-text-muted">{agent.role}</span>
-                      <span className="text-[11px] text-accent">{backends[agent.key] === "claude" ? "Claude Code" : "Codex"}</span>
+                      <span className="text-[11px] text-accent">{BACKENDS.find((b) => b.value === backends[agent.key])?.label || backends[agent.key]}</span>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
Fixes #905.

Finishes Gemini as a first-class agent provider. Most plumbing already existed (CLI detection, `--yolo`, MCP env injection, `add-config` gemini mapping, `MODEL_OPTIONS.gemini`); this closes the two real gaps.

## Gap A — model flag not passed (core "model setup" fix)
`buildAgentArgs`' model-arg block (`server/index.js`) branched only for `codex` (`-c model="…"`) and `claude` (`--model`), so a gemini agent's configured `model` was **silently dropped**. Added a `gemini` branch that forwards `--model <slug>` (the Gemini CLI's `-m`/`--model` flag), falling back to the CLI default when unset. Mirrors the claude branch; reasoning_effort has no Gemini equivalent.

> Flag note: the `gemini` CLI is **not installed in this build environment**, so I could not run it live. I used `--model` per the official `@google/gemini-cli` flag (`-m`/`--model <model>`), which the ticket also states. Worth a quick live confirm on a machine with the CLI.

## Gap B — setup wizard had no gemini provider
Added **"Gemini CLI"** to the wizard's per-agent provider list (`SetupWizard.tsx`). `/api/cli-status` already reports `gemini` and `add-config` already maps `gemini` → `mcp_inject: "env"`, so selecting it persists `command: "gemini"` and flows through end-to-end. Also:
- Generalized the single-CLI auto-default to **any** one installed CLI (a gemini-only machine now defaults all agents to gemini; claude+codex mixed default unchanged).
- Fixed the launch-step roster label, which hardcoded `Claude Code`/`Codex` and would mislabel gemini — now uses the provider's `BACKENDS` label.
- Provider selection only; per-agent **model** is configured in the dashboard Agent Models widget, exactly as for claude/codex (the wizard has never selected models). The model then takes effect via Gap A.

## Part C
`MODEL_OPTIONS.gemini` (`gemini-2.5-pro` / `gemini-2.5-flash`) left unchanged — both are current and I won't add unverified slugs without an installed CLI to confirm.

## Testability + test
`buildAgentArgs` wasn't exported, and `index.js` calls `server.listen` at import time (the bin `require`s it for side effects, so `require.main` can't gate it). Added a `QUADWORK_SKIP_LISTEN` env guard around the top-level `listen` + poller and exported `buildAgentArgs`. Production never sets the var, so `quadwork start` / `node server/` are unaffected.

New `server/agentArgs.gemini.test.js` — **8 assertions**: gemini forwards `--model <slug>`, no `--model` when unset (CLI default), `--yolo` preserved; **codex still uses `-c model="…"` and claude still uses `--model` (no regression)**.

## Acceptance criteria
- [x] A gemini agent receives its configured `model` on the spawned command (asserted); CLI default when unset
- [x] Setup wizard offers **gemini** as a per-agent provider, persisted to config (`command: gemini`)
- [x] No regression to claude / codex agents (asserted in tests; build/suite green)
- [x] `npm run build` passes
- [~] End-to-end spawn of a live gemini agent — not runnable here (no `gemini` CLI installed); covered by unit assertions + existing env-injection plumbing. Needs a manual smoke on a CLI-equipped host.

## Verification
- `npm test` → **39 passed, 0 failed** (incl. the new gemini test).
- `npm run build` → exit 0, compiled successfully.
- `eslint` on changed components → 0 errors (2 pre-existing unrelated warnings).
- Test file excluded from the npm tarball by the existing `!server/**/*.test.js` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)