### PR TITLE
[#944] Persist pinned_projects & sidebar_groups via field-scoped endpoints

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -329,12 +329,96 @@ router.put("/api/config", (req, res) => {
     const body = req.body;
     const dir = path.dirname(CONFIG_PATH);
     ensureSecureDir(dir);
+    // #944: pinned_projects and sidebar_groups are owned by the field-scoped
+    // /api/pins and /api/sidebar-groups endpoints below. A whole-config PUT
+    // (settings save, idle toggle, bridge/queue/trigger widgets) carries a
+    // snapshot the client GET'd earlier, which may be stale for these two keys
+    // — a pin/group added by another save in the meantime. Never let a full PUT
+    // clobber them: always re-read the current on-disk values and keep those.
+    const disk = readConfigFile();
+    if ("pinned_projects" in disk) body.pinned_projects = disk.pinned_projects;
+    else delete body.pinned_projects;
+    if ("sidebar_groups" in disk) body.sidebar_groups = disk.sidebar_groups;
+    else delete body.sidebar_groups;
     writeConfig(body);
     // Trigger sync is handled internally since we're in the same process now
     if (typeof req.app.get("syncTriggers") === "function") {
       req.app.get("syncTriggers")();
     }
     res.json({ ok: true });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to write config", detail: err.message });
+  }
+});
+
+// ─── Pinned projects & sidebar groups (field-scoped, race-free) ─────────────
+// #944: pins/groups used to persist via the whole-config GET→mutate→PUT path,
+// which dropped them whenever any concurrent writer PUT a stale snapshot — and
+// a restart fires several of those at once. These endpoints read the freshest
+// config off disk, set ONLY their own key, and write it back, so a save can
+// never clobber a concurrent one. The whole-config PUT above preserves both
+// keys for the same reason.
+
+// Validate pinned_projects: array of non-empty project-id strings, deduped.
+// Returns the cleaned array, or null if the shape is invalid.
+function validatePinnedProjects(value) {
+  if (!Array.isArray(value)) return null;
+  const out = [];
+  for (const id of value) {
+    if (typeof id !== "string" || !id) return null;
+    if (!out.includes(id)) out.push(id);
+  }
+  return out;
+}
+
+// Validate sidebar_groups: array of { name: non-empty string, projects: string[] }.
+// Returns the cleaned array, or null if the shape is invalid.
+function validateSidebarGroups(value) {
+  if (!Array.isArray(value)) return null;
+  const out = [];
+  for (const g of value) {
+    if (!g || typeof g !== "object" || Array.isArray(g)) return null;
+    if (typeof g.name !== "string" || !g.name) return null;
+    if (!Array.isArray(g.projects)) return null;
+    const projects = [];
+    for (const id of g.projects) {
+      if (typeof id !== "string" || !id) return null;
+      projects.push(id);
+    }
+    out.push({ name: g.name, projects });
+  }
+  return out;
+}
+
+router.put("/api/pins", (req, res) => {
+  const pins = validatePinnedProjects(req.body && req.body.pinned_projects);
+  if (pins === null) {
+    return res.status(400).json({ error: "pinned_projects must be an array of project id strings" });
+  }
+  try {
+    const dir = path.dirname(CONFIG_PATH);
+    ensureSecureDir(dir);
+    const cfg = readConfigFile(); // read fresh — never a stale client snapshot
+    cfg.pinned_projects = pins;
+    writeConfig(cfg);
+    res.json({ ok: true, pinned_projects: pins });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to write config", detail: err.message });
+  }
+});
+
+router.put("/api/sidebar-groups", (req, res) => {
+  const groups = validateSidebarGroups(req.body && req.body.sidebar_groups);
+  if (groups === null) {
+    return res.status(400).json({ error: "sidebar_groups must be an array of { name, projects } objects" });
+  }
+  try {
+    const dir = path.dirname(CONFIG_PATH);
+    ensureSecureDir(dir);
+    const cfg = readConfigFile(); // read fresh — never a stale client snapshot
+    cfg.sidebar_groups = groups;
+    writeConfig(cfg);
+    res.json({ ok: true, sidebar_groups: groups });
   } catch (err) {
     res.status(500).json({ error: "Failed to write config", detail: err.message });
   }

--- a/server/routes.persistPins.test.js
+++ b/server/routes.persistPins.test.js
@@ -1,0 +1,191 @@
+// #944: pinned_projects / sidebar_groups reset on server restart.
+// Root cause: they persisted via the whole-config GET→mutate→PUT path, so any
+// concurrent writer holding a stale snapshot (and a restart fires several at
+// once) silently dropped them. This test proves the fix:
+//   1. PUT /api/pins / PUT /api/sidebar-groups read fresh server-side and write
+//      ONLY their own key (other keys untouched, input validated/sanitized).
+//   2. A stale whole-config PUT (settings / idle / bridge widgets) can NEVER
+//      clobber pins or groups — the server preserves the on-disk values.
+//   3. Pins/groups survive the startup config-rewrite and a version-bump reseed.
+//
+// Plain node:assert script — run with `node server/routes.persistPins.test.js`.
+
+const assert = require("node:assert/strict");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const TEST_DIR = path.join(os.tmpdir(), `routes-pins-test-${process.pid}-${Date.now()}`);
+
+// Override HOME BEFORE requiring config/routes — config.js resolves CONFIG_PATH
+// from os.homedir() at module load time.
+const origHome = os.homedir;
+os.homedir = () => TEST_DIR;
+
+const CONFIG_DIR = path.join(TEST_DIR, ".quadwork");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+
+// Seed an initial config carrying pins/groups alongside unrelated keys, so we
+// can prove the field-scoped writes leave everything else intact.
+fs.mkdirSync(CONFIG_DIR, { recursive: true });
+const INITIAL = {
+  port: 8400,
+  operator_name: "alice",
+  file_chat_switchover_done: false,
+  pinned_projects: ["quadwork", "plotlink"],
+  sidebar_groups: [{ name: "Work", projects: ["quadwork"] }],
+  projects: [{ id: "quadwork", name: "QuadWork" }],
+};
+fs.writeFileSync(CONFIG_PATH, JSON.stringify(INITIAL, null, 2));
+
+const config = require("./config");
+const router = require("./routes");
+const express = require("express");
+
+function cleanup() {
+  os.homedir = origHome;
+  try { fs.rmSync(TEST_DIR, { recursive: true, force: true }); } catch {}
+}
+process.on("exit", cleanup);
+
+function readDisk() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+function req(server, { method = "GET", urlPath, body } = {}) {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address();
+    const payload = body === undefined ? null : Buffer.from(JSON.stringify(body));
+    const r = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method,
+        path: urlPath,
+        headers: payload ? { "content-type": "application/json", "content-length": payload.length } : {},
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode, buf: Buffer.concat(chunks) }));
+      },
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+
+  try {
+    // --- PUT /api/pins updates ONLY pinned_projects (deduped), other keys intact
+    const setPins = await req(server, { method: "PUT", urlPath: "/api/pins", body: { pinned_projects: ["a", "b", "a"] } });
+    assert.equal(setPins.status, 200, "PUT /api/pins succeeds");
+    let disk = readDisk();
+    assert.deepEqual(disk.pinned_projects, ["a", "b"], "pins set + deduped server-side");
+    assert.equal(disk.operator_name, "alice", "unrelated key preserved by pins write");
+    assert.deepEqual(disk.sidebar_groups, INITIAL.sidebar_groups, "groups untouched by pins write");
+    assert.equal(disk.projects.length, 1, "projects preserved by pins write");
+    console.log("PASS: PUT /api/pins writes only pinned_projects, preserving everything else");
+
+    // --- PUT /api/sidebar-groups updates ONLY sidebar_groups (sanitized)
+    const setGroups = await req(server, {
+      method: "PUT",
+      urlPath: "/api/sidebar-groups",
+      body: { sidebar_groups: [{ name: "G", projects: ["a"], extra: "drop-me" }] },
+    });
+    assert.equal(setGroups.status, 200, "PUT /api/sidebar-groups succeeds");
+    disk = readDisk();
+    assert.deepEqual(disk.sidebar_groups, [{ name: "G", projects: ["a"] }], "groups set, sanitized to { name, projects }");
+    assert.deepEqual(disk.pinned_projects, ["a", "b"], "pins untouched by groups write");
+    console.log("PASS: PUT /api/sidebar-groups writes only sidebar_groups, sanitized");
+
+    // --- CORE AC: a STALE whole-config PUT must NOT clobber pins/groups ---
+    // Mirror a settings/idle/bridge save that GET'd config before the writes
+    // above, so its body carries stale pinned_projects/sidebar_groups values.
+    const stalePut = await req(server, {
+      method: "PUT",
+      urlPath: "/api/config",
+      body: {
+        port: 8400,
+        operator_name: "bob",
+        file_chat_switchover_done: true,
+        pinned_projects: ["STALE"],
+        sidebar_groups: [{ name: "STALE", projects: [] }],
+        projects: [{ id: "quadwork", name: "QuadWork" }],
+      },
+    });
+    assert.equal(stalePut.status, 200, "stale whole-config PUT succeeds");
+    disk = readDisk();
+    assert.deepEqual(disk.pinned_projects, ["a", "b"], "stale full PUT did NOT clobber pins");
+    assert.deepEqual(disk.sidebar_groups, [{ name: "G", projects: ["a"] }], "stale full PUT did NOT clobber groups");
+    assert.equal(disk.operator_name, "bob", "the full PUT's own field still applied");
+    console.log("PASS: a stale whole-config PUT cannot drop pinned_projects/sidebar_groups");
+
+    // --- Validation: malformed shapes rejected with 400, disk unchanged ---
+    assert.equal((await req(server, { method: "PUT", urlPath: "/api/pins", body: { pinned_projects: "nope" } })).status, 400, "non-array pins → 400");
+    assert.equal((await req(server, { method: "PUT", urlPath: "/api/pins", body: { pinned_projects: [1, 2] } })).status, 400, "non-string pin ids → 400");
+    assert.equal((await req(server, { method: "PUT", urlPath: "/api/sidebar-groups", body: { sidebar_groups: {} } })).status, 400, "non-array groups → 400");
+    assert.equal((await req(server, { method: "PUT", urlPath: "/api/sidebar-groups", body: { sidebar_groups: [{ projects: [] }] } })).status, 400, "group missing name → 400");
+    disk = readDisk();
+    assert.deepEqual(disk.pinned_projects, ["a", "b"], "rejected writes left pins unchanged");
+    assert.deepEqual(disk.sidebar_groups, [{ name: "G", projects: ["a"] }], "rejected writes left groups unchanged");
+    console.log("PASS: malformed pins/groups payloads are rejected and leave config untouched");
+
+    // --- GET /api/config reflects the field-scoped values ---
+    const got = JSON.parse((await req(server, { urlPath: "/api/config" })).buf.toString());
+    assert.deepEqual(got.pinned_projects, ["a", "b"], "GET reflects current pins");
+    assert.deepEqual(got.sidebar_groups, [{ name: "G", projects: ["a"] }], "GET reflects current groups");
+  } finally {
+    server.close();
+  }
+
+  // --- BOOT TEST 1: the startup config-rewrite preserves pins/groups ---
+  // Mirror server/index.js startup: readConfig() (whole file) → set a one-time
+  // startup flag → writeConfig(). The freshly-read snapshot carries pins/groups,
+  // so the rewrite cannot drop them.
+  {
+    const cfg = config.readConfig();
+    assert.deepEqual(cfg.pinned_projects, ["a", "b"], "readConfig carries pins into startup");
+    cfg.file_chat_switchover_done = true; // the gated one-time startup write
+    config.writeConfig(cfg);
+    const disk = readDisk();
+    assert.deepEqual(disk.pinned_projects, ["a", "b"], "pins survive the startup config rewrite");
+    assert.deepEqual(disk.sidebar_groups, [{ name: "G", projects: ["a"] }], "groups survive the startup config rewrite");
+    console.log("PASS: pinned_projects/sidebar_groups survive the startup config rewrite");
+  }
+
+  // --- BOOT TEST 2: a version-bump reseed never rewrites config.json ---
+  // autoReseedOnStartup persists only ~/.quadwork/reseed-state.json, so a
+  // version-bump restart (the issue's reseed case) leaves config.json — and
+  // therefore pins/groups — byte-identical.
+  {
+    const before = fs.readFileSync(CONFIG_PATH, "utf-8");
+    const cfg = config.readConfig();
+    cfg.projects = [{ id: "quadwork", name: "QuadWork", working_dir: TEST_DIR }];
+    await router.autoReseedOnStartup(cfg, {
+      version: "9.9.9-bump",
+      statePath: path.join(CONFIG_DIR, "reseed-state.json"),
+      log: () => {},
+      getProgress: async () => ({ complete: true, completeConfirmed: true, items: [] }),
+      isActiveFromProgress: () => false,
+      performWrites: () => ({ reseeded: [], skipped: [], preserved: [] }),
+    });
+    const after = fs.readFileSync(CONFIG_PATH, "utf-8");
+    assert.equal(after, before, "version-bump reseed left config.json byte-identical (pins/groups intact)");
+    console.log("PASS: version-bump reseed does not touch config.json");
+  }
+
+  console.log("routes.persistPins.test.js: all assertions passed");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -396,19 +396,14 @@ export default function Sidebar() {
 
   const persistPins = useCallback((newPins: string[]) => {
     setPinnedIds(newPins);
-    // Re-read latest config before writing to avoid clobbering concurrent changes
-    fetch("/api/config")
-      .then((r) => r.json())
-      .then((latest) => {
-        const updated = { ...latest, pinned_projects: newPins };
-        configRef.current = updated;
-        return fetch("/api/config", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(updated),
-        });
-      })
-      .catch(() => {});
+    // #944: field-scoped write — the server reads the freshest config and
+    // updates only pinned_projects, so a concurrent group/idle/settings save
+    // (or a restart firing several saves at once) can't clobber pins.
+    fetch("/api/pins", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pinned_projects: newPins }),
+    }).catch(() => {});
   }, []);
 
   const toggleGroupCollapse = (groupName: string) => {
@@ -423,18 +418,13 @@ export default function Sidebar() {
 
   const persistGroups = useCallback((newGroups: SidebarGroup[]) => {
     setGroups(newGroups);
-    fetch("/api/config")
-      .then((r) => r.json())
-      .then((latest) => {
-        const updated = { ...latest, sidebar_groups: newGroups };
-        configRef.current = updated;
-        return fetch("/api/config", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(updated),
-        });
-      })
-      .catch(() => {});
+    // #944: field-scoped write — see persistPins. Server updates only
+    // sidebar_groups against a freshly-read config.
+    fetch("/api/sidebar-groups", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sidebar_groups: newGroups }),
+    }).catch(() => {});
   }, []);
 
   const moveToGroup = (projectId: string, groupName: string) => {


### PR DESCRIPTION
Fixes #944.

## Problem
Pinned projects and sidebar groups reset on **server restart**. All persistence (pins, groups, idle toggle, settings, the bridge/queue/trigger widgets) went through the same **whole-config GET→mutate→PUT** path. Any writer holding a snapshot taken *before* a pin/group was added silently drops it on its next full PUT — and a reload/restart is exactly when several of these fire together.

## Fix
1. **Field-scoped, race-free endpoints** — `PUT /api/pins` and `PUT /api/sidebar-groups` read the freshest config off disk server-side, set **only** their own key, validate/sanitize the payload (array of project-id strings / `{ name, projects }` objects; malformed → 400), and write back. A save can no longer clobber a concurrent one.
2. **Whole-config PUT can no longer drop them** — `PUT /api/config` now re-reads the on-disk `pinned_projects`/`sidebar_groups` and keeps those, ignoring whatever (possibly stale) values the body carried. These two keys are now server-managed exclusively via the field-scoped endpoints, so settings/idle/bridge/queue/trigger saves can never drop them.
3. **Frontend** — `Sidebar` `persistPins`/`persistGroups` now call the new endpoints (no more GET→PUT round-trip).

## Startup-writer audit (issue fix #2)
- The only startup writer of `config.json` (the gated one-time `file_chat_switchover`) and `migrateAgentKeys`/`runStartupMigrations` all operate on a **freshly-read whole-file** `readConfig()` snapshot, so they already preserve unknown/newer top-level keys — they don't drop pins/groups.
- The module-level `const config = readConfig()` in `server/index.js` is only used for `PORT` and is never written back.
- The **version-bump reseed** (`autoReseedOnStartup`) persists only `~/.quadwork/reseed-state.json` and never rewrites `config.json`.

## Test — `server/routes.persistPins.test.js`
Mounts the real router under a temp `.quadwork` HOME and asserts:
- `PUT /api/pins` / `PUT /api/sidebar-groups` write only their key (deduped/sanitized), other keys untouched.
- **A stale whole-config PUT cannot drop pins/groups** (the core AC), while still applying its own field.
- Malformed payloads → 400 and leave config unchanged.
- Pins/groups **survive the startup config rewrite** and a **version-bump reseed** (config.json byte-identical).

## Verification
- `npm test` → **47 passed, 0 failed, 2 skipped** (Jest-style, out of scope)
- `tsc --noEmit` → exit 0
- `npm run build` → OK
- `node --check` clean on edited files

## Acceptance criteria
- [x] Pinned projects and sidebar groups survive a server restart (incl. version-bump reseed)
- [x] Concurrent pin/group/idle/settings saves never drop each other's keys
- [x] Boot test proves `pinned_projects`/`sidebar_groups` survive startup
- [x] No regression to existing config persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)