### PR TITLE
[#923] Wake a standing-by agent on @mention — defer, don't drop

### DIFF
--- a/server/pty-dispatcher.js
+++ b/server/pty-dispatcher.js
@@ -45,12 +45,22 @@ function dispatchToAgentPTY(projectId, msg, agentSessions, deps) {
     if (!session || !session.term || session.state !== "running") continue;
     if (msg.sender === agentId) continue;
 
-    // #736: skip injection if agent recently sent a message — they're
-    // already active and will read chat via chat_read
+    // An agent is "active" if it is producing PTY output right now (mid-turn)
+    // OR it sent a chat message very recently (#736 — it's likely still in the
+    // turn it sent from and will re-read chat itself). Either way we must not
+    // inject mid-activity.
+    //
+    // #923: but we must NOT drop the mention either. The old code `continue`d
+    // on the recent-send case, so a mention that landed within the suppression
+    // window was lost — stranding a standing-by agent (whose turn had actually
+    // ENDED after it posted) on stale chat until the next scheduled-trigger
+    // pulse re-dispatched it (up to ~15 min). Instead DEFER via a pending wake
+    // that drains once the agent goes quiet, so the mention reliably starts a
+    // new turn within seconds. The scheduled trigger is now only a periodic
+    // backstop, not the primary wake mechanism for direct assignments.
     const lastSent = _lastChatSentAt.get(key);
-    if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) continue;
-
-    if (isAgentBusy(session)) {
+    const recentlySent = lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS);
+    if (isAgentBusy(session) || recentlySent) {
       queuePendingWake(key, session, deps);
       continue;
     }
@@ -79,9 +89,10 @@ function queuePendingWake(key, session, deps) {
     _pendingWake.delete(key);
     cleanupDrainListener(key);
 
-    const lastSent = _lastChatSentAt.get(key);
-    if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) return;
-
+    // #923: fire the deferred wake unconditionally once the agent has been
+    // quiet for the idle window. Do NOT re-suppress on a recent send here — a
+    // standing-by agent that just posted (then ended its turn) would otherwise
+    // be stranded again, which is the exact stall this fix removes.
     injectIntoTerm(session.term, buildInjectionPrompt(session.agentId), deps);
   };
 
@@ -141,9 +152,10 @@ function scheduleCoalescedInjection(key, projectId, agentId, msg, agentSessions,
     const session = agentSessions.get(key);
     if (!session || !session.term || session.state !== "running") return;
 
-    const lastSent = _lastChatSentAt.get(key);
-    if (lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS)) return;
-
+    // #923: the defer-vs-inject decision was already made in dispatchToAgentPTY
+    // (this path is reached only for an idle, not-recently-active agent). Inject
+    // when the coalesce window closes rather than re-suppressing on a recent
+    // send here — re-suppression is what dropped wakes for standing-by agents.
     injectIntoTerm(session.term, buildInjectionPrompt(agentId), deps);
   }, COALESCE_WINDOW_MS);
 

--- a/server/pty-dispatcher.js
+++ b/server/pty-dispatcher.js
@@ -152,10 +152,19 @@ function scheduleCoalescedInjection(key, projectId, agentId, msg, agentSessions,
     const session = agentSessions.get(key);
     if (!session || !session.term || session.state !== "running") return;
 
-    // #923: the defer-vs-inject decision was already made in dispatchToAgentPTY
-    // (this path is reached only for an idle, not-recently-active agent). Inject
-    // when the coalesce window closes rather than re-suppressing on a recent
-    // send here — re-suppression is what dropped wakes for standing-by agents.
+    // re1 on #923: the idle / not-recently-active decision was made at dispatch
+    // time, but it can go stale during the 1s coalesce window — the agent may
+    // have started a turn or posted a message in the meantime. Re-check at fire
+    // time: if it is now active, DEFER via a pending wake (which drains once it
+    // goes quiet) rather than injecting mid-activity (#736). Crucially this
+    // defers, it does NOT drop (#923) — the drain still delivers the wake.
+    const lastSent = _lastChatSentAt.get(key);
+    const recentlySent = lastSent && (Date.now() - lastSent < ACTIVE_SUPPRESSION_MS);
+    if (isAgentBusy(session) || recentlySent) {
+      queuePendingWake(key, session, deps);
+      return;
+    }
+
     injectIntoTerm(session.term, buildInjectionPrompt(agentId), deps);
   }, COALESCE_WINDOW_MS);
 

--- a/server/pty-dispatcher.test.js
+++ b/server/pty-dispatcher.test.js
@@ -210,6 +210,27 @@ async function runTests() {
     cleanupSession("proj/head");
   }
 
+  // --- Test 13: re1 on #923 — the idle decision can go STALE during the 1s
+  //     coalesce window. If the target posts a message (becomes recently-sent)
+  //     before the timer fires, the wake must be DEFERRED (pending wake), not
+  //     injected mid-activity (#736) and not lost (#923). ---
+  {
+    const { sessions, written } = makeSessions({ lastOutputAt: 0 });
+    const deps = makeDeps();
+    // Idle + not-recently-active at dispatch → takes the coalesce path.
+    dispatchToAgentPTY("proj", makeMsg({ sender: "head", mentions: ["dev"] }), sessions, deps);
+    // Agent posts a chat message DURING the coalesce window → now recently-sent.
+    _lastChatSentAt.set("proj/dev", Date.now());
+    await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
+    assert(written.length === 0, "stale-coalesce: now-active agent is NOT injected mid-activity (#736 preserved)");
+    assert(_pendingWake.has("proj/dev"), "stale-coalesce: wake is DEFERRED to a pending wake, not dropped (#923)");
+    // Drains once the agent is quiet (no further PTY output).
+    await new Promise((r) => setTimeout(r, IDLE_THRESHOLD_MS + 100));
+    assert(written.length >= 1, "stale-coalesce: deferred wake still fires once the agent goes quiet — not lost");
+    assert(!_pendingWake.has("proj/dev"), "stale-coalesce: pending wake cleared after drain");
+    cleanupSession("proj/dev");
+  }
+
   // --- Test 9: cleanupSession clears all state ---
   {
     _coalesceTimers.set("proj/dev", { timer: setTimeout(() => {}, 10000), messages: [] });

--- a/server/pty-dispatcher.test.js
+++ b/server/pty-dispatcher.test.js
@@ -164,15 +164,24 @@ async function runTests() {
     cleanupSession("proj/dev");
   }
 
-  // --- Test 10: active agent suppression — recently sent message skips injection ---
+  // --- Test 10: #923 — a recently-active agent's mention is DEFERRED, not
+  //     dropped. It must not inject mid-activity, but it must still wake once
+  //     the agent goes quiet (the old behavior dropped it, stranding a
+  //     standing-by agent until the next scheduled-trigger pulse). ---
   {
     const { sessions, written } = makeSessions({ lastOutputAt: 0 });
     const deps = makeDeps();
-    // Simulate dev having sent a message recently
+    // Simulate dev having sent a message recently (then its turn ended → idle).
     _lastChatSentAt.set("proj/dev", Date.now());
     dispatchToAgentPTY("proj", makeMsg({ sender: "head", mentions: ["dev"] }), sessions, deps);
     await new Promise((r) => setTimeout(r, COALESCE_WINDOW_MS + 50));
-    assert(written.length === 0, "recently active agent is not injected");
+    assert(written.length === 0, "recently-active agent is not injected immediately (no mid-activity barge-in)");
+    assert(_pendingWake.has("proj/dev"), "#923: recently-active mention is QUEUED as a pending wake, not dropped");
+    // Fallback drain fires after the idle window with no further PTY output.
+    await new Promise((r) => setTimeout(r, IDLE_THRESHOLD_MS + 100));
+    assert(written.length >= 1, "#923: deferred wake drains once the agent is quiet — no scheduled-trigger pulse needed");
+    assert(written[0].includes("You are @dev"), "drained wake uses the identity prompt");
+    assert(!_pendingWake.has("proj/dev"), "pending wake cleared after drain");
     cleanupSession("proj/dev");
   }
 


### PR DESCRIPTION
Fixes #923.

## Problem
After a batch completes (or agents restart), agents go "standing by." When Head then `@dev`-assigns the next item, **the assignment doesn't wake Dev** — Dev keeps standing by until the **scheduled trigger** fires (~15 min) or the operator runs `trigger_now`. Every batch's first item stalls right after assignment (the recurring "blocked again" symptom, worst for an MCP-driven operator).

## Root cause
The chat-mention dispatch and the scheduled-trigger pulse **both** go through `POST /api/chat` → `dispatchToAgentPTY` (the shim `chat_send` and the trigger both hit `/api/chat`). The asymmetry is the **#736 active-suppression**: if a mention lands within 30s (`ACTIVE_SUPPRESSION_MS`) of the *target* agent's own last chat send, the wake is **dropped** (`continue`) with no retry.

But *"recently sent a message" ≠ "still in a turn."* An agent that posts (e.g. its completion report) and then ends its turn is **idle/standing-by** — yet its wake gets dropped. The scheduled trigger only "works" because it's a *recurring new message* that eventually re-dispatches outside the 30s window — which is exactly why the trigger looked like the primary wake mechanism.

## Fix (`server/pty-dispatcher.js`)
Treat **busy OR recently-sent** as "active", but **defer** such a mention via the existing `queuePendingWake` machinery instead of dropping it. The pending wake drains once the agent goes quiet (idle window), so the mention **reliably starts a new turn within seconds** — no trigger needed. Removed the now-redundant recent-send re-checks in the drain and coalesce paths so a deferred/scheduled wake is never re-dropped.

This **preserves #736's intent** (never inject mid-activity — a busy/active agent still defers rather than getting barged into) while making the scheduled trigger only a **periodic backstop**.

- Standing-by agent (idle, recently posted): deferred wake drains within ~one idle window.
- Freshly-restarted agent (busy at spawn): same deferred path; later, truly-idle → coalesced injection (~1s).
- All cases wake with no `trigger_now`.

## Acceptance criteria
- [x] When Head `@dev`-assigns, Dev starts acting within seconds — no `trigger_now`
- [x] Same for any agent `@mention` (the dispatcher is agent-agnostic — Head→Dev, Dev→reviewers, operator→Head)
- [x] Works for a standing-by agent AND a freshly-restarted agent
- [x] The scheduled trigger still works as a periodic backstop (untouched)

## Verification
- `server/pty-dispatcher.test.js`: Test 10 rewritten — a recently-active mention is now **QUEUED (not dropped)** and **drains once the agent is quiet** (no trigger pulse), asserting both the no-immediate-barge-in and the eventual wake. Busy-agent, idle-agent, coalescing, self-mention, loop-guard, and suppression-window tests unchanged. **26/0**.
- Full `npm test` → **41 passed, 0 failed, 2 skipped**. `npm run build` → exit 0.

## Note
Distinct from #921 (Head's kickoff gate, just merged) — this is the **dispatch/wake** layer. Together they remove the two reasons batches stalled right after a start/assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)