### PR TITLE
[#910] Auto-respawn exited agents + clear stale 'running' via watchdog liveness probe

### DIFF
--- a/server/agentLiveness.test.js
+++ b/server/agentLiveness.test.js
@@ -1,0 +1,36 @@
+"use strict";
+
+// #910: isPtyAlive is the watchdog's liveness probe — it must report a session
+// whose process has exited as dead so the dashboard never shows a stale
+// `running`. QUADWORK_SKIP_LISTEN + a temp HOME let us require the server module
+// for the exported helper without starting the server (see #905).
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const TMP_HOME = path.join(os.tmpdir(), `quadwork-liveness-test-${process.pid}`);
+process.env.HOME = TMP_HOME;
+process.env.QUADWORK_SKIP_LISTEN = "1";
+fs.mkdirSync(path.join(TMP_HOME, ".quadwork"), { recursive: true });
+fs.writeFileSync(path.join(TMP_HOME, ".quadwork", "config.json"), JSON.stringify({ projects: [] }));
+
+const { isPtyAlive } = require("./index");
+
+let passed = 0, failed = 0;
+const assert = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+// A live process — our own pid — is alive.
+assert(isPtyAlive({ pid: process.pid }) === true, "isPtyAlive: own pid → alive");
+
+// A pid that does not exist → dead (process.kill throws ESRCH).
+assert(isPtyAlive({ pid: 2147483646 }) === false, "isPtyAlive: nonexistent pid → dead");
+
+// Defensive: no term / no pid → not alive (so a registration-failed session
+// isn't treated as running).
+assert(isPtyAlive(null) === false, "isPtyAlive: null term → not alive");
+assert(isPtyAlive({}) === false, "isPtyAlive: term without pid → not alive");
+
+try { fs.rmSync(TMP_HOME, { recursive: true, force: true }); } catch {}
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/server/index.js
+++ b/server/index.js
@@ -547,14 +547,7 @@ async function spawnAgentPty(project, agent, opts = {}) {
     term.onExit(({ exitCode }) => {
       const current = agentSessions.get(key);
       if (current && current.term === term) {
-        cleanupPtyDispatcher(key);
-        current.state = "stopped";
-        current.error = exitCode ? `exit:${exitCode}` : null;
-        current.term = null;
-        for (const v of current.viewers) {
-          if (v.readyState <= 1) v.close(1000, `exited:${exitCode}`);
-        }
-        current.viewers.clear();
+        markSessionExited(key, current, exitCode);
       }
     });
 
@@ -562,6 +555,37 @@ async function spawnAgentPty(project, agent, opts = {}) {
   } catch (err) {
     agentSessions.set(key, { projectId: project, agentId: agent, term: null, viewers: new Set(), viewerDims: new Map(), lastDims: null, state: "error", error: err.message });
     return { ok: false, error: err.message };
+  }
+}
+
+// #910: mark a session whose CLI process exited on its own (clean exit OR
+// crash) as stopped, and flag it `exitedUnexpectedly` so the watchdog will
+// auto-respawn it for a non-idle project. Shared by term.onExit and the
+// watchdog liveness probe (which catches the case where onExit never fired and
+// the dashboard was left showing a stale `running`).
+function markSessionExited(key, session, exitCode) {
+  cleanupPtyDispatcher(key);
+  session.state = "stopped";
+  session.error = exitCode ? `exit:${exitCode}` : null;
+  session.term = null;
+  session.exitedUnexpectedly = true;
+  for (const v of session.viewers) {
+    if (v.readyState <= 1) v.close(1000, `exited:${exitCode == null ? "" : exitCode}`);
+  }
+  session.viewers.clear();
+}
+
+// #910: is the PTY's child process still alive? signal 0 probes without
+// delivering a signal: ESRCH → gone, EPERM → alive but not ours. A session can
+// read `running` while its process is already dead if onExit didn't fire; this
+// is how the watchdog detects that and clears the stale state.
+function isPtyAlive(term) {
+  if (!term || typeof term.pid !== "number") return false;
+  try {
+    process.kill(term.pid, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === "EPERM";
   }
 }
 
@@ -594,6 +618,8 @@ async function stopAgentSession(key, { clearSelfHeal = false } = {}) {
   session.viewers.clear();
   session.state = "stopped";
   session.error = null;
+  // #910: a manual stop is intentional — do NOT let the watchdog respawn it.
+  session.exitedUnexpectedly = false;
   const [projectId, agentId] = key.split("/");
   if (projectId && agentId) stopMcpProxy(projectId, agentId);
 }
@@ -1811,16 +1837,56 @@ if (!process.env.QUADWORK_SKIP_LISTEN) {
 const WATCHDOG_TIMEOUT_MS = 10 * 60 * 1000;
 let _watchdogHandle = null;
 
-function watchdogCheck() {
+async function watchdogCheck() {
+  const toRespawn = [];
   for (const [key, session] of agentSessions) {
-    if (session.state !== "running" || !session.term) continue;
-    if (!session.lastOutputAt) continue;
-    // #732: skip file-chat projects — idle is normal, PTY dispatch wakes them
-    if (routes.getProjectChatMode(session.projectId) === "file") continue;
-    if (Date.now() - session.lastOutputAt > WATCHDOG_TIMEOUT_MS) {
+    // #910: liveness probe — a session can read `running` while its CLI process
+    // already exited (onExit didn't fire / process died without it), leaving a
+    // false green dot. Detect the dead pid and clear the stale state.
+    if (session.state === "running" && session.term && !isPtyAlive(session.term)) {
+      console.log(`[watchdog] ${key}: PTY process gone while state was 'running' — marking stopped`);
+      markSessionExited(key, session, null);
+    }
+
+    // #797/#825: stuck-agent detection (running but silent) — Ctrl+C nudge.
+    // #732: skip file-chat projects — idle is normal, PTY dispatch wakes them.
+    if (session.state === "running" && session.term && session.lastOutputAt
+        && routes.getProjectChatMode(session.projectId) !== "file"
+        && Date.now() - session.lastOutputAt > WATCHDOG_TIMEOUT_MS) {
       console.log(`[watchdog] ${key}: no output for 10m — sending Ctrl+C`);
       safeWrite(session.term, "\x03");
       session.lastOutputAt = Date.now();
+    }
+
+    // #910: collect agents that exited on their own (clean exit / crash) for
+    // auto-respawn. Operator-stopped agents have exitedUnexpectedly=false.
+    if (session.exitedUnexpectedly && session.state !== "running" && !session.term) {
+      toRespawn.push(key);
+    }
+  }
+
+  // #910: respawn exited agents for non-idle projects, after iterating (spawn
+  // mutates agentSessions). The self-heal respawn breaker caps repeated deaths
+  // so a session that keeps dying isn't loop-respawned.
+  for (const key of toRespawn) {
+    const session = agentSessions.get(key);
+    if (!session || !session.exitedUnexpectedly) continue;
+    const [projectId, agentId] = key.split("/");
+    if (!projectId || !agentId) continue;
+    if (isProjectIdleId(projectId)) continue; // #812: parked project — leave stopped
+    const decision = selfHeal.shouldRespawn(key, {
+      now: Date.now(),
+      onBreaker: (message) => { console.log(`[watchdog] ${key}: ${message}`); emitSystemMessage(projectId, message); },
+    });
+    if (decision !== "respawn") continue; // breaker tripped — leave stopped
+    session.exitedUnexpectedly = false; // consume the flag for this attempt
+    console.log(`[watchdog] ${key}: agent exited — auto-respawning`);
+    try {
+      const result = await spawnAgentPty(projectId, agentId, { suppressLifecycleMsg: true });
+      if (result.ok) emitSystemMessage(projectId, `${agentId} auto-respawned (had exited)`);
+      else console.error(`[watchdog] ${key}: auto-respawn failed: ${result.error}`);
+    } catch (err) {
+      console.error(`[watchdog] ${key}: auto-respawn threw: ${err.message}`);
     }
   }
 }
@@ -1961,4 +2027,4 @@ function shutdown() {
   }
 }
 
-module.exports = { shutdown, buildAgentArgs, buildAgentEnv };
+module.exports = { shutdown, buildAgentArgs, buildAgentEnv, isPtyAlive };

--- a/server/self-heal.js
+++ b/server/self-heal.js
@@ -83,9 +83,53 @@ function observeChunk(key, data, opts = {}) {
   }
 }
 
-// Drop guard state for an agent (e.g. on permanent stop).
+// #910: auto-respawn breaker. Separate concern from the thinking-block restart
+// above: the watchdog calls this when an agent's CLI process has EXITED on its
+// own (clean exit / crash) and the project is non-idle, to bring the long-lived
+// listener back. Its own window/limit so a session that keeps dying immediately
+// isn't loop-respawned forever (which would only mask a deeper failure).
+const RESPAWN_WINDOW_MS = 10 * 60 * 1000;
+const RESPAWN_MAX = 5;
+// key -> { respawns: number[], breakerNotified: boolean }
+const _respawnState = new Map();
+
+function respawnBreakerMessage(agent) {
+  return `${agent} keeps exiting and could not be kept running — auto-respawn paused, manual attention needed`;
+}
+
+// Decide whether to auto-respawn an exited agent, recording the attempt when
+// allowed. Pure decision + per-agent guard state (now injected for tests).
+// Returns "respawn" (caller should spawn) or "breaker" (too many recently —
+// refuse). onBreaker(message) fires once, the first time the breaker trips.
+function shouldRespawn(key, opts = {}) {
+  const now = opts.now;
+  const agent = key.split("/")[1] || key;
+  const st = _respawnState.get(key) || { respawns: [], breakerNotified: false };
+  // Drop attempts older than the window, then refuse if we've already hit MAX.
+  st.respawns = st.respawns.filter((t) => now - t < RESPAWN_WINDOW_MS);
+  if (st.respawns.length >= RESPAWN_MAX) {
+    const firstTrip = !st.breakerNotified;
+    st.breakerNotified = true;
+    _respawnState.set(key, st);
+    if (firstTrip && typeof opts.onBreaker === "function") {
+      try { opts.onBreaker(respawnBreakerMessage(agent)); } catch {}
+    }
+    return "breaker";
+  }
+  st.respawns.push(now);
+  // A successful respawn means the agent is healthy again — let the breaker
+  // re-arm by clearing the one-shot notify flag.
+  st.breakerNotified = false;
+  _respawnState.set(key, st);
+  return "respawn";
+}
+
+// Drop guard state for an agent (e.g. on permanent / manual stop). Clears BOTH
+// the thinking-block window and the respawn window, so a manual stop/restart
+// resets both breakers (#825 + #910).
 function clearState(key) {
   _state.delete(key);
+  _respawnState.delete(key);
 }
 
 module.exports = {
@@ -93,8 +137,13 @@ module.exports = {
   isThinkingBlock400,
   breakerMessage,
   clearState,
+  shouldRespawn,
+  respawnBreakerMessage,
   _state,
+  _respawnState,
   COOLDOWN_MS,
   CIRCUIT_WINDOW_MS,
   CIRCUIT_MAX,
+  RESPAWN_WINDOW_MS,
+  RESPAWN_MAX,
 };

--- a/server/self-heal.test.js
+++ b/server/self-heal.test.js
@@ -142,6 +142,46 @@ function runTests() {
     assert(breakerMsgs.length === 1, "the reset did not re-emit the breaker message");
   }
 
+  // --- Test 8 (#910): respawn breaker allows up to RESPAWN_MAX in-window, then trips ---
+  {
+    selfHeal._respawnState.clear();
+    const { shouldRespawn, respawnBreakerMessage, RESPAWN_MAX, RESPAWN_WINDOW_MS } = selfHeal;
+    let breakerMsgs = [];
+    const onBreaker = (m) => breakerMsgs.push(m);
+
+    // First RESPAWN_MAX exits in the window each get a respawn.
+    let respawns = 0;
+    for (let i = 0; i < RESPAWN_MAX; i++) {
+      if (shouldRespawn(KEY, { now: 1000 + i * 1000, onBreaker }) === "respawn") respawns++;
+    }
+    assert(respawns === RESPAWN_MAX, `respawns up to RESPAWN_MAX (${RESPAWN_MAX}) within the window`);
+
+    // The next exit inside the window trips the breaker.
+    const tripped = shouldRespawn(KEY, { now: 1000 + RESPAWN_MAX * 1000, onBreaker });
+    assert(tripped === "breaker", "exit beyond RESPAWN_MAX in-window → breaker");
+    assert(breakerMsgs.length === 1 && breakerMsgs[0] === respawnBreakerMessage("dev"), "respawn breaker notifies once, names the agent");
+
+    // Still tripped, no re-spam, while inside the window.
+    const again = shouldRespawn(KEY, { now: 1000 + (RESPAWN_MAX + 1) * 1000, onBreaker });
+    assert(again === "breaker" && breakerMsgs.length === 1, "respawn breaker stays tripped without re-spamming");
+
+    // After the window passes, attempts age out and respawn is allowed again.
+    const later = shouldRespawn(KEY, { now: 1000 + RESPAWN_WINDOW_MS + 10_000, onBreaker });
+    assert(later === "respawn", "after the window, old attempts age out → respawn allowed again");
+  }
+
+  // --- Test 9 (#910): clearState resets the respawn breaker too (manual stop) ---
+  {
+    selfHeal._respawnState.clear();
+    const { shouldRespawn, RESPAWN_MAX } = selfHeal;
+    // Trip the breaker: RESPAWN_MAX allowed, then the next refuses.
+    for (let i = 0; i < RESPAWN_MAX; i++) shouldRespawn(KEY, { now: 1000 + i * 1000 });
+    assert(shouldRespawn(KEY, { now: 1000 + RESPAWN_MAX * 1000 }) === "breaker", "precondition: respawn breaker tripped");
+    clearState(KEY);
+    assert(!selfHeal._respawnState.has(KEY), "clearState drops the respawn-breaker state");
+    assert(shouldRespawn(KEY, { now: 1000 + RESPAWN_MAX * 1000 + 1 }) === "respawn", "after clearState, respawn allowed again (manual stop re-enables)");
+  }
+
   console.log(`\n${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
Fixes #910. The recurring "agents stopped again" — reviewer CLIs exit on their own after their turn, the dashboard keeps showing a false green `running`, and self-heal (which only catches *stuck* agents at the 10m threshold) never brings them back. Three fixes, all in the existing 60s watchdog.

## 1. No stale `running` — liveness probe (AC1)
New `isPtyAlive(term)` uses `process.kill(pid, 0)` (ESRCH → process gone; EPERM → alive but not ours). The watchdog now checks every `running` session: if its PTY process is actually dead — i.e. `term.onExit` never fired — it clears the session to `stopped` within one cycle, so `/api/agents` and the dashboard dots reflect the real process state. `onExit` and this probe share one `markSessionExited` helper.

## 2. Auto-respawn clean exits (AC2)
`markSessionExited` flags the session `exitedUnexpectedly`. The watchdog respawns any such session for a **non-idle** project (`isProjectIdleId`), via `spawnAgentPty`. Crucially:
- A **manual stop** (`stopAgentSession`) sets `exitedUnexpectedly = false` → operator-stopped agents are **never** resurrected.
- Agents the operator never started have no session entry → not auto-started. We only respawn agents that *were* running and exited.

## 3. Respawn circuit breaker (don't loop-respawn a dying session)
New `selfHeal.shouldRespawn(key)` (pure, unit-tested) allows `RESPAWN_MAX` (5) respawns per 10-min window, then trips and notifies once — so a session that keeps dying immediately isn't respawned forever (which would only mask a deeper failure). It re-arms after the window. `selfHeal.clearState` now resets the respawn window too, so a manual stop/restart re-enables auto-respawn.

## Root cause of the CLI exits (AC3)
codex/claude are meant to be long-lived listener processes but exit on their own at turn-end / EOF / idle. **I could not reproduce the exact per-CLI trigger in this environment** (no live agents on the host to walk). So the fix treats *any* unexpected PTY exit as recoverable and respawns — addressing the symptom robustly regardless of the precise trigger. Worth confirming the exact trigger during live VPS operation and tuning if a specific CLI flag (e.g. a keep-alive/no-exit mode) turns out to exist.

## Acceptance criteria
- [x] On CLI exit, backend marks `stopped` within one watchdog cycle (no stale `running`) — `onExit` + liveness probe
- [x] Self-heal auto-respawns a cleanly-exited agent for a non-idle project, subject to a breaker
- [x] Root cause identified/documented (CLI exits at turn-end/EOF/idle; exact trigger not reproducible here — documented)
- [x] `npm run build` + tests pass

## Verification
- `server/self-heal.test.js` +2: respawn breaker allows `RESPAWN_MAX` then trips (notifies once), ages out after the window, and `clearState` resets it.
- New `server/agentLiveness.test.js`: `isPtyAlive` → own pid alive, nonexistent pid dead, null / no-pid → not alive.
- `npm test` → **40 passed, 0 failed**. `npm run build` → exit 0.
- Watchdog wiring (probe → mark → respawn, manual-stop exclusion, idle-project skip, post-iteration respawn to avoid mutating the map mid-loop) verified by reading; the pure breaker + liveness primitive are unit-tested. No frontend change — `stopped` is an existing dashboard state, so no new status styling needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)