### PR TITLE
[#943] Read persisted GITHUB.md for code-batch progress on cold cache; cap + soft-fail fallback

### DIFF
--- a/server/routes.batchProgressColdCache.test.js
+++ b/server/routes.batchProgressColdCache.test.js
@@ -1,0 +1,261 @@
+// #943: code-batch progress must read the PERSISTED GITHUB.md snapshot when the
+// in-memory _graphqlCache is empty (e.g. just after a server restart), instead
+// of firing an uncapped burst of live per-item Searches that mis-rendered queued
+// items as "fetch failed". This test proves:
+//   1. progressFromGithubFile reproduces the buckets from the parsed file.
+//   2. Cold cache (empty _graphqlCache) + a fresh GITHUB.md → items resolve from
+//      the file with ZERO gh/Search subprocess calls (AC#1, AC#5).
+//   3. With an in-memory snapshot present, items it can't prove fall to the
+//      live by-number fetch CONCURRENCY-CAPPED (≤ GH_MAX_CONCURRENT, AC#2), and a
+//      transient failure renders a SOFT "queued (retrying)" row, never a hard
+//      "fetch failed" (AC#3).
+//
+// Plain node:assert script — run with
+// `node server/routes.batchProgressColdCache.test.js`.
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const cp = require("child_process");
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+const GH_MAX_CONCURRENT = 2; // mirrors the const in routes.js
+
+// ── child_process.execFile stub installed BEFORE require("./routes") ─────────
+// Any gh call (issue/PR/Search/check-runs) routes through here. It (a) counts
+// calls so the cold-cache test can assert ZERO live fetches, (b) tracks max
+// concurrency so the capped-fallback test can assert ≤ GH_MAX_CONCURRENT, and
+// (c) ALWAYS errors so progressForItemRest rejects → the route's soft row.
+let ghCalls = 0;
+let inFlight = 0;
+let maxInFlight = 0;
+const realRunner = cp.execFile;
+cp.execFile = function stubRunner(file, args, opts, cb) {
+  const done = typeof opts === "function" ? opts : cb;
+  if (typeof done !== "function") return realRunner.apply(this, arguments);
+  ghCalls++;
+  inFlight++;
+  if (inFlight > maxInFlight) maxInFlight = inFlight;
+  // Defer the callback so genuinely-concurrent item chains overlap (a sync cb
+  // would never let inFlight exceed 1, hiding the cap).
+  setImmediate(() => {
+    inFlight--;
+    const err = new Error("test stub: gh not invoked");
+    err.code = "ENOTEST";
+    done(err, "", "");
+  });
+};
+
+// ── fs stubs installed BEFORE require("./routes") ────────────────────────────
+const real = { readFileSync: fs.readFileSync };
+let cfgJson = JSON.stringify({ projects: [] });
+let queueText = "";
+let githubMd = "";
+fs.readFileSync = function stubReadFileSync(p, ...rest) {
+  if (p === CONFIG_PATH) return cfgJson;
+  if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) return queueText;
+  if (typeof p === "string" && p.endsWith("GITHUB.md")) return githubMd;
+  // batch-progress-cache.json absent → readBatchSnapshot null → the upstream
+  // checkBatchSnapshotFreshness gh call is skipped entirely.
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
+  }
+  return real.readFileSync(p, ...rest);
+};
+fs.writeFileSync = () => {};
+fs.mkdirSync = () => {};
+fs.statSync = () => ({ mode: 0o700, isDirectory: () => true });
+fs.renameSync = () => {};
+fs.unlinkSync = () => {};
+
+const routes = require("./routes");
+const {
+  getOrComputeBatchProgress,
+  progressFromGithubFile,
+  approvalsFromReviewDetail,
+  softRetryingRow,
+  loadGithubParsed,
+  renderGithubMarkdown,
+  parseGithub,
+  _batchProgressCache,
+  _graphqlCache,
+} = routes;
+
+// Reviews authored by the shared reviewer login, distinguished by body marker
+// (the same shape refreshRepoRest stores; renderGithubMarkdown attributes them
+// by role into Review Detail, which parseGithub reads back).
+const review = (marker, state, ts) => ({ state, author: { login: "shared" }, submittedAt: ts, body: `${marker}: ${state}` });
+
+// A snapshot covering every bucket, rendered to a parser-faithful GITHUB.md.
+function buildGithubMd() {
+  const snapshot = {
+    issues: [
+      { number: 100, title: "queued thing", state: "OPEN", url: "https://x/i/100", assignees: [{ login: "dev" }] },
+      { number: 200, title: "in review thing", state: "OPEN", url: "https://x/i/200", assignees: [] },
+      { number: 300, title: "one approval thing", state: "OPEN", url: "https://x/i/300", assignees: [] },
+      { number: 400, title: "two approvals thing", state: "OPEN", url: "https://x/i/400", assignees: [] },
+    ],
+    prs: [
+      { number: 201, title: "[#200] in review", state: "OPEN", url: "https://x/p/201", reviews: [] },
+      { number: 301, title: "[#300] one approval", state: "OPEN", url: "https://x/p/301", reviews: [review("RE1", "APPROVED", "2026-06-01T00:00:00Z")] },
+      { number: 401, title: "[#400] two approvals", state: "OPEN", url: "https://x/p/401", reviews: [review("RE1", "APPROVED", "2026-06-01T00:00:00Z"), review("RE2", "APPROVED", "2026-06-02T00:00:00Z")] },
+    ],
+    closedIssues: [
+      { number: 500, title: "merged thing", state: "CLOSED", url: "https://x/i/500" },
+      { number: 600, title: "closed no pr", state: "CLOSED", url: "https://x/i/600" },
+    ],
+    mergedPrs: [
+      { number: 501, title: "[#500] merged pr", state: "MERGED", url: "https://x/p/501" },
+    ],
+  };
+  return renderGithubMarkdown("Proj", "o/r", snapshot, { generatedAt: Date.now(), staleCycles: 0 }, "(none)");
+}
+
+(async () => {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // A. progressFromGithubFile — pure buckets from the parsed file.
+  // ───────────────────────────────────────────────────────────────────────────
+  {
+    const parsed = parseGithub(buildGithubMd());
+    ok(parsed && parsed.ok, "A: GITHUB.md fixture parses ok");
+    const r100 = progressFromGithubFile(parsed, 100);
+    ok(r100.status === "queued" && r100.progress === 0, "A: OPEN issue, no PR → queued/0");
+    const r200 = progressFromGithubFile(parsed, 200);
+    ok(r200.status === "in_review" && r200.progress === 20 && r200.pr_number === 201, "A: open PR, 0 approvals → in_review/20");
+    const r300 = progressFromGithubFile(parsed, 300);
+    ok(r300.status === "approved1" && r300.progress === 50, "A: open PR, 1 role approved → approved1/50");
+    const r400 = progressFromGithubFile(parsed, 400);
+    ok(r400.status === "ready" && r400.progress === 80, "A: open PR, 2 roles approved → ready/80");
+    const r500 = progressFromGithubFile(parsed, 500);
+    ok(r500.status === "merged" && r500.progress === 100 && r500.pr_number === 501, "A: merged PR + CLOSED issue → merged/100");
+    const r600 = progressFromGithubFile(parsed, 600);
+    ok(r600.status === "closed" && r600.progress === 100, "A: CLOSED issue, no PR → closed/100");
+    ok(progressFromGithubFile(parsed, 999) === null, "A: issue absent from file → null (caller soft-retries)");
+    ok(progressFromGithubFile(null, 1) === null, "A: no parse → null");
+    ok(progressFromGithubFile({ ok: false }, 1) === null, "A: failed parse → null");
+  }
+
+  // A2. merged-but-still-OPEN ambiguity → null (defers to the snapshot), mirroring
+  //     progressFromSnapshot. A merged [#N] PR whose issue is still OPEN must not
+  //     be guessed as queued from the file.
+  {
+    // Titles are in the persisted (bracket-stripped) form parseGithub produces.
+    const parsed = {
+      ok: true,
+      openIssues: [{ number: 7, title: "merged but open", url: "u7" }],
+      openPRs: [], closedIssues: [],
+      mergedPrs: [{ number: 70, title: "#7 merged", url: "u70" }],
+      reviewDetail: {},
+    };
+    ok(progressFromGithubFile(parsed, 7) === null, "A2: OPEN issue with an in-window merged #N PR → null (merged-but-open ambiguity)");
+    // #80 must NOT match issue 8 (word-boundary guard).
+    const parsed8 = { ok: true, openIssues: [{ number: 8, title: "eight", url: "u8" }], openPRs: [{ number: 800, title: "#80 not eight", url: "u800" }], closedIssues: [], mergedPrs: [], reviewDetail: {} };
+    ok(progressFromGithubFile(parsed8, 8).status === "queued", "A2: '#80' PR title does NOT link to issue 8 → 8 stays queued (no false in_review)");
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // B. approvalsFromReviewDetail + softRetryingRow units.
+  // ───────────────────────────────────────────────────────────────────────────
+  {
+    const rd = { 301: { re1: { state: "APPROVED" } }, 401: { re1: { state: "APPROVED" }, re2: { state: "APPROVED" } }, 501: { re1: { state: "CHANGES_REQUESTED" } } };
+    ok(approvalsFromReviewDetail(rd, 301) === 1, "B: one role APPROVED → 1");
+    ok(approvalsFromReviewDetail(rd, 401) === 2, "B: two roles APPROVED → 2");
+    ok(approvalsFromReviewDetail(rd, 501) === 0, "B: CHANGES_REQUESTED → 0");
+    ok(approvalsFromReviewDetail(rd, 999) === 0, "B: unknown PR → 0");
+    ok(approvalsFromReviewDetail(undefined, 1) === 0, "B: no reviewDetail → 0");
+    const soft = softRetryingRow(42);
+    ok(soft.status === "queued" && soft.label === "queued (retrying)" && soft.progress === 0, "B: softRetryingRow → status queued, label 'queued (retrying)', 0%");
+    ok(softRetryingRow(42).title === "#42", "B: softRetryingRow default title");
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // C. AC#1 / AC#5 — cold in-memory cache + fresh GITHUB.md resolves every item
+  //    from the file with ZERO gh/Search subprocess calls.
+  // ───────────────────────────────────────────────────────────────────────────
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear(); // cold: in-memory snapshot empty (the post-restart state)
+    cfgJson = JSON.stringify({ projects: [{ id: "cold-proj", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 26\n\n- #100 queued\n- #200 in review\n- #300 one approval\n- #400 two approvals\n- #500 merged\n- #600 closed no pr\n\n## Backlog\n";
+    githubMd = buildGithubMd();
+    ghCalls = 0;
+
+    const data = await getOrComputeBatchProgress("cold-proj");
+    ok(data !== null && Array.isArray(data.items) && data.items.length === 6, `C: six items resolved (got ${data.items?.length})`);
+    const byNum = Object.fromEntries(data.items.map((it) => [it.issue_number, it]));
+    ok(byNum[100].status === "queued", "C: #100 queued from file");
+    ok(byNum[200].status === "in_review", "C: #200 in_review from file");
+    ok(byNum[300].status === "approved1", "C: #300 approved1 from file");
+    ok(byNum[400].status === "ready", "C: #400 ready from file");
+    ok(byNum[500].status === "merged", "C: #500 merged from file");
+    ok(byNum[600].status === "closed", "C: #600 closed from file");
+    ok(!data.items.some((it) => it.label === "fetch failed"), "C: NO 'fetch failed' row");
+    ok(!data.items.some((it) => it.label === "queued (retrying)"), "C: NO soft 'queued (retrying)' row — every item proven from the file");
+    ok(ghCalls === 0, `C: ZERO live gh/Search subprocess calls on the cold-cache path (got ${ghCalls})`);
+    ok(data.complete === false, "C: not complete (queued + in-review items present)");
+  }
+
+  // C2. Cold cache + ALL items merged/closed from file → complete:true, still
+  //     zero gh calls (the restart-after-batch-done case).
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "cold-done", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 27\n\n- #500 merged\n- #600 closed\n";
+    githubMd = buildGithubMd();
+    ghCalls = 0;
+
+    const data = await getOrComputeBatchProgress("cold-done");
+    ok(data.items.every((it) => it.status === "merged" || it.status === "closed"), "C2: both items merged/closed from file");
+    ok(data.complete === true, "C2: complete === true from the persisted file");
+    ok(ghCalls === 0, "C2: zero gh calls");
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // D. AC#2 / AC#3 — with an in-memory snapshot present that can't prove items,
+  //    the live by-number fallback is concurrency-capped and soft-fails.
+  // ───────────────────────────────────────────────────────────────────────────
+  {
+    _batchProgressCache.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "warm-proj", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 28\n\n- #1 a\n- #2 b\n- #3 c\n- #4 d\n- #5 e\n";
+    // Snapshot present but window-incomplete (no completeness flags) → every
+    // OPEN issue returns null from progressFromSnapshot → live by-number fetch.
+    _graphqlCache.set("o/r", {
+      ts: Date.now(),
+      issues: [1, 2, 3, 4, 5].map((n) => ({ number: n, title: `t${n}`, state: "OPEN", url: `u${n}` })),
+      prs: [], closedIssues: [], mergedPrs: [],
+      // openPrsWindowComplete / closedPrsWindowComplete intentionally absent.
+    });
+    ghCalls = 0; maxInFlight = 0; inFlight = 0;
+
+    const data = await getOrComputeBatchProgress("warm-proj");
+    ok(data.items.length === 5, "D: five items");
+    ok(data.items.every((it) => it.status === "queued" && it.label === "queued (retrying)"), "D: every failed by-number fetch → soft 'queued (retrying)' (AC#3)");
+    ok(!data.items.some((it) => it.label === "fetch failed"), "D: NO hard 'fetch failed' row (AC#3)");
+    ok(ghCalls > 0, "D: the live by-number fallback DID run (snapshot couldn't prove the items)");
+    ok(maxInFlight <= GH_MAX_CONCURRENT, `D: per-item fallback concurrency-capped at ≤ ${GH_MAX_CONCURRENT} (observed max ${maxInFlight}) (AC#2)`);
+    ok(data.complete === false, "D: soft-queued items keep the batch incomplete (no false complete)");
+  }
+
+  // D2. loadGithubParsed returns null when the file is missing/unparseable.
+  {
+    const prev = githubMd;
+    githubMd = "not a github file";
+    ok(loadGithubParsed("any") === null, "D2: unparseable GITHUB.md → loadGithubParsed null");
+    githubMd = prev;
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})().catch((err) => {
+  console.error("test crashed:", err);
+  process.exit(1);
+});

--- a/server/routes.js
+++ b/server/routes.js
@@ -2194,6 +2194,76 @@ function progressFromSnapshot(snapshot, n) {
   return null;
 }
 
+// #943: per-ROLE approval count from the PERSISTED GITHUB.md Review Detail,
+// which parseGithub already attributes by body-marker role → { re1?: { state },
+// re2?: { state } }. Mirrors countApprovedRoles' semantics (re1/re2, latest
+// decision APPROVED) but reads the already-attributed parse rather than raw
+// review bodies (the file doesn't carry per-review bodies).
+function approvalsFromReviewDetail(reviewDetail, prNumber) {
+  const rd = (reviewDetail && reviewDetail[prNumber]) || {};
+  return ["re1", "re2"].filter((role) => rd[role] && rd[role].state === "APPROVED").length;
+}
+
+// #943: resolve issue `n`'s progress row from the PERSISTED GITHUB.md parse
+// (parseGithub output) — used when the in-memory _graphqlCache is empty, e.g.
+// just after a server restart. The file survives restarts, so this replaces the
+// post-restart burst of live per-item Searches that mis-rendered queued items
+// as "fetch failed". Mirrors progressFromSnapshot's buckets, with two shape
+// differences: approvals come from the parsed Review Detail, and the merged/
+// closed windows are the file's recent-display slice (open PRs are the full
+// window). An active-batch OPEN issue with no matching [#N] open PR and no
+// in-window merged PR is genuinely queued (NO network). Items the file can't
+// classify (absent, or merged-but-still-open) return null; the caller renders a
+// soft "queued (retrying)" row that firms up once the snapshot repopulates.
+function progressFromGithubFile(parsed, n) {
+  if (!parsed || !parsed.ok) return null;
+  // NOTE: parseGithub's titles come through _sanitizeInline, which STRIPS the
+  // `[` `]` of the `[#N]` convention — so the persisted PR title reads `#N …`,
+  // not `[#N] …` (unlike the in-memory snapshot progressFromSnapshot matches).
+  // Anchor on `#N` + a word boundary so `#80` can't match issue 8.
+  const titleRe = new RegExp(`^\\s*#${n}\\b`);
+  const openPr = (parsed.openPRs || []).find((p) => titleRe.test(p.title || ""));
+  const mergedPr = (parsed.mergedPrs || []).find((p) => titleRe.test(p.title || ""));
+  const openIssue = (parsed.openIssues || []).find((i) => i.number === n);
+  const closedIssue = (parsed.closedIssues || []).find((i) => i.number === n);
+
+  // merged requires a matching merged PR AND the issue CLOSED.
+  if (mergedPr && closedIssue) {
+    return { issue_number: n, title: closedIssue.title, url: mergedPr.url || closedIssue.url, pr_number: mergedPr.number, status: "merged", progress: 100, label: "Merged ✓" };
+  }
+  // Matching open PR → in_review/approved/ready from the parsed Review Detail.
+  if (openPr) {
+    const title = (openIssue && openIssue.title) || openPr.title || `#${n}`;
+    const approvals = approvalsFromReviewDetail(parsed.reviewDetail, openPr.number);
+    if (approvals >= 2) return { issue_number: n, title, url: openPr.url, pr_number: openPr.number, status: "ready", progress: 80, label: `PR #${openPr.number} · 2 approvals · ready` };
+    if (approvals === 1) return { issue_number: n, title, url: openPr.url, pr_number: openPr.number, status: "approved1", progress: 50, label: `PR #${openPr.number} · 1 approval` };
+    return { issue_number: n, title, url: openPr.url, pr_number: openPr.number, status: "in_review", progress: 20, label: `PR #${openPr.number} · waiting on review` };
+  }
+  // No matching open PR. The persisted board lists the FULL open-PR window, so an
+  // OPEN active-batch issue with no [#N] open PR and no in-window merged PR is
+  // queued — NO network. A merged PR in-window for a still-OPEN issue is the
+  // ambiguous merged-but-open case (mirrors progressFromSnapshot returning null
+  // there) → defer to the authoritative snapshot next cycle.
+  if (openIssue && !mergedPr) {
+    return buildNoPrRow({ number: n, title: openIssue.title, state: "OPEN", url: openIssue.url });
+  }
+  // CLOSED issue with no in-window merged PR → closed (no PR) ✓ (superseded/runbook).
+  if (closedIssue && !mergedPr) {
+    return buildNoPrRow({ number: n, title: closedIssue.title, state: "CLOSED", url: closedIssue.url });
+  }
+  // Absent from the file, or merged-but-open ambiguity → unproven.
+  return null;
+}
+
+// #943: a transient or cold-cache-unproven item degrades to a SOFT "queued
+// (retrying)" row (status "queued", progress 0, retried next cycle) instead of a
+// hard "fetch failed". A queued batch item must never render an alarming error
+// just because the in-memory snapshot is briefly cold (post-restart) or a
+// transient secondary-rate-limit/network blip hit its by-number fetch.
+function softRetryingRow(n, title) {
+  return { issue_number: n, title: title || `#${n}`, url: null, status: "queued", progress: 0, label: "queued (retrying)" };
+}
+
 // Confirmed-complete state machine, per project. `complete` must hold across
 // TWO consecutive SUCCESSFUL fetch cycles with DISTINCT generatedAt (the
 // snapshot ts, which only advances on a real #806 refresh) before we confirm.
@@ -2803,16 +2873,33 @@ function loadGithubItemIndex(projectId) {
   return map;
 }
 
+// #943: load the persisted GITHUB.md board as a parseGithub result (or null if
+// missing / unparseable). The code-batch progress path uses this as the restart-
+// surviving fallback when the in-memory _graphqlCache is empty, so a cold cache
+// never triggers a live per-item Search burst.
+function loadGithubParsed(projectId) {
+  let text;
+  try {
+    text = fs.readFileSync(path.join(CONFIG_DIR, projectId, "GITHUB.md"), "utf-8");
+  } catch {
+    return null;
+  }
+  const parsed = parseGithub(text);
+  return parsed && parsed.ok ? parsed : null;
+}
+
 // #416 / quadwork#299: async variant used by the parallelized batch
 // progress fetcher. Wraps node's execFile in a promise.
 //
 // THROWS on subprocess failure (non-zero exit, timeout, JSON parse,
 // network) so progressForItemRest can decide which subset of
-// failures should bubble up to the Promise.allSettled "fetch failed"
-// row vs. which should fall through to a softer state. The previous
+// failures should bubble up to the route's per-item failure row
+// vs. which should fall through to a softer state. The previous
 // catch-all-and-return-null contract collapsed real subprocess
-// errors into the "not found" branch, making the new failure-row
+// errors into the "not found" branch, making the failure-row
 // fallback unreachable for genuine command failures (t2a review).
+// #943: the route now catches that rejection and renders a SOFT
+// "queued (retrying)" row (retried next cycle), not a hard "fetch failed".
 async function ghJsonExecAsync(args) {
   const { stdout } = await _execFileAsync("gh", args, { encoding: "utf-8", timeout: 10000, maxBuffer: GH_LIST_MAX_BUFFER });
   return JSON.parse(stdout);
@@ -2901,8 +2988,8 @@ async function _searchLinkedPrItems(repo, n) {
 // network / parse) is NOT proof of no PR — it must NOT collapse to null, or an
 // out-of-window OPEN issue with a real PR would render queued (and a CLOSED one
 // with a merged PR would render closed). So failure THROWS, and the caller
-// (progressForItemRest, awaiting without a catch) drops the item to the
-// non-authoritative "fetch failed" row, retried on the next cache miss.
+// (progressForItemRest, awaiting without a catch) lets the rejection reach the
+// route, which (#943) renders a soft "queued (retrying)" row retried next cycle.
 async function findLinkedPrByTitle(repo, n, search = _searchLinkedPrItems, opts = {}) {
   const items = await search(repo, n);
   return pickLinkedPrFromSearch(items, n, opts);
@@ -2915,8 +3002,8 @@ async function findLinkedPrByTitle(repo, n, search = _searchLinkedPrItems, opts 
 async function progressForItemRest(repo, issueNumber) {
   // Load-bearing call: the issue's own state via REST. If gh can't read it at
   // all (404, network, auth, timeout) we can't compute a meaningful row — let
-  // the rejection propagate to the route's Promise.allSettled "fetch failed"
-  // row instead of emitting a misleading "queued" entry.
+  // the rejection propagate to the route, which (#943) renders a soft "queued
+  // (retrying)" row instead of emitting a misleading "queued"/"merged" entry.
   const raw = await ghJsonExecAsync(["api", `repos/${repo}/issues/${issueNumber}`]);
   const issue = {
     number: raw.number,
@@ -2924,8 +3011,9 @@ async function progressForItemRest(repo, issueNumber) {
     state: (raw.state || "").toUpperCase(),
     url: raw.html_url,
   };
-  // Throws (→ route's "fetch failed" row) if Search itself fails, so a
-  // could-not-determine is NEVER mistaken for proof of no linked PR. A null
+  // Throws (→ route's soft "queued (retrying)" row, #943) if Search itself
+  // fails, so a could-not-determine is NEVER mistaken for proof of no linked PR.
+  // A null
   // here means Search SUCCEEDED with zero strict [#N] matches — authoritative.
   // #864/RE1: pass issue.state so the picker only prefers a merged duplicate
   // for CLOSED issues; OPEN/reopened issues keep legacy freshest-wins, so a
@@ -3221,21 +3309,33 @@ async function getOrComputeBatchProgress(projectId) {
   // state); #828 P1: fall back to a targeted by-number REST/Search fetch
   // (progressForItemRest, no GraphQL) only for active-batch issues the snapshot
   // can't prove (outside / truncated window, or absent).
+  // #943: when the in-memory snapshot is empty (e.g. just after a restart, until
+  // the next board refresh repopulates it), resolve from the PERSISTED GITHUB.md
+  // board instead of firing an uncapped burst of live per-item Searches. The
+  // file survives restarts, so the post-restart "fetch failed" window disappears.
+  // The live by-number fallback runs ONLY when an in-memory snapshot exists but
+  // can't prove a specific item — now (a) concurrency-capped via _mapLimited and
+  // (b) soft-failing a transient error to "queued (retrying)" rather than a hard
+  // "fetch failed".
   const snapshot = _graphqlCache.get(repo) || null;
-  const settled = await Promise.allSettled(
-    issueNumbers.map(async (n) => progressFromSnapshot(snapshot, n) || progressForItemRest(repo, n)),
-  );
-  const items = settled.map((r, i) => {
-    if (r.status === "fulfilled") return r.value;
-    return {
-      issue_number: issueNumbers[i],
-      title: `#${issueNumbers[i]} (fetch failed)`,
-      url: null,
-      status: "unknown",
-      progress: 0,
-      label: "fetch failed",
-    };
-  });
+  let items;
+  if (snapshot) {
+    items = await _mapLimited(issueNumbers, GH_MAX_CONCURRENT, async (n) => {
+      const fromSnap = progressFromSnapshot(snapshot, n);
+      if (fromSnap) return fromSnap;
+      try {
+        return await progressForItemRest(repo, n);
+      } catch {
+        return softRetryingRow(n); // #943: transient (secondary rate-limit/network) → soft
+      }
+    });
+  } else {
+    // Cold in-memory cache → persisted-snapshot fallback, zero live per-item
+    // Search. Items the file can't classify render soft "queued (retrying)" and
+    // firm up next cycle once _graphqlCache repopulates.
+    const parsed = loadGithubParsed(projectId);
+    items = issueNumbers.map((n) => progressFromGithubFile(parsed, n) || softRetryingRow(n));
+  }
   const summary = summarizeItems(items);
   // #350: treat CLOSED-without-PR items as complete alongside merged
   // so batches that mix runbook/superseded closes with real PRs
@@ -4562,6 +4662,11 @@ module.exports.summarizeItems = summarizeItems;
 // #810: expose batch-progress-from-snapshot helpers for unit tests.
 module.exports.progressFromSnapshot = progressFromSnapshot;
 module.exports.countApprovedRoles = countApprovedRoles;
+// #943: expose the persisted-GITHUB.md fallback helpers for unit tests.
+module.exports.progressFromGithubFile = progressFromGithubFile;
+module.exports.approvalsFromReviewDetail = approvalsFromReviewDetail;
+module.exports.softRetryingRow = softRetryingRow;
+module.exports.loadGithubParsed = loadGithubParsed;
 module.exports.evalBatchCompleteConfirmed = evalBatchCompleteConfirmed;
 // #693: expose normalizeMentions for unit tests
 module.exports.normalizeMentions = normalizeMentions;


### PR DESCRIPTION
Fixes #943.

## Problem
The code-batch Current Batch Progress panel showed transient **"fetch failed"** rows after a server restart even with healthy rate limits and a fresh GITHUB.md. It read the **in-memory** `_graphqlCache`, which is emptied on every restart; until the next board refresh, `progressFromSnapshot` returned null for every item and they all fell through to the #828 per-item live fallback (`gh issues/N` + Search) — which (a) fired **all items concurrently, uncapped**, and (b) rendered a transient failure (network / GitHub **secondary** rate limit) as a hard **"fetch failed"** row.

## Fix (`server/routes.js`, `getOrComputeBatchProgress` code-batch path)
1. **Persistent fallback (primary):** when `_graphqlCache` is empty, resolve each item from the **persisted GITHUB.md board** (`loadGithubParsed` → `parseGithub`) via the new `progressFromGithubFile`, which mirrors `progressFromSnapshot`'s buckets. The file survives restarts → **no live per-item Search burst** on the cold path.
   - The persisted PR titles are **bracket-stripped** by `_sanitizeInline`, so the file matcher anchors on `#N` + a word boundary (not the in-memory snapshot's `[#N]`). `#80` can't link to issue 8.
   - Approvals come from the parsed **Review Detail** (already role-attributed re1/re2), matching `countApprovedRoles` semantics.
2. **Concurrency cap (AC#2):** the live by-number fallback (in-memory snapshot present but can't prove an item) now runs through `_mapLimited(GH_MAX_CONCURRENT)` instead of an unbounded `Promise.allSettled`.
3. **Soft-fail (AC#3):** a transient per-item failure degrades to a soft **`queued (retrying)`** row (status `queued`, retried next cycle) instead of a hard `fetch failed`.

## Safety / scope
- **Review-batch path** (already file-backed via `loadGithubItemIndex`) and the **steady-state snapshot path** are unchanged.
- Items the file can't classify (absent / merged-but-still-open) defer to a soft row that firms up once `_graphqlCache` repopulates.
- `completeConfirmed` still requires a real snapshot `ts` (null on the cold path), so the file fallback can **never auto-confirm** a complete batch / trigger auto-stop.

## Test — `server/routes.batchProgressColdCache.test.js`
- `progressFromGithubFile` buckets: queued / in_review / approved1 / ready / merged / closed, plus **merged-but-open → null** and the **`#80` ↛ issue 8** word-boundary guard.
- `approvalsFromReviewDetail` + `softRetryingRow` units.
- **AC#1 / AC#5:** cold cache (`_graphqlCache` empty) + fresh GITHUB.md → all six bucket items resolve **from the file with ZERO gh subprocess calls** (asserted via a counting `execFile` stub); plus an all-merged/closed → `complete:true` case.
- **AC#2 / AC#3:** in-memory snapshot present but unprovable → live fallback runs **concurrency-capped** (observed max ≤ `GH_MAX_CONCURRENT`, via an async in-flight tracker) and **soft-fails every transient error to `queued (retrying)`**, never `fetch failed`.

## Verification
- `npm test` → **48 passed, 0 failed, 2 skipped** (Jest-style, out of scope)
- `tsc --noEmit` → exit 0
- `node --check` clean on edited files

## Acceptance criteria
- [x] After restart (cache empty), panel renders queued/PR states from persisted GITHUB.md, no live Search burst, no "fetch failed"
- [x] Per-item fallback fetches concurrency-capped
- [x] Transient per-item failure → soft `queued (retrying)`
- [x] No regression to review-batch or steady-state snapshot path
- [x] Test: snapshot-empty + fresh GITHUB.md → items resolve from file, zero Search calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)