### PR TITLE
[#939] Add pack-smoke CI guard against runtime requires missing from the tarball

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Reference: [plotlink at `pre-design-overhaul`](https://github.com/realproject7/p
 
 - AgentChattr: external dependency, cloned to `~/.quadwork/agentchattr` and run via `.venv/bin/python run.py`
 - Telegram bridge: external (`realproject7/agentchattr-telegram`), optional
+- Any new shared module `require`d by Node runtime code (`bin/`, `server/`) must live under a shipped dir or be added to `package.json` `files` — otherwise it's missing from the published tarball and crash-loops on fresh install (#937/#939). `server/pack-smoke.test.js` guards this in CI.
 
 ## Running locally
 

--- a/server/pack-smoke.test.js
+++ b/server/pack-smoke.test.js
@@ -1,0 +1,118 @@
+// #939: pack-smoke guard — prevention for the 2.3.4 crash-loop (#937 regression).
+//
+// #937 added `require("../src/lib/injectMode.js")` to runtime Node code
+// (bin/quadwork.js, server/index.js, server/routes.js) but `src/` was not in
+// package.json `files`, so the published tarball omitted the module and every
+// fresh `npm install` crash-looped on boot. It passed review + CI because the
+// git checkout HAS `src/lib/`, so the runtime require resolves fine there — the
+// failure only appears once the package is packed. Static review of the diff
+// can't catch this class; only the *tarball contents* can.
+//
+// This guard asks npm for the authoritative tarball file list (the real `files`
+// whitelist + ignore resolution, not a re-implementation) and asserts that every
+// relative `require()` in shipped bin/+server/ code resolves to a file that is
+// ALSO in the tarball. A module that exists in the checkout but is missing from
+// the pack — the exact #937 signature — fails here instead of in prod.
+//
+// Uses `npm pack --dry-run --json --ignore-scripts`: --dry-run packs nothing,
+// --ignore-scripts skips the slow `prepack` (next build) so this stays fast and
+// deterministic in the test runner. Plain node:assert script — run with
+// `node server/pack-smoke.test.js`.
+
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+
+// 1) Authoritative tarball file list from npm itself.
+function tarballFiles() {
+  const npmCli = process.platform === "win32" ? "npm.cmd" : "npm";
+  const out = execFileSync(
+    npmCli,
+    ["pack", "--dry-run", "--json", "--ignore-scripts"],
+    { cwd: ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: 32 * 1024 * 1024 },
+  );
+  // npm prints the JSON array; tolerate any leading non-JSON warning lines.
+  const start = out.indexOf("[");
+  const parsed = JSON.parse(out.slice(start));
+  // Normalize to forward-slash repo-relative paths.
+  return new Set((parsed[0]?.files || []).map((f) => f.path.split(path.sep).join("/")));
+}
+
+// 2) Resolve a relative require specifier (from `fromFile`) to a repo-relative
+//    path, trying Node's file-resolution order. Returns null if it doesn't
+//    resolve to an existing file in the checkout.
+function resolveRelativeRequire(fromFile, spec) {
+  const base = path.resolve(path.dirname(path.join(ROOT, fromFile)), spec);
+  const candidates = [base, `${base}.js`, `${base}.json`, path.join(base, "index.js")];
+  for (const c of candidates) {
+    try {
+      if (fs.statSync(c).isFile()) {
+        return path.relative(ROOT, c).split(path.sep).join("/");
+      }
+    } catch {
+      /* not this candidate */
+    }
+  }
+  return null;
+}
+
+// Match require("..."), require('...') with a relative specifier (starts with .).
+const REQUIRE_RE = /require\(\s*["'](\.[^"']*)["']\s*\)/g;
+
+(async () => {
+  const shipped = tarballFiles();
+
+  // Sanity: the list is non-empty and contains a known runtime entrypoint.
+  assert.ok(shipped.size > 0, "npm pack returned a non-empty file list");
+  assert.ok(shipped.has("bin/quadwork.js"), "tarball includes bin/quadwork.js");
+
+  // 3) Scan every shipped .js file under bin/ and server/ for relative requires.
+  const shippedNodeSrc = [...shipped].filter(
+    (f) => /\.js$/.test(f) && (f.startsWith("bin/") || f.startsWith("server/")),
+  );
+  assert.ok(shippedNodeSrc.length > 0, "found shipped Node source files to scan");
+
+  const violations = [];
+  for (const file of shippedNodeSrc) {
+    const code = fs.readFileSync(path.join(ROOT, file), "utf8");
+    for (const m of code.matchAll(REQUIRE_RE)) {
+      const spec = m[1];
+      const target = resolveRelativeRequire(file, spec);
+      // target === null → resolves to nothing in the checkout (e.g. a built
+      // artifact dir); not the #937 class, skip. A target that DOES exist in
+      // the checkout but is absent from the tarball is the bug we guard.
+      if (target && !shipped.has(target)) {
+        violations.push({ file, spec, target });
+      }
+    }
+  }
+
+  if (violations.length) {
+    const lines = violations
+      .map((v) => `  ${v.file}: require("${v.spec}") → ${v.target} (NOT in tarball)`)
+      .join("\n");
+    assert.fail(
+      `Runtime require(s) resolve to files missing from the npm tarball — ` +
+        `published install would crash (#937 class). Add the path(s) to package.json "files":\n${lines}`,
+    );
+  }
+
+  // 4) Regression anchor: the exact #937 module is required AND shipped.
+  assert.ok(
+    shipped.has("src/lib/injectMode.js"),
+    'src/lib/injectMode.js is require()d by runtime code and must stay in the tarball (#937)',
+  );
+
+  console.log(
+    `PASS: pack-smoke — ${shippedNodeSrc.length} shipped Node files scanned, ` +
+      `all relative requires resolve inside the tarball`,
+  );
+  console.log("server/pack-smoke.test.js: all assertions passed");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## #939 — Prevention: pack-smoke guard against runtime requires missing from the npm tarball

Closes #939. **Prevention-only** — the `files` whitelist hotfix already shipped in 2.3.5, so this PR does **not** touch `package.json` `files`.

### Background
2.3.4 crash-looped on every fresh install:
```
Error: Cannot find module '../src/lib/injectMode.js'  (bin/quadwork.js:8)
```
#937 added `require("../src/lib/injectMode.js")` to runtime Node code (`bin/quadwork.js`, `server/index.js`, `server/routes.js`), but `src/` wasn't in `package.json` `files` — so the published tarball omitted the module. It passed review + CI because the git checkout **has** `src/lib/`; the failure only appears once the package is packed. Static diff review can't catch this class — only the *tarball contents* can.

### Guard (`server/pack-smoke.test.js`)
1. Asks npm for the **authoritative** tarball file list — `npm pack --dry-run --json --ignore-scripts` (the real `files`/ignore resolution, not a re-implementation; `--dry-run` packs nothing, `--ignore-scripts` skips the slow `prepack` next-build so it's fast + deterministic).
2. Statically scans every shipped `.js` under `bin/` + `server/` for relative `require("./…")`/`require("../…")`.
3. Fails if any such require resolves to a file that exists in the checkout but is **absent from the tarball** — the exact #937 signature. The failure message names each offending require and tells you to add the path to `files`.
4. Regression anchor: asserts `src/lib/injectMode.js` is in the tarball.

This combines the issue's pack-smoke ask with the "guard against `require("../src/…")`" ask in one deterministic test, without executing the side-effectful entrypoints.

### Proof it catches the bug
Temporarily removing `src/lib/injectMode.js` from `files` makes the guard fail with:
```
Runtime require(s) resolve to files missing from the npm tarball — published install would crash (#937 class).
  bin/quadwork.js: require("../src/lib/injectMode.js") → src/lib/injectMode.js (NOT in tarball)
  server/index.js: require("../src/lib/injectMode.js") → src/lib/injectMode.js (NOT in tarball)
  server/routes.js: require("../src/lib/injectMode.js") → src/lib/injectMode.js (NOT in tarball)
```
Restoring `files` → passes. (`package.json` is unchanged in this PR.)

### Acceptance criteria
- [x] CI guard: pack the package, verify runtime requires resolve inside the tarball — fails if any resolves outside it (runs in `npm test`, the repo's CI gate; no `.github/workflows` exists)
- [x] Guards against `require("../src/…")` in `bin/`+`server/` not covered by `files`
- [x] Documents the rule (CLAUDE.md → Dependencies): new shared modules `require`d by Node runtime code must be under a shipped dir or added to `files`
- [x] Does **not** re-edit the `files` whitelist (already fixed in 2.3.5)

### Verification
- `node server/pack-smoke.test.js` passes (23 shipped Node files scanned); negative test (drop `src/` from `files`) fails as shown above.
- Full `npm test` **46/0/2-skip**; `node --check` clean on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
