### PR TITLE
[#915] Auto-retry deferred reseeds without a server restart

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1815,6 +1815,29 @@ if (!process.env.QUADWORK_SKIP_LISTEN) {
   setInterval(autoStopPollingTick, AUTO_STOP_POLL_INTERVAL_MS);
 }
 
+// #915: retry deferred reseeds without a server restart. A reseed deferred on
+// boot because a project's batch was active used to wait for the next startup —
+// stranding a busy project on old seeds indefinitely. autoReseedOnStartup is
+// idempotent (current projects skip, active ones defer, idle pending ones get
+// re-seeded), so re-running it on a tick re-attempts any pending project once
+// its batch clears, keeping the fail-closed mid-batch guard intact.
+const RESEED_RETRY_INTERVAL_MS = 60_000;
+let _reseedRetryRunning = false;
+async function reseedRetryTick() {
+  if (_reseedRetryRunning) return; // a slow tick must not overlap the next
+  _reseedRetryRunning = true;
+  try {
+    await routes.autoReseedOnStartup(readConfig(), { periodic: true });
+  } catch (err) {
+    console.error(`[reseed] periodic retry failed: ${err.message}`);
+  } finally {
+    _reseedRetryRunning = false;
+  }
+}
+if (!process.env.QUADWORK_SKIP_LISTEN) {
+  setInterval(reseedRetryTick, RESEED_RETRY_INTERVAL_MS);
+}
+
 // #422 / quadwork#310: auto-continue after loop guard.
 //
 // Per opted-in project, poll AC's /api/status every 10s. When we see

--- a/server/routes.autoReseed.test.js
+++ b/server/routes.autoReseed.test.js
@@ -193,8 +193,8 @@ function quietLog() {
     assert.deepEqual(out.decisions[0], { projectId: "busy", action: "deferred", reason: "batch active" });
     assert.deepEqual(ctx.writes, []);
     assert.deepEqual(_loadReseedState(ctx.statePath), { completedByProjectVersion: {} });
-    assert.ok(ctx.lines.some((l) => /will retry on next startup/.test(l)),
-      "deferral is logged with retry hint");
+    assert.ok(ctx.lines.some((l) => /will retry automatically once the batch clears/.test(l)),
+      "deferral is logged with the no-restart retry hint");
   }
 
   // 5. Batch state unknown (null result) → defer.
@@ -377,6 +377,64 @@ function quietLog() {
       performWrites: (p) => { writesAgain.push(p.id); return _performReseedWrites(p, cfg); },
     });
     assert.deepEqual(writesAgain, [], "second startup at same version skips already-current projects");
+  }
+
+  // 11. #915: deferred (active) → periodic retry once the batch clears re-seeds
+  //     WITHOUT a server restart. Simulates the recurring reseedRetryTick:
+  //     same statePath re-used across calls, no boot in between.
+  {
+    const cfg = { projects: [{ id: "busy915", working_dir: "/tmp/busy915" }] };
+    const dir = tmp("periodic-retry");
+    const statePath = path.join(dir, "state.json");
+    let batchActive = true;
+    const writes = [];
+    const performWrites = (p) => { writes.push(p.id); return { reseeded: ["head/AGENTS.md"], skipped: [], preserved: {} }; };
+    const getProgress = async () => batchActive
+      ? { items: [{ status: "in_review" }], complete: false }
+      : { items: [], complete: false };
+    const { log, lines } = quietLog();
+    const tick = () => autoReseedOnStartup(cfg, { version: "2.1.0", statePath, getProgress, performWrites, log, periodic: true });
+
+    // Tick 1 + 2 while the batch is active: deferred, state unchanged, NO writes.
+    await tick();
+    await tick();
+    assert.deepEqual(writes, [], "periodic ticks during an active batch never reseed");
+    assert.equal(_loadReseedState(statePath).completedByProjectVersion.busy915, undefined, "state stays pending while deferred");
+    assert.ok(!lines.some((l) => /busy915/.test(l)), "periodic deferral is NOT logged (no per-tick spam)");
+
+    // Batch clears → next tick reseeds, no restart needed.
+    batchActive = false;
+    const out = await tick();
+    assert.equal(out.decisions[0].action, "reseeded");
+    assert.deepEqual(writes, ["busy915"], "reseed runs on the tick after the batch clears");
+    assert.equal(_loadReseedState(statePath).completedByProjectVersion.busy915, "2.1.0", "state advances once reseeded");
+
+    // Further ticks are a no-op skip (idempotent).
+    writes.length = 0;
+    const out2 = await tick();
+    assert.equal(out2.decisions[0].action, "skip");
+    assert.deepEqual(writes, [], "already-current project is skipped on later ticks");
+  }
+
+  // 12. #915: periodic=false (startup) still logs the deferral; periodic=true
+  //     suppresses it — same decision either way.
+  {
+    const cfg = { projects: [{ id: "loud", working_dir: "/tmp/loud" }] };
+    const mk = (periodic) => {
+      const dir = tmp(`log-${periodic}`);
+      const statePath = path.join(dir, "state.json");
+      const { log, lines } = quietLog();
+      return { lines, run: () => autoReseedOnStartup(cfg, {
+        version: "2.1.0", statePath, log, periodic,
+        getProgress: async () => ({ items: [{ status: "in_review" }], complete: false }),
+      }) };
+    };
+    const boot = mk(false); const bootOut = await boot.run();
+    const tickCtx = mk(true); const tickOut = await tickCtx.run();
+    assert.equal(bootOut.decisions[0].action, "deferred");
+    assert.equal(tickOut.decisions[0].action, "deferred");
+    assert.ok(boot.lines.some((l) => /loud/.test(l)), "startup logs the deferral");
+    assert.ok(!tickCtx.lines.some((l) => /loud/.test(l)), "periodic tick suppresses the deferral log");
   }
 
   console.log("routes.autoReseed.test.js: all assertions passed");

--- a/server/routes.js
+++ b/server/routes.js
@@ -3604,6 +3604,14 @@ router.post("/api/projects/:project/reseed-agents", async (req, res) => {
   } catch (err) {
     return res.status(500).json({ ok: false, error: err.message });
   }
+  // #915: a manual reseed writes the current-version seeds, so advance the
+  // auto-reseed marker too — otherwise it read stale (e.g. 2.2.1) after a
+  // manual reseed to 2.3.0 and auto-reseed redundantly re-ran on next boot.
+  try {
+    const state = _loadReseedState();
+    state.completedByProjectVersion[projectId] = _readPackageVersion();
+    _saveReseedState(state);
+  } catch { /* best-effort marker update; auto-reseed re-running is harmless/idempotent */ }
   return res.json({
     ok: true,
     reseeded: result.reseeded,
@@ -3734,6 +3742,13 @@ async function autoReseedOnStartup(cfg, opts = {}) {
   const getProgress = opts.getProgress || getOrComputeBatchProgress;
   const isActiveFromProgress = opts.isActiveFromProgress || isBatchActiveFromProgress;
   const performWrites = opts.performWrites || _performReseedWrites;
+  // #915: `periodic` = invoked from the recurring retry tick, not boot. A
+  // still-deferred project is expected on every tick until its batch clears, so
+  // suppress the deferral log there (it would spam) — reseeded/error events
+  // still log. Deferral is otherwise identical: the project stays pending and
+  // is retried on the next tick, NO server restart required.
+  const periodic = !!opts.periodic;
+  const logDeferred = periodic ? () => {} : log;
 
   const state = _loadReseedState(statePath);
   const decisions = [];
@@ -3755,17 +3770,17 @@ async function autoReseedOnStartup(cfg, opts = {}) {
       active = isActiveFromProgress(progress);
     } catch (err) {
       decisions.push({ projectId: project.id, action: "deferred", reason: `batch-state check threw: ${err.message}` });
-      log(`[reseed] ${project.id}: deferred — batch state unknown (${err.message}); will retry on next startup`);
+      logDeferred(`[reseed] ${project.id}: deferred — batch state unknown (${err.message}); will retry automatically once the batch clears (no restart required)`);
       continue;
     }
     if (active === null) {
       decisions.push({ projectId: project.id, action: "deferred", reason: "batch state unknown" });
-      log(`[reseed] ${project.id}: deferred — batch state unknown; will retry on next startup`);
+      logDeferred(`[reseed] ${project.id}: deferred — batch state unknown; will retry automatically once the batch clears (no restart required)`);
       continue;
     }
     if (active === true) {
       decisions.push({ projectId: project.id, action: "deferred", reason: "batch active" });
-      log(`[reseed] ${project.id}: deferred — batch active; will retry on next startup`);
+      logDeferred(`[reseed] ${project.id}: deferred — batch active; will retry automatically once the batch clears (no restart required)`);
       continue;
     }
 
@@ -3774,7 +3789,7 @@ async function autoReseedOnStartup(cfg, opts = {}) {
       result = performWrites(project, cfg, {});
     } catch (err) {
       decisions.push({ projectId: project.id, action: "error", error: err.message });
-      log(`[reseed] ${project.id}: ERROR — ${err.message}; state NOT advanced, will retry on next startup`);
+      log(`[reseed] ${project.id}: ERROR — ${err.message}; state NOT advanced, will retry automatically (next tick or restart)`);
       continue;
     }
 


### PR DESCRIPTION
Fixes #915. Real incident: during the 2.3.0 upgrade, plotlink-ows's reseed was deferred (batch active) and — because a deferred reseed only retried on the *next server startup* (#856) — it stayed on 2.2.1 seeds for hours, with no `ticket-review`/`pr-review` instructions, deadlocking the review batch the operator requested.

## Fix: retry on a tick, no restart
`autoReseedOnStartup` is already idempotent and dependency-injected, so I run it on a recurring **60s `reseedRetryTick`** (`server/index.js`, guarded by `QUADWORK_SKIP_LISTEN` like the other pollers):
- Current-version projects skip cheaply (string equality, no GitHub call, no write).
- Active-batch projects still **defer** — the fail-closed mid-batch guard is fully preserved.
- An **idle pending** project is re-seeded within one tick of its batch clearing — no server restart.
- A `_reseedRetryRunning` re-entrancy flag prevents a slow tick from overlapping the next.

This satisfies the AC's "retry when the batch completes **or** on a periodic tick" — the tick catches the completion within ~60s.

## Quiet periodic mode
New `periodic` opt on `autoReseedOnStartup`: on the recurring tick a still-deferred project recurs every cycle, so its deferral log is suppressed there (it would spam); `reseeded`/`error` events still log. Deferral semantics are identical (stays pending, retried next tick). The now-inaccurate "will retry on next startup" wording is updated to "...automatically once the batch clears (no restart required)".

## Optional AC: manual reseed advances the marker
`POST /api/projects/:project/reseed-agents` now advances `reseed-state.json`'s `completedByProjectVersion` on success (best-effort) — it previously left the marker stale (e.g. `2.2.1` after a manual reseed to `2.3.0`), causing auto-reseed to redundantly re-run on next boot.

## Acceptance criteria
- [x] Deferred-due-to-active-batch reseed is auto-re-attempted when the batch completes / on a tick — no restart
- [x] A project upgraded mid-batch lands on new seeds within ~one tick (60s) of the batch finishing
- [x] Fail-closed "don't reseed during an active batch" guard preserved
- [x] (optional) manual reseed advances the reseed-state marker
- [x] Tests: deferred → batch completes → reseed runs

## Verification
- `server/routes.autoReseed.test.js` +2: (11) deferred-active project, two periodic ticks → no reseed/no log spam/state pending; batch clears → next tick reseeds + advances state; later tick is a no-op skip — **all with the same statePath, no boot in between**. (12) periodic suppresses the deferral log while startup still logs it (same decision). Existing test 4 wording assertion updated.
- `npm test` → **40 passed, 0 failed**. `npm run build` → exit 0.
- The manual-endpoint marker update reuses the unit-tested `_loadReseedState`/`_saveReseedState`/`_readPackageVersion` helpers (the route reads the real `CONFIG_PATH`/`RESEED_STATE_PATH`, so it isn't HTTP-tested here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)