### PR TITLE
[#922] Restore throttled visibility for stuck reseed deferrals on the periodic tick

### DIFF
--- a/server/routes.autoReseed.test.js
+++ b/server/routes.autoReseed.test.js
@@ -36,6 +36,8 @@ const {
   _saveReseedState,
   _readPackageVersion,
   _performReseedWrites,
+  _periodicDeferStreak,
+  PERIODIC_DEFER_LOG_EVERY,
 } = require("./routes");
 
 function tmp(label) {
@@ -434,7 +436,91 @@ function quietLog() {
     assert.equal(bootOut.decisions[0].action, "deferred");
     assert.equal(tickOut.decisions[0].action, "deferred");
     assert.ok(boot.lines.some((l) => /loud/.test(l)), "startup logs the deferral");
-    assert.ok(!tickCtx.lines.some((l) => /loud/.test(l)), "periodic tick suppresses the deferral log");
+    assert.ok(!tickCtx.lines.some((l) => /loud/.test(l)), "periodic tick suppresses the benign active-batch deferral log");
+  }
+
+  // 13. #922: periodic + batch-state check THREW → the error deferral is
+  //     visible but THROTTLED — logs on the first occurrence, stays silent
+  //     within the window, then re-logs once per PERIODIC_DEFER_LOG_EVERY ticks.
+  {
+    _periodicDeferStreak.clear();
+    const cfg = { projects: [{ id: "stuck13", working_dir: "/tmp/stuck13" }] };
+    const statePath = path.join(tmp("stuck13"), "state.json");
+    const { log, lines } = quietLog();
+    const tick = () => autoReseedOnStartup(cfg, {
+      version: "2.1.0", statePath, log, periodic: true,
+      getProgress: async () => { throw new Error("gh down"); },
+    });
+    await tick(); // tick 1
+    assert.equal(lines.filter((l) => /stuck13/.test(l)).length, 1, "periodic error-deferral logs on the FIRST occurrence (not silent)");
+    assert.ok(lines.some((l) => /still deferred after 1 periodic/.test(l)), "first stuck log carries the escalation hint");
+    for (let i = 2; i < PERIODIC_DEFER_LOG_EVERY; i++) await tick(); // ticks 2..N-1
+    assert.equal(lines.filter((l) => /stuck13/.test(l)).length, 1, "error-deferrals within the window are throttled (no per-tick spam)");
+    await tick(); // tick N == PERIODIC_DEFER_LOG_EVERY
+    assert.equal(lines.filter((l) => /stuck13/.test(l)).length, 2, "re-logs once per PERIODIC_DEFER_LOG_EVERY ticks");
+    assert.ok(lines.some((l) => new RegExp(`after ${PERIODIC_DEFER_LOG_EVERY} periodic`).test(l)), "escalation log reports the streak length");
+    // Fail-closed unchanged: a thrown batch-state check still defers, never reseeds.
+    const out = await tick();
+    assert.equal(out.decisions[0].action, "deferred", "thrown batch-state check still defers (fail-closed preserved)");
+  }
+
+  // 14. #922: periodic + batch state null (unknown) is ALSO surfaced (throttled),
+  //     not silently dropped — same error class as a throw.
+  {
+    _periodicDeferStreak.clear();
+    const cfg = { projects: [{ id: "null14", working_dir: "/tmp/null14" }] };
+    const statePath = path.join(tmp("null14"), "state.json");
+    const { log, lines } = quietLog();
+    await autoReseedOnStartup(cfg, {
+      version: "2.1.0", statePath, log, periodic: true,
+      getProgress: async () => null, isActiveFromProgress: () => null,
+    });
+    assert.ok(lines.some((l) => /null14.*deferred — batch state unknown/.test(l)), "periodic null-state deferral is visible (throttled), not silent");
+  }
+
+  // 15. #922: a BENIGN active-batch deferral on the periodic tick stays silent
+  //     (no spam) AND does not accumulate a stuck-streak (#915 preserved).
+  {
+    _periodicDeferStreak.clear();
+    const cfg = { projects: [{ id: "busy15", working_dir: "/tmp/busy15" }] };
+    const statePath = path.join(tmp("busy15"), "state.json");
+    const { log, lines } = quietLog();
+    const tick = () => autoReseedOnStartup(cfg, {
+      version: "2.1.0", statePath, log, periodic: true,
+      getProgress: async () => ({ items: [{ status: "in_review" }], complete: false }),
+    });
+    await tick(); await tick(); await tick();
+    assert.ok(!lines.some((l) => /busy15/.test(l)), "benign active-batch deferral is never logged on the periodic tick");
+    assert.ok(!_periodicDeferStreak.has("busy15"), "benign active deferral does not accumulate a stuck-streak");
+  }
+
+  // 16. #922: the stuck-streak RESETS when the project stops error-deferring, so
+  //     a fresh stuck episode logs immediately; and boot (non-periodic) logs
+  //     every error-deferral with no throttle.
+  {
+    _periodicDeferStreak.clear();
+    const cfg = { projects: [{ id: "reset16", working_dir: "/tmp/reset16" }] };
+    const statePath = path.join(tmp("reset16"), "state.json");
+    const { log, lines } = quietLog();
+    let mode = "throw";
+    const tick = () => autoReseedOnStartup(cfg, {
+      version: "2.1.0", statePath, log, periodic: true,
+      getProgress: async () => { if (mode === "throw") throw new Error("blip"); return { items: [{ status: "in_review" }], complete: false }; },
+    });
+    await tick(); // throw → streak 1 → logs
+    assert.equal(lines.filter((l) => /reset16/.test(l)).length, 1, "first stuck episode logs");
+    mode = "active"; await tick(); // benign active → clears streak, silent
+    assert.ok(!_periodicDeferStreak.has("reset16"), "streak cleared once the project is no longer error-deferred");
+    mode = "throw"; await tick(); // fresh episode → logs immediately
+    assert.equal(lines.filter((l) => /reset16/.test(l)).length, 2, "a fresh stuck episode logs immediately (streak reset, not waiting out the window)");
+
+    const { log: blog, lines: blines } = quietLog();
+    const boot = () => autoReseedOnStartup(cfg, {
+      version: "2.1.0", statePath, log: blog, periodic: false,
+      getProgress: async () => { throw new Error("blip"); },
+    });
+    await boot(); await boot(); await boot();
+    assert.equal(blines.filter((l) => /reset16/.test(l)).length, 3, "boot (non-periodic) logs every error-deferral — no throttle");
   }
 
   console.log("routes.autoReseed.test.js: all assertions passed");

--- a/server/routes.js
+++ b/server/routes.js
@@ -3799,6 +3799,14 @@ function _saveReseedState(state, statePath = RESEED_STATE_PATH) {
   fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
 }
 
+// #922: per-project throttle for the periodic-tick "stuck deferral" log (the
+// batch-state-unknown / threw paths only). Map: projectId -> consecutive
+// periodic error-deferral count. The first occurrence logs immediately, then
+// once every PERIODIC_DEFER_LOG_EVERY ticks — so a persistently-erroring
+// project stays observable without per-tick spam. Exported for test reset.
+const PERIODIC_DEFER_LOG_EVERY = 15; // ~15 min at the 60s retry-tick cadence
+const _periodicDeferStreak = new Map();
+
 async function autoReseedOnStartup(cfg, opts = {}) {
   const version = opts.version || _readPackageVersion();
   const statePath = opts.statePath || RESEED_STATE_PATH;
@@ -3809,11 +3817,31 @@ async function autoReseedOnStartup(cfg, opts = {}) {
   const performWrites = opts.performWrites || _performReseedWrites;
   // #915: `periodic` = invoked from the recurring retry tick, not boot. A
   // still-deferred project is expected on every tick until its batch clears, so
-  // suppress the deferral log there (it would spam) — reseeded/error events
-  // still log. Deferral is otherwise identical: the project stays pending and
-  // is retried on the next tick, NO server restart required.
+  // suppress the BENIGN active-batch deferral log there (it would spam) —
+  // reseeded/error events still log. Deferral semantics are unchanged: the
+  // project stays pending and is retried on the next tick, no restart.
   const periodic = !!opts.periodic;
-  const logDeferred = periodic ? () => {} : log;
+  const logActiveDeferral = periodic ? () => {} : log;
+  // #922: the error/unknown deferral paths (batch-state check threw OR returned
+  // null) are NOT a healthy active batch — they mean we couldn't confirm the
+  // batch state, so the project stays on old seeds. On the periodic tick these
+  // were also fully suppressed, so a persistently-erroring project was stranded
+  // with zero signal between restarts (the silent-stranding class #915 fought).
+  // Keep them visible but THROTTLED per project: log the first occurrence, then
+  // once per PERIODIC_DEFER_LOG_EVERY ticks. On boot (non-periodic) everything
+  // logs every time, exactly as before.
+  const logStuckDeferral = (projectId, message) => {
+    if (!periodic) { log(message); return; }
+    const streak = (_periodicDeferStreak.get(projectId) || 0) + 1;
+    _periodicDeferStreak.set(projectId, streak);
+    if (streak === 1 || streak % PERIODIC_DEFER_LOG_EVERY === 0) {
+      log(`${message} [still deferred after ${streak} periodic check(s) — check the project's batch/GitHub state]`);
+    }
+  };
+  // A project that is no longer error-deferred (current, reseeded, or a benign
+  // active batch) clears its streak, so a fresh stuck episode logs immediately
+  // rather than waiting out a stale counter.
+  const clearStuckStreak = (projectId) => { _periodicDeferStreak.delete(projectId); };
 
   const state = _loadReseedState(statePath);
   const decisions = [];
@@ -3821,6 +3849,7 @@ async function autoReseedOnStartup(cfg, opts = {}) {
 
   for (const project of projects) {
     if (state.completedByProjectVersion[project.id] === version) {
+      clearStuckStreak(project.id);
       decisions.push({ projectId: project.id, action: "skip", reason: "already current" });
       continue;
     }
@@ -3835,19 +3864,23 @@ async function autoReseedOnStartup(cfg, opts = {}) {
       active = isActiveFromProgress(progress);
     } catch (err) {
       decisions.push({ projectId: project.id, action: "deferred", reason: `batch-state check threw: ${err.message}` });
-      logDeferred(`[reseed] ${project.id}: deferred — batch state unknown (${err.message}); will retry automatically once the batch clears (no restart required)`);
+      logStuckDeferral(project.id, `[reseed] ${project.id}: deferred — batch state unknown (${err.message}); will retry automatically once the batch clears (no restart required)`);
       continue;
     }
     if (active === null) {
       decisions.push({ projectId: project.id, action: "deferred", reason: "batch state unknown" });
-      logDeferred(`[reseed] ${project.id}: deferred — batch state unknown; will retry automatically once the batch clears (no restart required)`);
+      logStuckDeferral(project.id, `[reseed] ${project.id}: deferred — batch state unknown; will retry automatically once the batch clears (no restart required)`);
       continue;
     }
     if (active === true) {
+      clearStuckStreak(project.id);
       decisions.push({ projectId: project.id, action: "deferred", reason: "batch active" });
-      logDeferred(`[reseed] ${project.id}: deferred — batch active; will retry automatically once the batch clears (no restart required)`);
+      logActiveDeferral(`[reseed] ${project.id}: deferred — batch active; will retry automatically once the batch clears (no restart required)`);
       continue;
     }
+    // active === false: batch state is definitively known/idle — no longer
+    // error-deferred, so clear any stuck-streak before attempting the reseed.
+    clearStuckStreak(project.id);
 
     let result;
     try {
@@ -4470,6 +4503,8 @@ module.exports.reviewerRateLimitPayload = reviewerRateLimitPayload;
 // (state corruption, version round-trip, per-project decision matrix).
 module.exports.autoReseedOnStartup = autoReseedOnStartup;
 module.exports._loadReseedState = _loadReseedState;
+module.exports._periodicDeferStreak = _periodicDeferStreak;
+module.exports.PERIODIC_DEFER_LOG_EVERY = PERIODIC_DEFER_LOG_EVERY;
 module.exports._saveReseedState = _saveReseedState;
 module.exports._readPackageVersion = _readPackageVersion;
 module.exports._performReseedWrites = _performReseedWrites;


### PR DESCRIPTION
Fixes #922 (follow-up I filed during the Batch 19 review of #918).

## Problem
#918's periodic reseed retry set `logDeferred = () => {}` on the recurring tick, suppressing **all three** deferral paths uniformly. That's right for the benign `active === true` case (a busy project legitimately defers every 60s — logging would spam), but it also silenced the **error/unknown** paths:
- `active === null` — batch state unknown
- batch-state check **threw** (e.g. GitHub/progress lookup persistently failing)

For those, a project whose batch state couldn't be confirmed was stranded on old seeds with **zero signal** between restarts — the exact silent-stranding class #915 set out to fix.

## Fix (`server/routes.js`, `autoReseedOnStartup`)
Split the periodic deferral logging by reason:
- **`active === true`** keeps the #915 suppression (`logActiveDeferral`, no-op on the tick) — no spam.
- **`null` / threw** now log **throttled per project** (`logStuckDeferral`): the **first occurrence logs immediately**, then **once per `PERIODIC_DEFER_LOG_EVERY` (15) ticks** (~15 min at the 60s cadence), with a `still deferred after N periodic check(s)` escalation hint. Observable, but no per-tick spam.
- The per-project streak **resets** when the project is no longer error-deferred (current, reseeded, or a benign active batch), so a fresh stuck episode logs immediately rather than waiting out a stale counter.
- **Boot (non-periodic)** logs every deferral, exactly as before.
- **Deferral semantics unchanged**: still fail-closed, still pending, still retried next tick.

## Acceptance criteria
- [x] A project deferred because its batch-state check is **erroring** (`null` / threw) produces a throttled operator-visible log, not total silence
- [x] A healthy `active === true` project does **not** spam (no-spam behavior preserved)
- [x] No change to deferral semantics (still fail-closed, still pending, still retried)

## Verification
- `server/routes.autoReseed.test.js` +4 (tests 13–16): periodic + threw → logs tick 1, silent within the window, re-logs at tick 15, and **still defers** (fail-closed preserved); periodic + null → visible (throttled); benign `active === true` → silent and accrues **no** streak (#915 preserved); streak **resets** so a fresh episode logs immediately, and **boot logs every** deferral (no throttle).
- Existing #915 periodic tests (11/12) unchanged (they exercise the benign active path, still suppressed).
- Full `npm test` → **41 passed, 0 failed, 2 skipped**. `npm run build` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)