### PR TITLE
[#937] Reset/heal mcp_inject on agent Command change; share backend→mode map

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const readline = require("readline");
+const { injectModeForCommand } = require("../src/lib/injectMode.js");
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -679,8 +680,7 @@ function writeQuadWorkConfig(setup) {
 
   for (const agent of AGENTS) {
     const cmd = (setup.backends && setup.backends[agent]) || setup.backend;
-    const cliBase = cmd.split("/").pop().split(" ")[0];
-    const injectMode = cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag";
+    const injectMode = injectModeForCommand(cmd);
     project.agents[agent] = {
       cwd: setup.worktrees[agent],
       command: cmd,

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const fileChat = require("./file-chat");
 const { dispatchToAgentPTY, cleanupSession: cleanupPtyDispatcher } = require("./pty-dispatcher");
 const { runAcMigration } = require("./migrate-ac");
 const selfHeal = require("./self-heal");
+const { injectModeForCommand } = require("../src/lib/injectMode.js");
 
 const net = require("net");
 const config = readConfig();
@@ -399,7 +400,7 @@ async function buildAgentArgs(projectId, agentId) {
   }
 
   // MCP config injection — file-chat shim
-  const injectMode = agentCfg.mcp_inject || (cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag");
+  const injectMode = agentCfg.mcp_inject || injectModeForCommand(command);
   if (injectMode === "flag") {
     const { filePath: mcpConfigPath } = writeFileChatMcpConfig(projectId, agentId, PORT);
     const mcpFlag = agentCfg.mcp_flag || "--mcp-config";

--- a/server/injectMode.test.js
+++ b/server/injectMode.test.js
@@ -1,0 +1,68 @@
+// #937: changing an agent's Command in Settings reset the model (#931) but
+// not mcp_inject, so converting an agent to gemini left a stale "flag" and the
+// CLI crashed on launch (spawned with --mcp-config, which Gemini doesn't take).
+// The fix routes the wizard, the add-project route, the spawn default, and the
+// Settings command-change/save flow through one shared mapping in
+// src/lib/injectMode.js. This test pins that mapping and the save reconciliation
+// the component applies to agents (always) and the butler (heal-if-present).
+//
+// Plain node:assert script (run via server/run-tests.js). It requires the real
+// shared module the production code and UI use — no duplicated logic.
+
+const { cliBaseFromCommand, injectModeForCommand } = require("../src/lib/injectMode.js");
+
+let passed = 0,
+  failed = 0;
+const ok = (c, m) => {
+  if (c) {
+    passed++;
+    console.log(`  PASS: ${m}`);
+  } else {
+    failed++;
+    console.error(`  FAIL: ${m}`);
+  }
+};
+
+// ── cliBaseFromCommand: strip directory + args, claude fallback ──
+ok(cliBaseFromCommand("gemini") === "gemini", "cliBaseFromCommand keeps a bare command");
+ok(cliBaseFromCommand("/usr/bin/codex") === "codex", "cliBaseFromCommand strips a leading path");
+ok(cliBaseFromCommand("claude --dangerously-skip-permissions") === "claude", "cliBaseFromCommand strips trailing args");
+ok(cliBaseFromCommand("") === "claude", "cliBaseFromCommand falls back to claude for empty");
+ok(cliBaseFromCommand(undefined) === "claude", "cliBaseFromCommand falls back to claude for undefined");
+
+// ── injectModeForCommand: the backend → mode mapping (matches bin/quadwork.js) ──
+ok(injectModeForCommand("codex") === "proxy_flag", "#937 AC: codex → proxy_flag");
+ok(injectModeForCommand("gemini") === "env", "#937 AC: gemini → env (no --mcp-config)");
+ok(injectModeForCommand("claude") === "flag", "#937 AC: claude → flag");
+ok(injectModeForCommand("/opt/bin/gemini") === "env", "injectModeForCommand resolves a pathed gemini → env");
+ok(injectModeForCommand("codex -c foo=bar") === "proxy_flag", "injectModeForCommand resolves codex with args → proxy_flag");
+ok(injectModeForCommand("") === "flag", "injectModeForCommand: empty command → flag (claude default)");
+ok(injectModeForCommand(undefined) === "flag", "injectModeForCommand: undefined command → flag (claude default)");
+ok(injectModeForCommand("aider") === "flag", "injectModeForCommand: unknown backend → flag");
+
+// ── save() reconciliation: agents are ALWAYS reconciled (wizard invariant + ──
+// the spawn path reads mcp_inject), mirroring SettingsPage.save().
+const reconcileAgent = (a) => ({ ...a, mcp_inject: injectModeForCommand(a.command || "claude") });
+ok(reconcileAgent({ command: "gemini", mcp_inject: "flag" }).mcp_inject === "env", "#937 core: save heals a stale 'flag' on a gemini-converted agent → 'env'");
+ok(reconcileAgent({ command: "codex", mcp_inject: "flag" }).mcp_inject === "proxy_flag", "save heals a codex agent's mcp_inject → proxy_flag");
+ok(reconcileAgent({ command: "claude", mcp_inject: "env" }).mcp_inject === "flag", "save heals a claude agent's mcp_inject → flag");
+ok(reconcileAgent({ command: "gemini" }).mcp_inject === "env", "save sets mcp_inject for a legacy agent that lacked one (matches spawn fallback)");
+ok(reconcileAgent({ command: "codex", mcp_inject: "proxy_flag" }).mcp_inject === "proxy_flag", "save leaves an already-correct mcp_inject unchanged");
+
+// ── save() reconciliation: the butler is HEAL-IF-PRESENT only (spawn ignores ──
+// mcp_inject and the wizard never writes one), mirroring SettingsPage.save().
+const reconcileButler = (butler) =>
+  butler
+    ? {
+        ...butler,
+        ...(butler.mcp_inject !== undefined
+          ? { mcp_inject: injectModeForCommand(butler.command || "claude") }
+          : {}),
+      }
+    : butler;
+ok(reconcileButler({ command: "gemini", mcp_inject: "flag" }).mcp_inject === "env", "#937: save heals a stale butler mcp_inject when present → 'env'");
+ok(!("mcp_inject" in reconcileButler({ command: "gemini" })), "#937: save does NOT fabricate mcp_inject on a butler that never had one");
+ok(reconcileButler(undefined) === undefined, "save leaves a missing butler config untouched");
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/server/routes.js
+++ b/server/routes.js
@@ -13,6 +13,7 @@ const multer = require("multer");
 const fileChat = require("./file-chat");
 const telegramBridge = require("./bridges/telegram");
 const discordBridge = require("./bridges/discord");
+const { injectModeForCommand } = require("../src/lib/injectMode.js");
 
 const router = express.Router();
 
@@ -3433,12 +3434,11 @@ router.post("/api/setup", (req, res) => {
       for (const agentId of ["head", "re1", "re2", "dev"]) {
         const cmd = (backends && backends[agentId]) || "claude";
         const cliBase = cmd.split("/").pop().split(" ")[0];
-        const injectMode = cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag";
         agents[agentId] = {
           cwd: path.join(parentDir, `${dirName}-${agentId}`),
           command: cmd,
           auto_approve: autoApprove,
-          mcp_inject: injectMode,
+          mcp_inject: injectModeForCommand(cmd),
           ...(cliBase === "codex" ? { reasoning_effort: "medium" } : {}),
         };
       }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { useLocale } from "@/components/LocaleProvider";
 import { modelsForBackend, effectiveModel, sanitizeModel } from "@/lib/agentModels";
+import { injectModeForCommand } from "@/lib/injectMode";
 import ActiveSwitch from "./ActiveSwitch";
 import ConfirmModal from "./ConfirmModal";
 import { persistProjectIdle, onIdleChange, idleConfirmTitle, IDLE_CONFIRM_BODY } from "@/lib/idle";
@@ -14,6 +15,10 @@ interface AgentConfig {
   cwd: string;
   model: string;
   agents_md: string;
+  // #937: MCP injection mode (codex→proxy_flag, gemini→env, else flag). Written
+  // by the setup wizard on every agent; the spawn path reads it. The Settings
+  // command-change/save flow must keep it in sync with the command.
+  mcp_inject?: string;
 }
 
 // Per-project Telegram config + Scheduled Trigger fields are still on
@@ -36,6 +41,10 @@ interface ButlerConfig {
   model?: string;
   auto_start?: boolean;
   cwd?: string;
+  // #937: present only if a config carries it (the wizard doesn't write one for
+  // the butler and the butler spawn doesn't consume it). Healed on save only
+  // when already set, so a stale value never re-persists.
+  mcp_inject?: string;
 }
 
 interface Config {
@@ -499,17 +508,34 @@ export default function SettingsPage() {
       // #935: the butler model needs the same guard. Its dropdown is
       // provider-aware and resets on Command-change, but a butler left invalid
       // (hand-edited config, never command-changed) would otherwise re-persist.
+      // #937: reconcile mcp_inject the same way. Every agent carries one (the
+      // wizard writes it and the spawn path reads it), so always re-derive it
+      // from the command — this heals a stale "flag" left on an agent converted
+      // to gemini before this fix, which would otherwise crash the CLI. The
+      // butler is different: its spawn doesn't consume mcp_inject and the wizard
+      // never writes one, so we only heal a value that's already present rather
+      // than fabricate one.
       const normalizedConfig = {
         ...config,
         projects: config.projects.map((p) => {
           const agents: Record<string, AgentConfig> = {};
           for (const [id, a] of Object.entries(p.agents)) {
-            agents[id] = { ...a, model: sanitizeModel(a.command || "claude", a.model) };
+            agents[id] = {
+              ...a,
+              model: sanitizeModel(a.command || "claude", a.model),
+              mcp_inject: injectModeForCommand(a.command || "claude"),
+            };
           }
           return { ...p, agents };
         }),
         butler: config.butler
-          ? { ...config.butler, model: sanitizeModel(config.butler.command || "claude", config.butler.model) }
+          ? {
+              ...config.butler,
+              model: sanitizeModel(config.butler.command || "claude", config.butler.model),
+              ...(config.butler.mcp_inject !== undefined
+                ? { mcp_inject: injectModeForCommand(config.butler.command || "claude") }
+                : {}),
+            }
           : config.butler,
       };
       const res = await fetch("/api/config", {
@@ -835,7 +861,14 @@ export default function SettingsPage() {
                 const models = modelsForBackend(v);
                 const currentModel = config.butler?.model || "opus";
                 const modelValid = models.some((m) => m.value === currentModel);
-                updateButler({ command: v, model: modelValid ? currentModel : models[0].value });
+                // #937: only re-derive mcp_inject if this config actually carries
+                // one — the butler spawn doesn't consume it and the wizard never
+                // writes one, so we heal a stale value without fabricating a field.
+                updateButler({
+                  command: v,
+                  model: modelValid ? currentModel : models[0].value,
+                  ...(config.butler?.mcp_inject !== undefined ? { mcp_inject: injectModeForCommand(v) } : {}),
+                });
               }}
               options={BACKENDS.map((b) => ({
                 value: b.value,
@@ -971,10 +1004,14 @@ export default function SettingsPage() {
                                 // valid for the new backend (mirror the butler dropdown
                                 // above) — otherwise a Claude model leaks onto a
                                 // codex/gemini agent and is saved/spawned as invalid.
+                                // #937: likewise reset mcp_inject to the new backend's
+                                // mode — otherwise converting to gemini leaves a stale
+                                // "flag" and the CLI crashes on launch (--mcp-config).
                                 const command = e.target.value;
                                 updateAgent(idx, agentId, {
                                   command,
                                   model: effectiveModel(command, agent.model),
+                                  mcp_inject: injectModeForCommand(command),
                                 });
                               }}
                               className="bg-transparent text-[11px] text-text outline-none border border-border px-1 py-0.5 focus:border-accent"

--- a/src/lib/injectMode.js
+++ b/src/lib/injectMode.js
@@ -1,0 +1,32 @@
+// #937: single source of truth for the backend → MCP injection-mode mapping.
+// The setup wizard (bin/quadwork.js), the add-project route (server/routes.js),
+// and the spawn default (server/index.js) all derive `mcp_inject` from an
+// agent's command — codex → "proxy_flag", gemini → "env", everything else
+// → "flag". Before this helper the mapping was copy-pasted in all three, and
+// the Settings UI's command-change/save flow didn't touch mcp_inject at all,
+// so converting an agent to gemini left a stale "flag" and crashed the CLI
+// (it was spawned with `--mcp-config`, which Gemini doesn't accept).
+//
+// Plain JS on purpose (not .ts): this module is required by Node production
+// code (bin/quadwork.js, server/*.js) which runs on Node >=20 — without .ts
+// type-stripping — and imported by the Settings UI (tsconfig allowJs).
+
+/**
+ * Resolve a command string to its CLI base name, matching how the spawn paths
+ * derive it: strip any directory and take the first whitespace-separated token.
+ * e.g. "gemini" / "/usr/bin/gemini" / "claude --foo" → "gemini" / "gemini" / "claude".
+ */
+function cliBaseFromCommand(command) {
+  return String(command || "claude").split("/").pop().split(" ")[0];
+}
+
+/**
+ * MCP injection mode for an agent's command:
+ *   codex → "proxy_flag", gemini → "env", everything else → "flag".
+ */
+function injectModeForCommand(command) {
+  const cliBase = cliBaseFromCommand(command);
+  return cliBase === "codex" ? "proxy_flag" : cliBase === "gemini" ? "env" : "flag";
+}
+
+module.exports = { cliBaseFromCommand, injectModeForCommand };


### PR DESCRIPTION
## Summary
Sibling of #931/#935 on the same Settings command-change + `save()` seam. Changing an agent's **Command** in Settings reset the **model** (#931) but did **not** update `mcp_inject`. Since the setup wizard writes an explicit `mcp_inject` on every agent (codex→`proxy_flag`, gemini→`env`, claude→`flag`), converting an existing agent to **gemini** left a stale `mcp_inject: "flag"` → the agent was spawned with `--mcp-config` (which Gemini doesn't accept) → **gemini crashed on launch**. Symmetric breakage existed for any conversion crossing injection modes.

This is the realistic "enable a gemini agent from an existing team" flow (16/16 live agents carry an explicit `mcp_inject`), so it hit every time.

## Fix
**1. One shared helper (`src/lib/injectMode.js`).** The backend→injectMode mapping was copy-pasted in three Node sites — `bin/quadwork.js`, `server/routes.js` (`/api/setup`), and `server/index.js`'s spawn default. Factored into a single `injectModeForCommand(command)` (+ `cliBaseFromCommand`) and wired all three through it, eliminating drift. **Plain JS, not `.ts`, on purpose:** required by Node production code that runs on Node `>=20` (no `.ts` type-stripping), and imported by the Settings UI (`tsconfig allowJs`).

**2. Settings command-change + save (`src/components/SettingsPage.tsx`).**
- Per-agent Command `onChange` now resets `mcp_inject` to the new backend's mode alongside the existing model reset.
- `save()` reconciles each agent's `mcp_inject` with its command — **always**, since every agent carries one (wizard invariant) and the spawn path reads it. This heals a stale `"flag"` left on a pre-fix gemini conversion, regardless of how state got it.
- The **butler** is **heal-if-present only**: its spawn doesn't consume `mcp_inject` and the wizard never writes one, so a stale value is healed but a field is never fabricated. (Mirrors the #935 butler treatment without adding a no-op field universally.)

## Acceptance criteria
- [x] Converting any agent to `command: gemini` yields `mcp_inject: "env"` (no `--mcp-config`; gemini launches)
- [x] codex→`proxy_flag`, claude→`flag` on conversion
- [x] `save()` heals a stale/mismatched `mcp_inject` for agents and butler
- [x] Unit test the backend→injectMode mapping + the save reconciliation
- [x] `npm run build` / tests pass

## Verification
- New `server/injectMode.test.js` (**21/0**) exercises the **real shared module** — the mapping (incl. pathed/argument'd commands, claude fallback) and the agent (always-reconcile) + butler (heal-if-present, never-fabricate) save expressions.
- Full `npm test` **44/0/2-skip** (new test auto-discovered); `npm run build` + TypeScript typecheck exit 0.
- `node --check` clean on all three edited Node files; require path resolves from `bin/` and `server/` (both siblings of `src/`).

Completes Batch 24 (sole item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)