### PR TITLE
[#940] Fix chat image attachments: serve under dot-dir + persist attachments

### DIFF
--- a/server/file-chat.js
+++ b/server/file-chat.js
@@ -137,7 +137,7 @@ function shutdownProject(projectId) {
   projectState.delete(projectId);
 }
 
-function appendMessage(projectId, { sender, channel = "general", text, type = "message" }, _skipLoopGuard = false) {
+function appendMessage(projectId, { sender, channel = "general", text, type = "message", attachments } = {}, _skipLoopGuard = false) {
   const state = getState(projectId);
   if (state.nextId === null) {
     throw new Error(`Project ${projectId} not initialized — call initProject first`);
@@ -154,6 +154,7 @@ function appendMessage(projectId, { sender, channel = "general", text, type = "m
     type,
     text: text || "",
     mentions: parseMentions(text),
+    ...(attachments && attachments.length > 0 ? { attachments } : {}),
   };
 
   const dir = chatDir(projectId);

--- a/server/routes.js
+++ b/server/routes.js
@@ -869,11 +869,32 @@ router.post("/api/chat", (req, res) => {
   } else if (bridgeSender && isLocalhost(req.ip)) {
     sender = bridgeSender;
   }
+  // #940: thread image attachments through. Persist only the `name`
+  // (the absolute server FS `path` must not be stored/broadcast), and
+  // since the name is later used to build a serve path, reject any with
+  // path separators — same guard as the serve route.
+  let attachments;
+  if (req.body?.attachments !== undefined) {
+    if (!Array.isArray(req.body.attachments)) {
+      return res.status(400).json({ error: "attachments must be an array" });
+    }
+    attachments = req.body.attachments.map((att) => {
+      const name = att?.name;
+      if (typeof name !== "string" || !name || /[/\\]/.test(name)) {
+        return null;
+      }
+      return { name };
+    });
+    if (attachments.some((att) => att === null)) {
+      return res.status(400).json({ error: "Invalid attachment name" });
+    }
+  }
   const msg = fileChat.appendMessage(projectId, {
     sender,
     text: normalizeMentions(text, selfMentionSkip),
     channel: req.body?.channel || "general",
     type: "message",
+    attachments,
   });
   // #717: loop guard — count agent hops, pause if threshold reached
   const maxHops = getProjectMaxHops(projectId);
@@ -931,7 +952,7 @@ router.get("/api/uploads/:project/:filename", (req, res) => {
   // #560: pass error callback so Express/send NotFoundError (race between
   // existsSync and sendFile, or stricter file resolution in Express 5's
   // send module) is handled gracefully instead of spamming the server log.
-  res.sendFile(filePath, (err) => {
+  res.sendFile(filePath, { dotfiles: "allow" }, (err) => {
     if (!err || res.headersSent) return;
     if (err.status === 404 || err.code === "ENOENT") {
       res.status(404).json({ error: "Not found" });

--- a/server/routes.uploadAttachments.test.js
+++ b/server/routes.uploadAttachments.test.js
@@ -1,0 +1,158 @@
+// #940: chat image attachments — two regressions, two fixes.
+//   1. GET /api/uploads/:project/:filename must serve a file living under
+//      the ~/.quadwork dot-dir (res.sendFile needs { dotfiles: "allow" }).
+//   2. POST /api/chat + appendMessage must thread `attachments` through and
+//      persist only the `name` (never the absolute server FS `path`).
+//
+// Plain node:assert script — run with `node server/routes.uploadAttachments.test.js`.
+
+const assert = require("node:assert/strict");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const TEST_DIR = path.join(os.tmpdir(), `routes-uploads-test-${process.pid}-${Date.now()}`);
+
+// Override HOME BEFORE requiring routes/config so CONFIG_DIR resolves to a
+// `.quadwork` dot-dir under the temp dir (exercising the real dotfiles path).
+const origHome = os.homedir;
+os.homedir = () => TEST_DIR;
+
+const fileChat = require("./file-chat");
+const router = require("./routes");
+const express = require("express");
+
+const CONFIG_DIR = path.join(TEST_DIR, ".quadwork");
+const PROJECT = "uploads-test-project";
+const UPLOAD_NAME = "upload-12345.png";
+// 1x1 transparent PNG
+const PNG_BYTES = Buffer.from(
+  "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6360000002000154a24f5f0000000049454e44ae426082",
+  "hex",
+);
+
+function cleanup() {
+  os.homedir = origHome;
+  try { fs.rmSync(TEST_DIR, { recursive: true, force: true }); } catch {}
+}
+process.on("exit", cleanup);
+
+function req(server, { method = "GET", urlPath, body, headers = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address();
+    const payload = body === undefined ? null : Buffer.from(JSON.stringify(body));
+    const r = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method,
+        path: urlPath,
+        headers: {
+          ...(payload ? { "content-type": "application/json", "content-length": payload.length } : {}),
+          ...headers,
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode, buf: Buffer.concat(chunks) }));
+      },
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+(async () => {
+  // --- Direct appendMessage unit checks (no HTTP) ---------------------------
+  fileChat.initProject(PROJECT);
+
+  {
+    const m = fileChat.appendMessage(PROJECT, {
+      sender: "user",
+      text: "hi",
+      attachments: [{ name: "upload-a.png" }],
+    });
+    assert.deepEqual(m.attachments, [{ name: "upload-a.png" }], "appendMessage stores attachments");
+  }
+  {
+    const m = fileChat.appendMessage(PROJECT, { sender: "user", text: "no attach" });
+    assert.equal("attachments" in m, false, "appendMessage omits attachments field when absent");
+  }
+  {
+    const m = fileChat.appendMessage(PROJECT, { sender: "user", text: "empty", attachments: [] });
+    assert.equal("attachments" in m, false, "appendMessage omits attachments field when empty array");
+  }
+  console.log("PASS: appendMessage attachments round-trip (store / omit-absent / omit-empty)");
+
+  // --- HTTP: serve under dot-dir + POST /api/chat persistence ---------------
+  const uploadsDir = path.join(CONFIG_DIR, PROJECT, "uploads");
+  fs.mkdirSync(uploadsDir, { recursive: true });
+  fs.writeFileSync(path.join(uploadsDir, UPLOAD_NAME), PNG_BYTES);
+
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+
+  try {
+    // Bug 1: serve route returns 200 for a file living under the dot-dir.
+    const served = await req(server, { urlPath: `/api/uploads/${PROJECT}/${UPLOAD_NAME}` });
+    assert.equal(served.status, 200, "GET /api/uploads serves dot-dir file with 200");
+    assert.equal(served.buf.length, PNG_BYTES.length, "served bytes match the on-disk file");
+    console.log("PASS: serve endpoint returns 200 for a file under the .quadwork dot-dir");
+
+    // Bug 1 guard retained: traversal in filename is rejected.
+    const trav = await req(server, { urlPath: `/api/uploads/${PROJECT}/..%2Fconfig.json` });
+    assert.ok(trav.status === 400 || trav.status === 404, "traversal filename is not served");
+
+    // Bug 2: POST /api/chat persists attachments (name only, no path).
+    const posted = await req(server, {
+      method: "POST",
+      urlPath: `/api/chat?project=${PROJECT}`,
+      body: {
+        text: "look at this",
+        attachments: [{ path: "/home/u/.quadwork/p/uploads/upload-x.png", name: "upload-x.png" }],
+      },
+    });
+    assert.equal(posted.status, 200, "POST /api/chat with attachments succeeds");
+    const postedMsg = JSON.parse(posted.buf.toString()).message;
+    assert.deepEqual(postedMsg.attachments, [{ name: "upload-x.png" }], "persisted attachment carries name only (path dropped)");
+
+    // Refetch confirms persistence survives reload from disk.
+    const fetched = await req(server, { urlPath: `/api/chat?project=${PROJECT}&since_id=${postedMsg.id - 1}` });
+    const msgs = JSON.parse(fetched.buf.toString());
+    const reloaded = msgs.find((m) => m.id === postedMsg.id);
+    assert.ok(reloaded, "posted message is returned on refetch");
+    assert.deepEqual(reloaded.attachments, [{ name: "upload-x.png" }], "attachments survive refetch with name only");
+    console.log("PASS: POST /api/chat round-trips attachments (name only) through persistence");
+
+    // Bug 2 validation: non-array attachments rejected.
+    const badType = await req(server, {
+      method: "POST",
+      urlPath: `/api/chat?project=${PROJECT}`,
+      body: { text: "x", attachments: { name: "nope.png" } },
+    });
+    assert.equal(badType.status, 400, "non-array attachments rejected with 400");
+
+    // Bug 2 validation: attachment name with path separators rejected.
+    const badName = await req(server, {
+      method: "POST",
+      urlPath: `/api/chat?project=${PROJECT}`,
+      body: { text: "x", attachments: [{ name: "../../etc/passwd" }] },
+    });
+    assert.equal(badName.status, 400, "attachment name with path separators rejected with 400");
+    console.log("PASS: POST /api/chat rejects non-array attachments and traversal names");
+  } finally {
+    server.close();
+  }
+
+  console.log("routes.uploadAttachments.test.js: all assertions passed");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## #940 — Chat image attachments broken (two independent regressions)

Closes #940. Both root causes from the issue, both fixes small and verified.

### Bug 1 — serve endpoint 404s under the `~/.quadwork` dot-dir
`GET /api/uploads/:project/:filename` used `res.sendFile(filePath, cb)`. Express/`send` defaults to `dotfiles: "ignore"`, and uploads live under `~/.quadwork/<project>/uploads/` — a dot-segment path — so every upload 404'd despite being on disk (the broken-image thumbnail in the report).

**Fix:** `res.sendFile(filePath, { dotfiles: "allow" }, cb)`. Existing traversal guard (`/[/\\]/` on project + filename) and the `#560` error-callback are untouched.

### Bug 2 — attachments never persisted (#723 regression)
`POST /api/chat` never read `req.body.attachments`, and `appendMessage` didn't accept the field, so sent images vanished on refetch (0 persisted messages carried `attachments`).

**Fix:**
1. `POST /api/chat`: read + validate `req.body.attachments` — must be an array of `{ name }`; reject non-arrays and names with path separators (the `name` later builds a serve path).
2. Persist the **`name` only** — the absolute server FS `path` from the upload response is dropped (not stored/broadcast to clients).
3. `appendMessage` accepts `attachments` and includes it on the record only when non-empty (`...(attachments && attachments.length > 0 ? { attachments } : {})`).

### Acceptance criteria
- [x] `GET /api/uploads/...` serves an existing upload with 200 (dotfiles allowed)
- [x] Sending a message with an image persists `attachments`; renders after refetch
- [x] Path-traversal protection retained on serve **and** on the persisted `name`
- [x] Persisted attachment carries `name` only (no absolute FS `path`)
- [x] Tests: serve under a dot-dir → 200; `appendMessage`/`POST /api/chat` round-trip an `attachments` array
- [x] `npm run build` / tests pass

### Verification
- New `server/routes.uploadAttachments.test.js` (mounts the **real** router under a temp `.quadwork` dot-dir HOME): serve-under-dot-dir → 200 with matching bytes, traversal rejected; `appendMessage` store/omit-absent/omit-empty; `POST /api/chat` round-trip persists `name` only and survives refetch; non-array + traversal-name attachments → 400.
- Full `npm test` **45/0/2-skip**; `npm run build` OK; `tsc --noEmit` exit 0; `node --check` clean on `routes.js` + `file-chat.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
