### PR TITLE
[#932] Wrap bare-array MCP tool bodies in an object so gemini chat_read works

### DIFF
--- a/server/mcp-chat-shim.js
+++ b/server/mcp-chat-shim.js
@@ -94,7 +94,11 @@ async function handleToolCall(id, name, params) {
       if (res.status >= 400) {
         return jsonRpcError(id, -32000, `API error ${res.status}: ${JSON.stringify(res.body)}`);
       }
-      return jsonRpc(id, { content: [{ type: "text", text: JSON.stringify(res.body) }] });
+      // #932: MCP structuredContent must be a record, not a top-level array —
+      // gemini's SDK auto-parses the result text and rejects a bare array with
+      // `invalid_type`. chat_read's body is an array of messages, so wrap it in
+      // an object; chat_send's body is already an object → the guard is a no-op.
+      return jsonRpc(id, { content: [{ type: "text", text: JSON.stringify(Array.isArray(res.body) ? { messages: res.body } : res.body) }] });
     }
 
     if (name === "chat_read") {
@@ -106,7 +110,11 @@ async function handleToolCall(id, name, params) {
       if (res.status >= 400) {
         return jsonRpcError(id, -32000, `API error ${res.status}: ${JSON.stringify(res.body)}`);
       }
-      return jsonRpc(id, { content: [{ type: "text", text: JSON.stringify(res.body) }] });
+      // #932: MCP structuredContent must be a record, not a top-level array —
+      // gemini's SDK auto-parses the result text and rejects a bare array with
+      // `invalid_type`. chat_read's body is an array of messages, so wrap it in
+      // an object; chat_send's body is already an object → the guard is a no-op.
+      return jsonRpc(id, { content: [{ type: "text", text: JSON.stringify(Array.isArray(res.body) ? { messages: res.body } : res.body) }] });
     }
 
     return jsonRpcError(id, -32601, `Unknown tool: ${name}`);

--- a/server/mcp-chat-shim.test.js
+++ b/server/mcp-chat-shim.test.js
@@ -143,8 +143,16 @@ async function runTests() {
   });
   const readResp = await readResponse(shim);
   assert(readResp.result?.content?.[0]?.type === "text", "chat_read returns text content");
-  const messages = JSON.parse(readResp.result.content[0].text);
-  assert(Array.isArray(messages), "chat_read returns array");
+  const readBody = JSON.parse(readResp.result.content[0].text);
+  // #932: MCP structuredContent must be a record — chat_read's array of
+  // messages is wrapped in an object so gemini's SDK doesn't reject it with
+  // `invalid_type` (expected record, received array).
+  assert(
+    readBody && typeof readBody === "object" && !Array.isArray(readBody),
+    "#932: chat_read returns an object (record), not a bare array",
+  );
+  const messages = readBody.messages;
+  assert(Array.isArray(messages), "#932: chat_read wraps the message array under `messages`");
   assert(messages.length >= 1, "chat_read contains the sent message");
   assert(messages[messages.length - 1]?.text === "hello from shim @user", "chat_read message text matches");
 
@@ -165,7 +173,7 @@ async function runTests() {
     params: { name: "chat_read", arguments: { since_id: lastId } },
   });
   const sinceResp = await readResponse(shim);
-  const sinceMessages = JSON.parse(sinceResp.result.content[0].text);
+  const sinceMessages = JSON.parse(sinceResp.result.content[0].text).messages;
   assert(sinceMessages.length === 1, "chat_read with since_id returns only new messages");
   assert(sinceMessages[0]?.text === "second message", "since_id filtered message matches");
 


### PR DESCRIPTION
Fixes #932.

## Problem
A **gemini** agent froze on every `chat_read` with `invalid_type` (`structuredContent` must be a record, not an array), so it could never receive tasks — a blocker for the whole Gemini integration (#909). Claude/codex use the same shim and were unaffected.

## Root cause (`server/mcp-chat-shim.js`)
`chat_read` returns the HTTP body verbatim as the tool result text, and `GET /api/chat` returns a **bare JSON array** of messages. Gemini's MCP SDK auto-parses the result text into `structuredContent`, and the MCP spec requires that to be an **object/record** → Zod rejects an array. `chat_send` works because its body (`{ ok, message }`) is already an object; claude/codex clients don't strict-validate `structuredContent`, so they never hit it.

## Fix
Wrap an array body in `{ messages: [...] }` before stringifying, at both shim content returns:
```js
text: JSON.stringify(Array.isArray(res.body) ? { messages: res.body } : res.body)
```
- Applied at **both** `chat_send` and `chat_read` returns (the issue's audit note — "defensively for any array body"). The `Array.isArray` guard is a **no-op for `chat_send`** (object body) → its output is byte-identical; only `chat_read`'s array is now wrapped.
- Error paths are untouched (they embed the body in an error *string*, not `structuredContent`, so they're never parsed/validated).
- No `outputSchema` is declared on either tool, so there is no schema to update — the SDK derives `structuredContent` from the text alone.

## No-regression check (per AC)
- Seeds/docs: `templates/seeds/butler.CLAUDE.md` and `server/pty-dispatcher.js` reference only the tool **name** (instructional text), not the output shape — nothing parses the array shape, so no doc changes needed.
- No internal code consumes the shim's MCP output; the only clients are the CLI agents, which read whatever the shim returns.

## Acceptance criteria
- [x] `chat_read` returns a tool result whose JSON text is an object (`{ "messages": [...] }`), not a bare array
- [x] A gemini agent can read chat without `invalid_type` (verified end-to-end in the issue: `READ_OK 50`, then `chat_send`)
- [x] No regression for claude/codex — chat_read still parses; no seed/doc describes the array shape rigidly
- [x] Test asserts array bodies are wrapped in an object
- [x] `npm run build` / tests pass

## Verification
- `server/mcp-chat-shim.test.js`: Test 4 now asserts chat_read returns a **record** (not a bare array) and reads messages under `.messages`; Test 5 reads via `.messages`. **15/0**.
- Full `npm test` → **42 passed, 0 failed, 2 skipped**. `npm run build` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)