### PR TITLE
[#925] Read archived review-batch final states from the matching Done block

### DIFF
--- a/server/routes.archivedBatchDoneStates.test.js
+++ b/server/routes.archivedBatchDoneStates.test.js
@@ -1,0 +1,182 @@
+// #925: after a review batch is archived, the Current Batch panel must show
+// each item's FINAL state (from Head's `## Done` block), not a stale snapshot
+// that froze at a pre-final state. Plain node:assert script (no runner) — run
+// with `node server/routes.archivedBatchDoneStates.test.js`.
+//
+// The bug: when the last item reaches `approved` and Head archives the batch
+// BETWEEN the 30s batch-progress polls, no poll captured the final state, so
+// the persisted snapshot froze at e.g. `#916 in-review (1/2)`. Once the Active
+// Batch is emptied (archived), resolveDisplayedBatch serves the snapshot
+// (#870 sticky display) — whose reviewItems are stale — and the panel never
+// reads complete. The Done block has the authoritative final states but was
+// never consulted (#870 deliberately ignores Done for progress). The fix reads
+// the SINGLE Done block matching the displayed (archived) batch's number.
+//
+// Snapshot I/O is injected so this test never touches the real
+// ~/.quadwork/{id}/batch-progress-cache.json (the running orchestrator owns it).
+
+const assert = require("node:assert/strict");
+const { resolveDisplayedBatch, parseDoneBatchReviewItems } = require("./routes");
+
+// A realistic archived queue: Active Batch emptied, a multi-batch `## Done`
+// with `**Batch:** N` markers exactly as Head writes them.
+function archivedQueue() {
+  return [
+    "# QuadWork — Overnight Queue",
+    "",
+    "## Active Batch",
+    "",
+    "## Backlog",
+    "",
+    "(none)",
+    "",
+    "## Done",
+    "",
+    "**Batch:** 19",
+    "**Batch type:** pr-review",
+    "**Started:** 2026-06-01 07:52",
+    "",
+    "- #918 — approved",
+    "- #916 — approved",
+    "",
+    "**Batch:** 18",
+    "",
+    "- #915 Deferred reseed only retries on server restart",
+    "- #914 operator-mcp.md: operating model + never rules",
+    "",
+    "**Batch:** 16",
+    "**Batch type:** pr-review",
+    "**Started:** 2026-06-01 06:13",
+    "",
+    "- #906 — approved",
+    "- #904 — approved",
+    "",
+  ].join("\n");
+}
+
+function makeStore(initial) {
+  let stored = initial;
+  return {
+    opts: {
+      _readSnapshot: () => stored,
+      _writeSnapshot: (_pid, snap) => { stored = snap; },
+    },
+    get: () => stored,
+  };
+}
+
+const isComplete = (reviewItems) =>
+  reviewItems.length > 0 && reviewItems.every((r) => r.review_state === "approved");
+const stateOf = (reviewItems, n) => {
+  const r = reviewItems.find((x) => x.issue === n);
+  return r ? r.review_state : undefined;
+};
+
+function run() {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  // ── The exact Batch 19 incident: snapshot froze with #916 at in-review (1/2)
+  //    because the final approval + archive happened between polls. ──
+  {
+    const store = makeStore({
+      batchNumber: 19,
+      issueNumbers: [918, 916],
+      batch_type: "pr-review",
+      reviewItems: [
+        { issue: 918, review_state: "approved", approvals: 2 },
+        { issue: 916, review_state: "in-review", approvals: 1 }, // FROZEN pre-final
+      ],
+    });
+    const res = resolveDisplayedBatch(archivedQueue(), "proj-925", store.opts);
+    ok(res.issueNumbers.length === 2 && res.issueNumbers.includes(918) && res.issueNumbers.includes(916), "archived: sticky view keeps both issue numbers");
+    ok(res.batch_type === "pr-review", "archived: batch_type stays pr-review");
+    ok(stateOf(res.reviewItems, 918) === "approved", "archived: #918 approved (from Done block)");
+    ok(stateOf(res.reviewItems, 916) === "approved", "archived: #916 reads FINAL approved from Done block, not the frozen in-review");
+    ok(isComplete(res.reviewItems) === true, "archived: batch reads as COMPLETE (was stuck at 1/2 before the fix)");
+    // Self-heal: the snapshot is re-persisted with the final states.
+    ok(store.get().reviewItems.every((r) => r.review_state === "approved"), "archived: snapshot re-persisted with final approved states (self-heals next poll)");
+  }
+
+  // ── Regression guard: WITHOUT the Done-block read, this exact frozen snapshot
+  //    would have served #916 = in-review and never reached complete. The Done
+  //    block is the only source of #916's approved state here. ──
+  {
+    const frozen = makeStore({
+      batchNumber: 19,
+      issueNumbers: [918, 916],
+      batch_type: "pr-review",
+      reviewItems: [
+        { issue: 918, review_state: "approved", approvals: 2 },
+        { issue: 916, review_state: "in-review", approvals: 1 },
+      ],
+    });
+    const res = resolveDisplayedBatch(archivedQueue(), "proj-925b", frozen.opts);
+    ok(stateOf(res.reviewItems, 916) === "approved" && isComplete(res.reviewItems), "frozen snapshot + Done block → complete (would freeze at 1/2 without the fix)");
+  }
+
+  // ── Only the Done block matching the displayed batch number is read; other
+  //    Done batches stay ignored (#870). Snapshot batchNumber 16 → reads the
+  //    Batch 16 block, not Batch 19's. ──
+  {
+    const b16 = makeStore({
+      batchNumber: 16,
+      issueNumbers: [906, 904],
+      batch_type: "pr-review",
+      reviewItems: [
+        { issue: 906, review_state: "in-review", approvals: 1 },
+        { issue: 904, review_state: "queued", approvals: 0 },
+      ],
+    });
+    const res = resolveDisplayedBatch(archivedQueue(), "proj-925c", b16.opts);
+    ok(res.issueNumbers.length === 2 && res.issueNumbers.includes(906) && res.issueNumbers.includes(904), "matching-block: Batch 16 issue set preserved");
+    ok(stateOf(res.reviewItems, 906) === "approved" && stateOf(res.reviewItems, 904) === "approved", "matching-block: states read from the Batch 16 Done block (both approved)");
+    ok(!res.reviewItems.some((r) => r.issue === 918 || r.issue === 916), "matching-block: Batch 19's items do NOT leak into the Batch 16 display");
+  }
+
+  // ── No matching Done block (snapshot batch not in Done) → fall back to the
+  //    snapshot reviewItems unchanged (graceful — never invents states). ──
+  {
+    const orphan = makeStore({
+      batchNumber: 99,
+      issueNumbers: [700],
+      batch_type: "pr-review",
+      reviewItems: [{ issue: 700, review_state: "in-review", approvals: 1 }],
+    });
+    const res = resolveDisplayedBatch(archivedQueue(), "proj-925d", orphan.opts);
+    ok(stateOf(res.reviewItems, 700) === "in-review", "no-match: snapshot reviewItems preserved when no Done block matches (no fabricated state)");
+  }
+
+  // ── Code-batch no-regression: an archived CODE batch's Done block carries no
+  //    state annotations (and no `**Batch type:**`) → parsed as "code" → the
+  //    #925 override is skipped; batch_type stays code, reviewItems stays []. ──
+  {
+    const codeStore = makeStore({ batchNumber: 18, issueNumbers: [915, 914], batch_type: "code", reviewItems: [] });
+    const res = resolveDisplayedBatch(archivedQueue(), "proj-925e", codeStore.opts);
+    ok(res.batch_type === "code", "code batch: batch_type stays code (uses the GitHub-derived path, not reviewItems)");
+    ok(res.reviewItems.length === 0, "code batch: reviewItems stays [] (Done-block override not applied to code batches)");
+    ok(res.issueNumbers.length === 2 && res.issueNumbers.includes(915) && res.issueNumbers.includes(914), "code batch: Done-moved issue set still sticky-visible");
+  }
+
+  // ── parseDoneBatchReviewItems unit checks ──
+  {
+    const q = archivedQueue();
+    const b19 = parseDoneBatchReviewItems(q, 19);
+    ok(b19 && b19.batch_type === "pr-review" && b19.reviewItems.length === 2, "parse: Batch 19 block → pr-review, 2 items");
+    ok(b19.reviewItems.every((r) => r.review_state === "approved"), "parse: Batch 19 items both approved");
+    const b18 = parseDoneBatchReviewItems(q, 18);
+    ok(b18 && b18.batch_type === "code" && b18.reviewItems.length === 2, "parse: Batch 18 (code) block → code, 2 items, states default queued");
+    ok(b18.reviewItems.every((r) => r.review_state === "queued"), "parse: Batch 18 code lines have no annotation → queued");
+    ok(parseDoneBatchReviewItems(q, 99) === null, "parse: missing batch number → null");
+    ok(parseDoneBatchReviewItems(q, null) === null, "parse: non-integer batch number → null");
+    ok(parseDoneBatchReviewItems("", 19) === null, "parse: empty queue → null");
+    // Isolation: the Batch 16 block must NOT bleed Batch 18's lines or vice versa.
+    const b16 = parseDoneBatchReviewItems(q, 16);
+    ok(b16 && b16.reviewItems.length === 2 && b16.reviewItems.every((r) => r.issue === 906 || r.issue === 904), "parse: Batch 16 block isolated to its own two items");
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();

--- a/server/routes.js
+++ b/server/routes.js
@@ -2438,6 +2438,28 @@ function resolveDisplayedBatch(
       next.reviewItems = next.issueNumbers.map(
         (n) => liveByIssue.get(n) || snapByIssue.get(n) || { issue: n, review_state: "queued", approvals: 0 },
       );
+    } else {
+      // #925: the Active Batch is empty → this is the just-ARCHIVED batch's
+      // sticky display (#870). The snapshot's reviewItems can be frozen at a
+      // pre-final state when the last item's approval + the archive landed
+      // between polls, so the panel never read as complete. Head's matching
+      // `## Done` block holds the authoritative final states — read them for
+      // THIS batch only. Gated on the Done block being a review batch, so code
+      // batches (Done lines carry no state → "queued") are left untouched and
+      // keep using the GitHub-derived path. Merge across the preserved issue
+      // set (Done state first, then snapshot, then queued) to stay aligned with
+      // next.issueNumbers — same shape as the #899/#900 live-refresh above.
+      const doneBatch = parseDoneBatchReviewItems(queueText, next.batchNumber);
+      if (doneBatch && REVIEW_BATCH_TYPES.has(doneBatch.batch_type) && doneBatch.reviewItems.length > 0) {
+        next.batch_type = doneBatch.batch_type;
+        const doneByIssue = new Map(doneBatch.reviewItems.map((r) => [r.issue, r]));
+        const snapByIssue = new Map(
+          (Array.isArray(snapshot.reviewItems) ? snapshot.reviewItems : []).map((r) => [r.issue, r]),
+        );
+        next.reviewItems = next.issueNumbers.map(
+          (n) => doneByIssue.get(n) || snapByIssue.get(n) || { issue: n, review_state: "queued", approvals: 0 },
+        );
+      }
     }
   }
   // Snapshot persists batchNumber/issueNumbers (existing consumers) PLUS the
@@ -2557,6 +2579,49 @@ function parseReviewItems(queueText) {
     items.push({ issue: n, review_state, approvals });
   }
   return items;
+}
+
+// #925: parse the per-item review states from the ONE `## Done` block whose
+// `**Batch:** N` matches `batchNumber`. After a review batch is archived the
+// Active Batch is empty, so resolveDisplayedBatch serves the snapshot — whose
+// reviewItems can be frozen at a pre-final state (the final approval + archive
+// happened between the 30s polls). Head's Done block holds the AUTHORITATIVE
+// final states, so for the archived (displayed) batch we read them from there.
+// Scoped to the single matching block — every OTHER Done batch stays ignored
+// (#870: never count `## Done` for progress beyond this one sticky block).
+// Returns { batch_type, reviewItems } or null if no matching block exists.
+const DONE_SECTION_RE = /##\s+Done\b[\s\S]*?(?=\n##\s|$)/i;
+const DONE_BATCH_MARKER_RE = /\*\*Batch:\*\*\s*(\d+)/g;
+function parseDoneBatchReviewItems(queueText, batchNumber) {
+  if (typeof queueText !== "string" || !queueText || !Number.isInteger(batchNumber)) return null;
+  const dm = queueText.match(DONE_SECTION_RE);
+  if (!dm) return null;
+  const done = dm[0];
+  // Split the Done section into per-batch blocks at each `**Batch:** N` marker
+  // (`**Batch type:**` is NOT matched — it has no `:` right after "Batch").
+  const markers = [];
+  let mk;
+  DONE_BATCH_MARKER_RE.lastIndex = 0;
+  while ((mk = DONE_BATCH_MARKER_RE.exec(done)) !== null) {
+    markers.push({ num: parseInt(mk[1], 10), start: mk.index });
+  }
+  const idx = markers.findIndex((b) => b.num === batchNumber);
+  if (idx === -1) return null;
+  const block = done.slice(markers[idx].start, idx + 1 < markers.length ? markers[idx + 1].start : done.length);
+  const tm = block.match(/\*\*Batch type:\*\*\s*(code|ticket-review|pr-review)\b/i);
+  const batch_type = tm ? tm[1].toLowerCase() : "code";
+  const seen = new Set();
+  const reviewItems = [];
+  for (const line of block.split("\n")) {
+    const lm = line.match(REVIEW_ITEM_LINE_RE);
+    if (!lm) continue;
+    const n = parseInt(lm[1], 10);
+    if (seen.has(n)) continue;
+    seen.add(n);
+    const { review_state, approvals } = parseReviewState(lm[2]);
+    reviewItems.push({ issue: n, review_state, approvals });
+  }
+  return { batch_type, reviewItems };
 }
 
 // Map a parsed review state → the batch-progress item, EXTENDING the existing
@@ -4348,6 +4413,7 @@ module.exports.pickDisplayedSource = pickDisplayedSource;
 // #870: expose review-batch parsers/helpers for the reviewBatch fixture test.
 module.exports.parseBatchType = parseBatchType;
 module.exports.parseReviewItems = parseReviewItems;
+module.exports.parseDoneBatchReviewItems = parseDoneBatchReviewItems;
 module.exports.parseReviewState = parseReviewState;
 module.exports.reviewItemView = reviewItemView;
 module.exports.summarizeReviewItems = summarizeReviewItems;


### PR DESCRIPTION
Fixes #925.

## Problem
After a review batch is archived, the Current Batch panel showed **stale, pre-final** item states. In Batch 19 both items finished `approved` (2/2) and Head archived correctly, but the panel showed `#916 50% · 1 of 2 approvals` and **never read as complete**.

## Root cause (three sources, three answers)
- **`## Done` block** (what Head wrote at archive): `#918 approved`, `#916 approved` ✓ authoritative
- **Persisted snapshot** (`batch-progress-cache.json`): `#916 in-review(1)` ✗ **stale** — it froze at #916's pre-final state because the final approval **and** the archive landed *between* the 30s batch-progress polls
- **`/api/batch-progress`**: serves the snapshot → `complete:false` ✗

Once the Active Batch is emptied (archived), `resolveDisplayedBatch` serves the snapshot (#870 sticky display) and the #899 live-refresh is skipped (the live Active Batch parse is empty). The Done section has the correct final states but is deliberately never parsed for progress (#870) — so the stale snapshot wins. Any review batch whose last item completes-and-archives within one poll interval froze (the common case — final approval + archive happen back-to-back).

## Fix
When the displayed batch is the just-archived one (Active Batch empty, snapshot still sticky), read each item's final state from the **one** `## Done` block whose `**Batch:** N` matches the snapshot's batch number.
- **Scoped to that single block** — every other Done batch stays ignored (#870 preserved).
- **Gated on it being a review batch** (`ticket-review`/`pr-review`) — code-batch Done lines carry no state annotation (→ parsed `code`), so code batches are left fully untouched and keep using the GitHub-derived path.
- States **merge across the preserved issue set** (Done → snapshot → queued), the same shape as the #899/#900 live-refresh.
- The snapshot is re-persisted with the final states, so it **self-heals** on the next poll (the ticket's "equivalently, refresh the snapshot from the Done block").
- An archived review batch's Done states are all `approved` (Head only archives when complete) → the panel reads complete.

New `parseDoneBatchReviewItems(queueText, batchNumber)` parses the matching Done block's `batch_type` + per-item states (reusing `parseReviewState`/`REVIEW_ITEM_LINE_RE`); returns `null` when no block matches.

## Acceptance criteria
- [x] After archive, the panel shows each item's FINAL state (all `approved`) and the batch as complete — not a frozen pre-final state
- [x] An item that reaches `approved` and is archived within one poll interval still shows `approved`/100%
- [x] Only the Done block matching the displayed (archived) batch's number is read; other Done batches stay ignored
- [x] Live (non-archived) review-batch progress unchanged (#907/#899 preserved)
- [x] Code batches unchanged
- [x] Test: complete a 2-item review batch, archive between polls → both `approved` + complete

## Verification
- New `server/routes.archivedBatchDoneStates.test.js` (22 assertions): the exact Batch 19 incident (frozen `in-review` snapshot → reads `approved` + complete from the Done block), regression guard, matching-block isolation (Batch 16 vs 19 don't bleed), no-match fallback (snapshot preserved, no fabricated state), code-batch no-regression, and `parseDoneBatchReviewItems` unit checks.
- Existing `reviewBatch` (49/0), `reviewBatchProgression` (26/0), `batchActiveCompletion` (43/0) suites pass unchanged.
- `npm test` → **41 passed, 0 failed, 2 skipped**. `npm run build` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)