### PR TITLE
[#914] operator-mcp.md: operating model + 'never' rules, fix Typical-flow anti-pattern, document review batches

### DIFF
--- a/docs/operator-mcp.md
+++ b/docs/operator-mcp.md
@@ -6,6 +6,37 @@ It is the same surface a human operator uses from the dashboard, exposed as tool
 
 > **The MCP client must run on the same machine as QuadWork.** The server only reaches `127.0.0.1:<port>` — see [Remote / VPS](#remote--vps-registration) below.
 
+## Operating model — read this first
+
+You operate QuadWork **exclusively through these MCP tools**. QuadWork is a team
+of four agents (**Head, Dev, Reviewer1, Reviewer2**) coordinating over a chat;
+you act as the human operator by talking to them.
+
+- **HEAD owns the queue.** `OVERNIGHT-QUEUE.md` has a strict format (batch
+  numbering, `**Batch type:**` markers, per-item state annotations). **HEAD
+  writes it.** To start any batch you `send_message` HEAD a plain-English
+  request — you do **not** write the queue yourself.
+- **The tools are the whole surface.** Everything a human operator can do is a
+  tool. If something seems to need a shell, a file edit, or an HTTP call, it
+  doesn't — there's a tool, or it's HEAD's job.
+
+### Never
+
+- **Never SSH into the host** to run `sed`/`grep`/`find`/`git`/etc. The tools
+  reach the running instance; the host filesystem is not your interface.
+- **Never edit `OVERNIGHT-QUEUE.md` (or any project file) by hand.** Ask HEAD
+  via `send_message`; HEAD formats it correctly. Hand-written queues cause
+  malformed items, confirm-loop deadlocks, and a stuck progress panel.
+- **Never `curl` / hit the backend HTTP API directly.** Use the tool that wraps
+  it.
+- **Never reverse-engineer internals** (seed files, `routes.js`, the queue
+  grammar) to improvise. If a tool doesn't cover what you need, `send_message`
+  HEAD and let the team handle it.
+
+> **If `list_projects` fails, the MCP is not registered/connected — fix THAT
+> first** (see [Registration](#registration)); do **not** fall back to SSH or
+> curl. No tools = not connected, not a reason to hand-operate.
+
 ## Registration
 
 The package installs a dedicated bin, `quadwork-mcp-operator`. Always register with the bin (never a `<quadwork-dir>/server/...` path — that breaks on global/VPS installs).
@@ -69,17 +100,47 @@ The operator server speaks to `127.0.0.1:8400` — the loopback of **whatever ma
 
 | Tool | Input | Does |
 |------|-------|------|
-| `send_message` | `project`, `text` | Post to the team chat **as the operator** (see security note). |
-| `set_batch` | `project`, `content` | Replace `OVERNIGHT-QUEUE.md` (full overwrite). |
-| `append_batch` | `project`, `content` | Append to the queue (read-then-write). |
-| `ensure_batch` | `project` | Create the queue from template if absent (idempotent). |
-| `start_batch` | `project`, `interval_min?`, `duration_min?`, `message?` | Start the scheduled trigger that drives the batch. |
+| `send_message` | `project`, `text` | Post to the team chat **as the operator** (see security note). **This is how you start and steer batches** — `@head <plain request>`. |
+| `start_batch` | `project`, `interval_min?`, `duration_min?`, `message?` | Start the scheduled trigger that drives the batch (first pulse at T+interval). |
 | `trigger_now` | `project` | Fire one trigger pulse immediately. |
 | `stop_batch` | `project` | Stop the scheduled trigger. |
 | `agent_control` | `project`, `agent`, `action` | Non-destructive lifecycle: `start` / `stop` / `restart` / `interrupt` (Ctrl+C). |
 | `interrupt_all` | `project` | Send Ctrl+C to every running agent in the project. |
+| `set_batch` | `project`, `content` | **Escape hatch** — overwrite `OVERNIGHT-QUEUE.md` raw. Bypasses HEAD's formatting; **not** the normal path (see below). |
+| `append_batch` | `project`, `content` | **Escape hatch** — append raw queue content (read-then-write). Same caveat. |
+| `ensure_batch` | `project` | Create the queue from template if absent (idempotent). |
 
-Typical flow: `set_batch` / `append_batch` to define the work → `start_batch` for a scheduled cadence, or `trigger_now` for a single immediate pulse → `batch_status` to watch progress.
+> **`set_batch` / `append_batch` are low-level escape hatches**, for when you
+> deliberately bypass HEAD with pre-formatted content. The normal way to define
+> work is `send_message` HEAD — and for **review batches** the raw-write tools
+> are simply wrong (HEAD must set the `**Batch type:**` marker + per-item state
+> annotations the progress panel parses). When in doubt, message HEAD.
+
+## Workflow recipes
+
+Each is 1–3 tool calls. Start every session with `list_projects` to get the
+`project` id; if it fails, the MCP isn't connected — fix registration, don't SSH.
+
+**Start a code batch** — let HEAD plan and write the queue:
+1. `send_message(project, "@head start a batch for <feature>: #12 #15 #18")` — HEAD files issues + writes `OVERNIGHT-QUEUE.md`, then asks you to start.
+2. Kick it off: `start_batch(project, { interval_min: 15 })` for an overnight cadence (first pulse at T+interval), or `trigger_now(project)` for an immediate first pulse.
+3. Monitor (below).
+
+**Run a review batch** (review-only — no code, no merges). Just ask HEAD; it stamps the `**Batch type:**` marker — you never touch the queue:
+- Tickets: `send_message(project, "@head review tickets #12 #15")` → `batch_type: ticket-review`.
+- Merged PRs: `send_message(project, "@head review merged PR #N")` → `batch_type: pr-review`.
+Then monitor with `batch_status` (it shows review states: *queued · in review · 1 of 2 approvals · approved*).
+
+**Monitor a batch:**
+- `batch_status(project)` — `active` is authoritative for "work remaining"; `progress` may stay sticky on a just-finished batch.
+- `read_chat(project, { since_id })` — tail the team conversation.
+- `read_queue(project)` — see raw item states (read-only).
+
+**Restart a stuck/exited agent:**
+1. `list_agents(project)` — find one whose `state` isn't `running`.
+2. `agent_control(project, agent, "restart")` (or `"interrupt"` to send Ctrl+C without killing). `interrupt_all(project)` stops a runaway loop project-wide.
+
+**Check the rate-limit budget:** there is **no operator-MCP tool** for the GitHub rate-limit budget — watch the dashboard's rate-limit badge. To conserve budget, prefer review batches (they discover via `GITHUB.md` + REST, not `gh pr list`). Don't `curl` the API to check it.
 
 ## Security
 


### PR DESCRIPTION
Fixes #914. Docs-only on `docs/operator-mcp.md`.

## Why
A field agent handed this doc to drive QuadWork **bypassed the MCP entirely** — SSH'd the VPS, hand-operated with `sed`/`grep`/`curl`/`find`, reverse-engineered `routes.js` + the seed files to learn the queue format, and planned to hand-write a review batch into `OVERNIGHT-QUEUE.md`. The doc was a solid *reference* but (a) never stated the golden rule, (b) its "Typical flow" told operators to write the queue with `set_batch`, and (c) said nothing about review batches.

## Changes
- **Operating model section** (near the top, before Registration): operate **exclusively through the tools**; **HEAD owns the queue**; start any batch via `send_message` HEAD, not `set_batch`. Plus a hard **Never** list — never SSH the host, never edit `OVERNIGHT-QUEUE.md` by hand, never `curl` the backend, never reverse-engineer internals — and a prominent prerequisite: **if `list_projects` fails the MCP isn't connected → fix registration, don't fall back to SSH.**
- **`set_batch`/`append_batch` reframed as escape hatches** (demoted in the Tier-2 table + a callout explaining they bypass HEAD's formatting and are *wrong* for review batches, which need the `**Batch type:**` marker + state annotations).
- **"Typical flow" replaced** with a `send_message`-first **Workflow recipes** section: start a code batch, **run a review batch** (`send_message("@head review merged PR #N")` → monitor, never writing the queue), monitor, restart a stuck/exited agent, and the rate-limit budget (honestly noted as **not** an MCP tool — watch the badge, don't `curl`).

## Acceptance criteria
- [x] Opens with an operating model + a never (SSH / edit-queue / curl / reverse-engineer) list
- [x] Typical flow leads with `send_message` → HEAD; `set_batch`/`append_batch` reframed as escape hatches
- [x] A review-batch recipe exists (`send_message("@head review merged PR #N")` → monitor; no queue writing)
- [x] Recipes for code batch / monitor / agent restart / rate-limit, each as concrete tool calls
- [x] `npm run build` passes

## Consistency / verification
- Kept consistent with the **#902 Skill** (`skills/quadwork-operator/SKILL.md`) — same operating rules and recipe shapes; the Skill already leads with "let HEAD plan" and the "rate-limit is not an MCP tool" note.
- `npm run build` → exit 0. Internal anchors (`#registration`, `#remote--vps-registration`) resolve. `npm pack --dry-run` still ships `docs/operator-mcp.md` (9.1kB).
- Note from the ticket: the root operational cause is that the agent never ran `claude mcp add …` (no tools → it improvised with SSH). This doc makes the rules unmistakable and tells the agent to fix registration first; confirming registration actually lands is operational, outside a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)