### PR TITLE
[#908] Setup wizard: default to an installed CLI for all multi-CLI combos + unify single-CLI message

### DIFF
--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -357,6 +357,14 @@ export default function SetupWizard() {
         } else if (status.claude && status.codex) {
           // Both Claude + Codex available — mixed defaults for review diversity
           setBackends({ head: "codex", dev: "claude", re1: "codex", re2: "claude" });
+        } else if (installed.length >= 1) {
+          // #908: any other multi-install combo without claude+codex (e.g.
+          // codex+gemini, claude+gemini). Without this the wizard would keep
+          // its initial all-"claude" default — which may be uninstalled here —
+          // and submit worktrees with an uninstalled backend. Default every
+          // agent to an installed CLI instead.
+          const only = installed[0];
+          setBackends({ head: only, re1: only, re2: only, dev: only });
         }
       })
       .catch(() => {});
@@ -778,29 +786,26 @@ export default function SetupWizard() {
                   {t.modelsStep.desc}
                 </p>
 
-                {/* Single-CLI friendly message */}
-                {cliStatus && !cliStatus.claude && cliStatus.codex && (
-                  <div className="border border-accent/20 bg-accent/5 p-3 mb-4 text-[11px]">
-                    <p className="text-text">You have Codex CLI installed — great! All 4 agents will use Codex.</p>
-                    <p className="text-text-muted mt-1.5">
-                      Tip: Installing Claude Code too gives your team different AI perspectives,
-                      which can improve code review quality. You can add it anytime:
-                    </p>
-                    <p className="text-accent mt-1 font-mono text-[10px]">npm install -g @anthropic-ai/claude-code</p>
-                    <p className="text-text-muted mt-1.5">For now, Codex CLI handles everything perfectly. Let&apos;s continue!</p>
-                  </div>
-                )}
-                {cliStatus && cliStatus.claude && !cliStatus.codex && (
-                  <div className="border border-accent/20 bg-accent/5 p-3 mb-4 text-[11px]">
-                    <p className="text-text">You have Claude Code installed — great! All 4 agents will use Claude.</p>
-                    <p className="text-text-muted mt-1.5">
-                      Tip: Installing Codex CLI too gives your team different AI perspectives,
-                      which can improve code review quality. You can add it anytime:
-                    </p>
-                    <p className="text-accent mt-1 font-mono text-[10px]">npm install -g codex</p>
-                    <p className="text-text-muted mt-1.5">For now, Claude Code handles everything perfectly. Let&apos;s continue!</p>
-                  </div>
-                )}
+                {/* #908: single-CLI friendly message — one generic block for
+                    whichever CLI is the only one installed (claude / codex /
+                    gemini). Replaces the old claude-only + codex-only blocks,
+                    which missed gemini-only and mis-fired for multi-install
+                    combos (e.g. codex+gemini) that aren't single-CLI. */}
+                {cliStatus && (() => {
+                  const installed = (["claude", "codex", "gemini"] as const).filter((c) => cliStatus[c]);
+                  if (installed.length !== 1) return null;
+                  const label = BACKENDS.find((b) => b.value === installed[0])?.label || installed[0];
+                  return (
+                    <div className="border border-accent/20 bg-accent/5 p-3 mb-4 text-[11px]">
+                      <p className="text-text">You have {label} installed — great! All 4 agents will use {label}.</p>
+                      <p className="text-text-muted mt-1.5">
+                        Tip: installing another CLI (Claude Code, Codex, or Gemini) gives your team
+                        different AI perspectives, which can improve code review quality. You can add one anytime.
+                      </p>
+                      <p className="text-text-muted mt-1.5">For now, {label} handles everything perfectly. Let&apos;s continue!</p>
+                    </div>
+                  );
+                })()}
 
                 <div className="border border-border mb-4">
                   {AGENTS.map((agent) => (


### PR DESCRIPTION
Fixes #908. Regression I introduced in #906, caught by @re2 in the Batch 16 pr-review.

## The regression
The auto-default in `SetupWizard.tsx` was:
```ts
const installed = (["claude","codex","gemini"] as const).filter((c) => status[c]);
if (installed.length === 1) { setBackends(all installed[0]); }
else if (status.claude && status.codex) { /* mixed codex/claude */ }
// else: nothing → stays at the initial { all: "claude" }
```
For a **codex+gemini box with Claude NOT installed**, `installed.length === 2` and `status.claude` is false, so **neither branch fired** — the wizard kept its initial all-`claude` default, which is uninstalled (the dropdown shows it `disabled` + "(not installed)"). Submitting without manually fixing all four dropdowns would drive `create-worktrees` with an uninstalled backend. Pre-#906 this combo correctly defaulted all-codex.

## Fix
Add a final fallback so any uncovered multi-install combo defaults to an **installed** CLI:
```ts
else if (installed.length >= 1) { setBackends(all installed[0]); }
```

## Bundled: Gemini-only friendly message (@re1 finding)
The two hardcoded single-CLI message blocks (claude-only / codex-only) missed **gemini-only** entirely, and their conditions (`!claude && codex`) also mis-fired for multi-install combos like codex+gemini. Replaced both with **one generic single-provider block** that renders only when exactly one CLI is installed and names it (Claude Code / Codex / Gemini CLI).

## Combos verified (all 4 agents)
| Installed | Default |
|---|---|
| claude only / codex only / gemini only | all that CLI (+ friendly message) |
| claude + codex | mixed codex/claude (review diversity) |
| claude + gemini | all claude *(installed)* |
| **codex + gemini** *(the regressed combo)* | **all codex** *(installed)* |
| all three | mixed codex/claude |
| none | unchanged (can't proceed anyway) |

No agent defaults to an uninstalled CLI in any combo.

## Verification
- `npm run build` → exit 0, compiled successfully.
- `eslint src/components/SetupWizard.tsx` → 0 errors (2 pre-existing unrelated `repo` warnings).
- `npm test` → 39 passed / 0 failed (frontend-only; server suite unaffected).
- No frontend/TS test harness exists in this repo (all tests are plain-node server tests), so the combo matrix above is verified by build + exhaustive logic trace rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)