### PR TITLE
[#935] Sanitize the butler model in SettingsPage.save()

### DIFF
--- a/server/agentModels.test.js
+++ b/server/agentModels.test.js
@@ -56,5 +56,21 @@ ok(sanitizeModel("claude", "claude-opus-4-8") === "claude-opus-4-8", "sanitizeMo
 ok(sanitizeModel("codex", "") === "", "sanitizeModel keeps '' (CLI default) — valid for every CLI, never clobbered");
 ok(sanitizeModel("gemini", undefined) === "", "sanitizeModel maps undefined → '' (CLI default), not a fabricated model");
 
+// ── #935: SettingsPage.save() normalizes the butler model the same way it ──
+// normalizes per-agent models. The save path is a React component (no harness),
+// so we pin the exact expression save() applies to config.butler. A butler left
+// invalid (hand-edited config / never command-changed) must heal on save, while
+// "" (CLI default) is preserved.
+const normalizeButler = (butler) =>
+  butler
+    ? { ...butler, model: sanitizeModel(butler.command || "claude", butler.model) }
+    : butler;
+ok(normalizeButler({ command: "codex", model: "opus" }).model === "gpt-5.4", "#935: save() heals an invalid butler model (codex + 'opus') to the first valid codex model");
+ok(normalizeButler({ command: "gemini", model: "sonnet" }).model === "gemini-2.5-pro", "#935: save() heals a cross-backend butler model (gemini + 'sonnet')");
+ok(normalizeButler({ command: "codex", model: "" }).model === "", "#935: save() preserves '' (CLI default) on the butler");
+ok(normalizeButler({ command: "claude", model: "opus" }).model === "opus", "#935: save() keeps an already-valid butler model");
+ok(normalizeButler({ command: "codex" }).model === "", "#935: save() maps an unset butler model → '' (CLI default), not a fabricated model");
+ok(normalizeButler(undefined) === undefined, "#935: save() leaves a missing butler config untouched");
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -496,6 +496,9 @@ export default function SettingsPage() {
       // invalid by the old hardcoded dropdown (e.g. a codex agent saved with
       // "sonnet") and also covers a new project seeded from DEFAULT_AGENTS with
       // a non-Claude default command. sanitizeModel keeps "" (CLI default) as-is.
+      // #935: the butler model needs the same guard. Its dropdown is
+      // provider-aware and resets on Command-change, but a butler left invalid
+      // (hand-edited config, never command-changed) would otherwise re-persist.
       const normalizedConfig = {
         ...config,
         projects: config.projects.map((p) => {
@@ -505,6 +508,9 @@ export default function SettingsPage() {
           }
           return { ...p, agents };
         }),
+        butler: config.butler
+          ? { ...config.butler, model: sanitizeModel(config.butler.command || "claude", config.butler.model) }
+          : config.butler,
       };
       const res = await fetch("/api/config", {
         method: "PUT",


### PR DESCRIPTION
## Summary
Follow-up to #931 (surfaced by @re2 on PR #934). `SettingsPage.save()` normalizes every **per-agent** model through `sanitizeModel(command, model)` before the PUT, but spread `config.butler` through **unchanged**. So a butler left with a model invalid for its command (hand-edited config or a pre-#931 state) re-persisted on save — the same class of bug #931 fixed for per-agent models.

The butler dropdown is already provider-aware and resets the model on Command-change, so the invalid state only survives if the butler is never command-changed. Real, but low-impact — exactly as the issue scoped it.

## Fix (`src/components/SettingsPage.tsx`)
The issue's exact one-liner — run `config.butler` through the same shared helper in the `normalizedConfig` built by `save()`:

```ts
butler: config.butler
  ? { ...config.butler, model: sanitizeModel(config.butler.command || "claude", config.butler.model) }
  : config.butler,
```

`sanitizeModel` (in `src/lib/agentModels.ts`, added in #931) preserves `""` (CLI default — valid for every CLI) and heals only non-empty invalid values, so this is behavior-preserving for the valid cases and a no-op when `config.butler` is absent.

## Acceptance criteria
- [x] `save()` persists a butler model valid for the butler's command, even if it was never command-changed
- [x] `""` (CLI default) is preserved
- [x] Extended `server/agentModels.test.js` — pins the exact butler save expression (codex+`opus` → `gpt-5.4`, cross-backend heal, `""` preserved, already-valid kept, unset → `""`, missing butler untouched). 6 new assertions.
- [x] `npm run build` / tests pass

## Verification
- Full `npm test` **43/0/2-skip** (agentModels test exercises the **real** shared module — Node strips the TS types at require-time, no duplicated logic).
- `npm run build` + TypeScript typecheck exit 0.

Frontend-only; reuses the proven #931 helper. Completes Batch 23 (sole item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)