### PR TITLE
[#911] Package README-linked install/troubleshooting docs in the npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "!server/__tests__/",
     "templates/",
     "out/",
+    "docs/install-mac.md",
+    "docs/install-windows.md",
+    "docs/install-vps.md",
+    "docs/troubleshooting.md",
     "docs/operator-mcp.md",
     "docs/review-batches.md",
     "skills/"


### PR DESCRIPTION
Fixes #911. Closes the last of the README dead-link packaging class (same as #894/#901/#904), flagged during the #904 pr-review.

## Change
README links six `docs/*.md` files; four weren't in the package `files` whitelist:
- `docs/install-mac.md`, `docs/install-windows.md`, `docs/install-vps.md`, `docs/troubleshooting.md`

Added all four. Kept the **scoped per-file** pattern (no wholesale `docs/`, per #894 and the ticket's "stay scoped"), and preserved the already-shipped `operator-mcp.md` / `review-batches.md` / `skills/` entries.

## Acceptance criteria
- [x] README-linked install + troubleshooting docs are available to package consumers (verified with `npm pack --dry-run`)
- [x] Packaging stays scoped — only the README-linked docs are whitelisted, no unrelated docs
- [x] Verification command documented (below)
- [x] Operator-MCP / review-batches docs + skills already shipped are preserved

## Verification
`npm pack --dry-run` ships exactly the six README-linked docs, nothing else:
```
docs/install-mac.md  docs/install-vps.md  docs/install-windows.md
docs/operator-mcp.md  docs/review-batches.md  docs/troubleshooting.md
```
Link-coverage check — every `docs/*.md` linked from the README now ships (zero dead):
```bash
PACKED=$(npm pack --dry-run 2>&1 | grep -oE 'docs/[A-Za-z0-9._/-]+\.md' | sort -u)
for f in $(grep -oE 'docs/[A-Za-z0-9._/-]+\.md' README.md | sort -u); do
  echo "$PACKED" | grep -qx "$f" && echo "SHIPS $f" || echo "DEAD $f"
done   # → all SHIPS
```
`package.json` valid JSON; `npm run build` → exit 0. (Those four are the only `docs/*.md` not already shipped, and the only README-linked docs — so this also leaves no other dead doc links.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)