### PR TITLE
[#950] Cache terminal batch progress rows

### DIFF
--- a/server/routes.batchProgressTerminalCache.test.js
+++ b/server/routes.batchProgressTerminalCache.test.js
@@ -1,0 +1,159 @@
+// #950: batch-progress must not refetch terminal items every cycle, and stale
+// rendered payloads should return immediately while one background refresh runs.
+//
+// Plain node:assert script — run with
+// `node server/routes.batchProgressTerminalCache.test.js`.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const cp = require("child_process");
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+let ghCalls = [];
+let delayGh = false;
+const realRunner = cp.execFile;
+cp.execFile = function stubRunner(file, args, opts, cb) {
+  const done = typeof opts === "function" ? opts : cb;
+  if (file !== "gh" || typeof done !== "function") return realRunner.apply(this, arguments);
+  ghCalls.push(args.slice());
+  const finish = () => done(null, JSON.stringify({ number: 10 }), "");
+  if (delayGh) setTimeout(finish, 80);
+  else setImmediate(finish);
+};
+
+const real = { readFileSync: fs.readFileSync };
+let cfgJson = JSON.stringify({ projects: [] });
+let queueText = "";
+let snapshotJson = null;
+fs.readFileSync = function stubReadFileSync(p, ...rest) {
+  if (p === CONFIG_PATH) return cfgJson;
+  if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) return queueText;
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    if (snapshotJson !== null) return snapshotJson;
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
+  }
+  if (typeof p === "string" && p.endsWith("GITHUB.md")) return "";
+  return real.readFileSync(p, ...rest);
+};
+fs.writeFileSync = function stubWriteFileSync(p, data) {
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    snapshotJson = String(data);
+  }
+};
+fs.mkdirSync = () => {};
+fs.statSync = () => ({ mode: 0o700, isDirectory: () => true });
+fs.renameSync = () => {};
+fs.unlinkSync = () => { snapshotJson = null; };
+
+const {
+  getOrComputeBatchProgress,
+  _batchProgressCache,
+  _batchProgressRefreshes,
+  _graphqlCache,
+} = require("./routes");
+
+function mergedRowsSnapshot(repo, nums) {
+  _graphqlCache.set(repo, {
+    ts: Date.now(),
+    issues: [],
+    prs: [],
+    closedIssues: nums.map((n) => ({ number: n, title: `done ${n}`, url: `https://x/i/${n}` })),
+    mergedPrs: nums.map((n) => ({ number: n + 1000, title: `[#${n}] done ${n}`, url: `https://x/p/${n + 1000}`, reviews: [] })),
+    openPrsWindowComplete: true,
+    closedPrsWindowComplete: true,
+    closedPrIssueNums: nums.slice(),
+  });
+}
+
+function perItemIssueFetches() {
+  return ghCalls.filter((args) => {
+    const target = args.find((a) => typeof a === "string" && /repos\/o\/r\/issues\/\d+$/.test(a));
+    return target && !args.includes("--jq");
+  });
+}
+
+(async () => {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  // A. First compute resolves terminal rows from the in-memory board snapshot
+  // and persists them to batch-progress-cache.json.
+  {
+    _batchProgressCache.clear();
+    _batchProgressRefreshes.clear();
+    _graphqlCache.clear();
+    ghCalls = [];
+    snapshotJson = null;
+    cfgJson = JSON.stringify({ projects: [{ id: "terminal-proj", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 950\n\n- #10 done\n- #11 done\n- #12 done\n";
+    mergedRowsSnapshot("o/r", [10, 11, 12]);
+
+    const data = await getOrComputeBatchProgress("terminal-proj");
+    ok(data.items.length === 3, "A: three items resolved");
+    ok(data.items.every((it) => it.status === "merged"), "A: all rows are terminal merged rows");
+    ok(snapshotJson && JSON.parse(snapshotJson).terminalItems["10"].status === "merged", "A: terminal row persisted to batch-progress-cache.json");
+    ok(perItemIssueFetches().length === 0, "A: first snapshot-proven compute made no per-item REST issue fetches");
+  }
+
+  // B. Next compute has an incomplete board snapshot that would normally fall
+  // through to progressForItemRest for every item. The persisted terminal rows
+  // short-circuit those per-item fetches; only the existing one-shot snapshot
+  // freshness probe is allowed.
+  {
+    _batchProgressCache.clear();
+    _batchProgressRefreshes.clear();
+    _graphqlCache.clear();
+    ghCalls = [];
+    _graphqlCache.set("o/r", {
+      ts: Date.now(),
+      issues: [10, 11, 12].map((n) => ({ number: n, title: `open ${n}`, state: "OPEN", url: `https://x/i/${n}` })),
+      prs: [],
+      closedIssues: [],
+      mergedPrs: [],
+    });
+
+    const data = await getOrComputeBatchProgress("terminal-proj");
+    ok(data.items.every((it) => it.status === "merged"), "B: persisted terminal rows win over incomplete snapshot");
+    ok(perItemIssueFetches().length === 0, "B: terminal-cache reuse made zero per-item REST issue fetches");
+    ok(ghCalls.length === 1 && ghCalls[0].includes("--jq"), "B: only the snapshot freshness probe ran");
+  }
+
+  // C. A stale rendered payload returns immediately and starts exactly one
+  // background refresh. This keeps the panel responsive on large batches.
+  {
+    _batchProgressCache.clear();
+    _batchProgressRefreshes.clear();
+    _graphqlCache.clear();
+    ghCalls = [];
+    delayGh = true;
+    _batchProgressCache.set("terminal-proj", {
+      ts: Date.now() - 60_000,
+      data: { batch_number: 950, items: [{ issue_number: 10, status: "merged" }], summary: "1/1 merged", complete: true, completeConfirmed: true, batch_type: "code" },
+    });
+
+    const start = Date.now();
+    const data = await getOrComputeBatchProgress("terminal-proj");
+    const elapsed = Date.now() - start;
+    ok(elapsed < 50, `C: stale cache returned immediately (${elapsed}ms)`);
+    ok(data._stale === true && data._refreshing === true, "C: stale response is marked refreshing");
+    ok(_batchProgressRefreshes.has("terminal-proj"), "C: background refresh started");
+
+    const again = await getOrComputeBatchProgress("terminal-proj");
+    ok(_batchProgressRefreshes.size === 1, "C: second stale poll did not start another refresh");
+    ok(again._refreshing === true, "C: second stale poll still serves cache");
+
+    await _batchProgressRefreshes.get("terminal-proj");
+    ok(!_batchProgressRefreshes.has("terminal-proj"), "C: refresh gate clears after completion");
+    delayGh = false;
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})().catch((err) => {
+  console.error("test crashed:", err);
+  process.exit(1);
+});

--- a/server/routes.batchProgressTerminalCache.test.js
+++ b/server/routes.batchProgressTerminalCache.test.js
@@ -27,6 +27,7 @@ const real = { readFileSync: fs.readFileSync };
 let cfgJson = JSON.stringify({ projects: [] });
 let queueText = "";
 let snapshotJson = null;
+let githubMd = "";
 fs.readFileSync = function stubReadFileSync(p, ...rest) {
   if (p === CONFIG_PATH) return cfgJson;
   if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) return queueText;
@@ -36,7 +37,7 @@ fs.readFileSync = function stubReadFileSync(p, ...rest) {
     err.code = "ENOENT";
     throw err;
   }
-  if (typeof p === "string" && p.endsWith("GITHUB.md")) return "";
+  if (typeof p === "string" && p.endsWith("GITHUB.md")) return githubMd;
   return real.readFileSync(p, ...rest);
 };
 fs.writeFileSync = function stubWriteFileSync(p, data) {
@@ -54,6 +55,7 @@ const {
   _batchProgressCache,
   _batchProgressRefreshes,
   _graphqlCache,
+  renderGithubMarkdown,
 } = require("./routes");
 
 function mergedRowsSnapshot(repo, nums) {
@@ -99,9 +101,8 @@ function perItemIssueFetches() {
     ok(perItemIssueFetches().length === 0, "A: first snapshot-proven compute made no per-item REST issue fetches");
   }
 
-  // B. Next compute has an incomplete board snapshot that would normally fall
-  // through to progressForItemRest for every item. The persisted terminal rows
-  // short-circuit those per-item fetches; only the existing one-shot snapshot
+  // B1. Next compute has no fresh per-item evidence, so the persisted terminal
+  // rows short-circuit REST fallback; only the existing one-shot snapshot
   // freshness probe is allowed.
   {
     _batchProgressCache.clear();
@@ -110,16 +111,74 @@ function perItemIssueFetches() {
     ghCalls = [];
     _graphqlCache.set("o/r", {
       ts: Date.now(),
-      issues: [10, 11, 12].map((n) => ({ number: n, title: `open ${n}`, state: "OPEN", url: `https://x/i/${n}` })),
+      issues: [],
       prs: [],
       closedIssues: [],
       mergedPrs: [],
     });
 
     const data = await getOrComputeBatchProgress("terminal-proj");
-    ok(data.items.every((it) => it.status === "merged"), "B: persisted terminal rows win over incomplete snapshot");
-    ok(perItemIssueFetches().length === 0, "B: terminal-cache reuse made zero per-item REST issue fetches");
-    ok(ghCalls.length === 1 && ghCalls[0].includes("--jq"), "B: only the snapshot freshness probe ran");
+    ok(data.items.every((it) => it.status === "merged"), "B1: persisted terminal rows fill missing snapshot evidence");
+    ok(perItemIssueFetches().length === 0, "B1: terminal-cache reuse made zero per-item REST issue fetches");
+    ok(ghCalls.length === 1 && ghCalls[0].includes("--jq"), "B1: only the snapshot freshness probe ran");
+  }
+
+  // B2. Fresh snapshot evidence wins over stale terminal cache. A reopened item
+  // must not remain complete indefinitely, and its stale terminal row is evicted
+  // from the persistent cache.
+  {
+    _batchProgressCache.clear();
+    _batchProgressRefreshes.clear();
+    _graphqlCache.clear();
+    ghCalls = [];
+    _graphqlCache.set("o/r", {
+      ts: Date.now(),
+      issues: [{ number: 10, title: "reopened 10", state: "OPEN", url: "https://x/i/10" }],
+      prs: [],
+      closedIssues: [],
+      mergedPrs: [],
+      openPrsWindowComplete: true,
+      closedPrsWindowComplete: true,
+      closedPrIssueNums: [],
+    });
+
+    const data = await getOrComputeBatchProgress("terminal-proj");
+    const row10 = data.items.find((it) => it.issue_number === 10);
+    ok(row10.status === "queued", `B2: fresh reopened snapshot overrides terminal cache (got ${row10.status})`);
+    ok(row10.status !== "merged" && row10.status !== "closed", "B2: reopened item is no longer terminal");
+    ok(!JSON.parse(snapshotJson).terminalItems["10"], "B2: stale terminal row evicted from persistent cache");
+  }
+
+  // B3. The persisted GITHUB.md cold-cache path also wins over stale terminal
+  // cache when it proves an item is open/nonterminal.
+  {
+    _batchProgressCache.clear();
+    _batchProgressRefreshes.clear();
+    _graphqlCache.clear();
+    ghCalls = [];
+    snapshotJson = JSON.stringify({
+      batchNumber: 950,
+      issueNumbers: [10],
+      batch_type: "code",
+      reviewItems: [],
+      terminalItems: {
+        10: { issue_number: 10, title: "done 10", url: "https://x/i/10", pr_number: 1010, status: "merged", progress: 100, label: "Merged ✓" },
+      },
+    });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 950\n\n- #10 reopened\n";
+    githubMd = renderGithubMarkdown(
+      "Proj",
+      "o/r",
+      { issues: [{ number: 10, title: "reopened 10", state: "OPEN", url: "https://x/i/10", assignees: [] }], prs: [], closedIssues: [], mergedPrs: [] },
+      { generatedAt: Date.now(), staleCycles: 0 },
+      "(none)",
+    );
+
+    const data = await getOrComputeBatchProgress("terminal-proj");
+    const row10 = data.items.find((it) => it.issue_number === 10);
+    ok(row10.status === "queued", `B3: persisted GITHUB.md reopened row overrides terminal cache (got ${row10.status})`);
+    ok(!JSON.parse(snapshotJson).terminalItems["10"], "B3: GITHUB.md nonterminal row evicts stale terminal cache");
+    githubMd = "";
   }
 
   // C. A stale rendered payload returns immediately and starts exactly one

--- a/server/routes.js
+++ b/server/routes.js
@@ -2450,6 +2450,8 @@ router.get("/api/github/merged-prs", (req, res) => serveGithubList(req, res, "me
 // Cached for 10s per project to avoid hammering gh on every poll.
 
 const _batchProgressCache = new Map(); // projectId -> { ts, data }
+const _batchProgressRefreshes = new Map(); // projectId -> Promise
+const BATCH_TERMINAL_STATUSES = new Set(["merged", "closed"]);
 
 // #429 / quadwork#316: persistent batch snapshot on disk so the
 // Batch Progress panel keeps showing merged items after Head moves
@@ -2482,6 +2484,36 @@ function deleteBatchSnapshot(projectId) {
   } catch {
     // Non-fatal — file may already be gone.
   }
+}
+
+function isTerminalBatchItem(item) {
+  return item && BATCH_TERMINAL_STATUSES.has(item.status);
+}
+
+function terminalItemsFromSnapshot(snapshot, batchNumber, issueNumbers) {
+  if (!snapshot || snapshot.batchNumber !== batchNumber || !Array.isArray(issueNumbers)) return new Map();
+  const source = snapshot.terminalItems && typeof snapshot.terminalItems === "object" ? snapshot.terminalItems : {};
+  const wanted = new Set(issueNumbers);
+  const rows = new Map();
+  for (const [rawIssue, row] of Object.entries(source)) {
+    const n = parseInt(rawIssue, 10);
+    if (!wanted.has(n) || !isTerminalBatchItem(row)) continue;
+    rows.set(n, row);
+  }
+  return rows;
+}
+
+function collectTerminalItems(items, previous = new Map()) {
+  const rows = {};
+  for (const [n, row] of previous.entries()) {
+    if (isTerminalBatchItem(row)) rows[n] = row;
+  }
+  for (const row of Array.isArray(items) ? items : []) {
+    if (isTerminalBatchItem(row) && Number.isInteger(row.issue_number)) {
+      rows[row.issue_number] = row;
+    }
+  }
+  return rows;
 }
 
 // #334: verify the snapshot's first issue number still exists on
@@ -2580,6 +2612,7 @@ function resolveDisplayedBatch(
       // as code. Absent (legacy / code snapshots) → "code"/[] — back-compatible.
       batch_type: snapshot.batch_type || "code",
       reviewItems: Array.isArray(snapshot.reviewItems) ? snapshot.reviewItems : [],
+      terminalItems: snapshot.terminalItems && typeof snapshot.terminalItems === "object" ? snapshot.terminalItems : {},
     };
     // #899: snapshot stickiness preserves the displayed issue SET (so items Head
     // moved to Done stay visible — #316/#429), but a review batch's per-item
@@ -3211,7 +3244,29 @@ async function getOrComputeBatchProgress(projectId) {
 
   const repo = getRepo(projectId);
   if (!repo) return null;
+  if (cached) {
+    startBatchProgressRefresh(projectId, repo);
+    return { ...cached.data, _stale: true, _refreshing: true };
+  }
 
+  return computeBatchProgress(projectId, repo);
+}
+
+function startBatchProgressRefresh(projectId, repo) {
+  if (_batchProgressRefreshes.has(projectId)) return _batchProgressRefreshes.get(projectId);
+  const refresh = computeBatchProgress(projectId, repo)
+    .catch(() => {
+      // Non-fatal: callers already received the last good payload. The next poll
+      // will retry rather than turning a transient gh/GitHub failure into UI lag.
+    })
+    .finally(() => {
+      _batchProgressRefreshes.delete(projectId);
+    });
+  _batchProgressRefreshes.set(projectId, refresh);
+  return refresh;
+}
+
+async function computeBatchProgress(projectId, repo) {
   const queuePath = path.join(CONFIG_DIR, projectId, "OVERNIGHT-QUEUE.md");
   let queueText = "";
   let queueReadOk = false;
@@ -3278,6 +3333,7 @@ async function getOrComputeBatchProgress(projectId) {
   // resets its streak when this changes, so a new already-complete batch can't
   // inherit the prior batch's first cycle and confirm in one tick.
   const batchKey = `${batchNumber}::${[...issueNumbers].sort((a, b) => a - b).join(",")}`;
+  const terminalRows = terminalItemsFromSnapshot(readBatchSnapshot(projectId), batchNumber, issueNumbers);
   if (issueNumbers.length === 0) {
     evalBatchCompleteConfirmed(projectId, batchKey, false, null); // reset any complete streak
     const data = { batch_number: batchNumber, items: [], summary: "", complete: false, completeConfirmed: false, liveActiveBatchCleared, batch_type };
@@ -3321,6 +3377,8 @@ async function getOrComputeBatchProgress(projectId) {
   let items;
   if (snapshot) {
     items = await _mapLimited(issueNumbers, GH_MAX_CONCURRENT, async (n) => {
+      const fromTerminalCache = terminalRows.get(n);
+      if (fromTerminalCache) return fromTerminalCache;
       const fromSnap = progressFromSnapshot(snapshot, n);
       if (fromSnap) return fromSnap;
       try {
@@ -3334,7 +3392,7 @@ async function getOrComputeBatchProgress(projectId) {
     // Search. Items the file can't classify render soft "queued (retrying)" and
     // firm up next cycle once _graphqlCache repopulates.
     const parsed = loadGithubParsed(projectId);
-    items = issueNumbers.map((n) => progressFromGithubFile(parsed, n) || softRetryingRow(n));
+    items = issueNumbers.map((n) => terminalRows.get(n) || progressFromGithubFile(parsed, n) || softRetryingRow(n));
   }
   const summary = summarizeItems(items);
   // #350: treat CLOSED-without-PR items as complete alongside merged
@@ -3346,6 +3404,13 @@ async function getOrComputeBatchProgress(projectId) {
   // transient/stale complete). Keyed on the snapshot's ts as the cycle marker.
   const completeConfirmed = evalBatchCompleteConfirmed(projectId, batchKey, complete, snapshot ? snapshot.ts : null);
   const data = { batch_number: batchNumber, items, summary, complete, completeConfirmed, liveActiveBatchCleared, batch_type };
+  writeBatchSnapshot(projectId, {
+    batchNumber,
+    issueNumbers: issueNumbers.slice(),
+    batch_type,
+    reviewItems,
+    terminalItems: collectTerminalItems(items, terminalRows),
+  });
   _batchProgressCache.set(projectId, { ts: Date.now(), data });
   return data;
 }
@@ -4723,6 +4788,7 @@ module.exports.RESEED_STATE_PATH = RESEED_STATE_PATH;
 // reads so the cache-miss completed-batch case is exercisable end-to-end.
 module.exports.getOrComputeBatchProgress = getOrComputeBatchProgress;
 module.exports._batchProgressCache = _batchProgressCache;
+module.exports._batchProgressRefreshes = _batchProgressRefreshes;
 module.exports._graphqlCache = _graphqlCache;
 module.exports.restIssueToCanonical = restIssueToCanonical;
 module.exports.restClosedIssueToCanonical = restClosedIssueToCanonical;

--- a/server/routes.js
+++ b/server/routes.js
@@ -2509,11 +2509,19 @@ function collectTerminalItems(items, previous = new Map()) {
     if (isTerminalBatchItem(row)) rows[n] = row;
   }
   for (const row of Array.isArray(items) ? items : []) {
-    if (isTerminalBatchItem(row) && Number.isInteger(row.issue_number)) {
-      rows[row.issue_number] = row;
-    }
+    if (!Number.isInteger(row && row.issue_number)) continue;
+    if (isTerminalBatchItem(row)) rows[row.issue_number] = row;
+    else delete rows[row.issue_number];
   }
   return rows;
+}
+
+function snapshotHasOpenIssue(snapshot, n) {
+  return !!(
+    snapshot &&
+    Array.isArray(snapshot.issues) &&
+    snapshot.issues.some((it) => it && it.number === n && it.state === "OPEN")
+  );
 }
 
 // #334: verify the snapshot's first issue number still exists on
@@ -3377,10 +3385,10 @@ async function computeBatchProgress(projectId, repo) {
   let items;
   if (snapshot) {
     items = await _mapLimited(issueNumbers, GH_MAX_CONCURRENT, async (n) => {
-      const fromTerminalCache = terminalRows.get(n);
-      if (fromTerminalCache) return fromTerminalCache;
       const fromSnap = progressFromSnapshot(snapshot, n);
       if (fromSnap) return fromSnap;
+      const fromTerminalCache = terminalRows.get(n);
+      if (fromTerminalCache && !snapshotHasOpenIssue(snapshot, n)) return fromTerminalCache;
       try {
         return await progressForItemRest(repo, n);
       } catch {
@@ -3392,7 +3400,7 @@ async function computeBatchProgress(projectId, repo) {
     // Search. Items the file can't classify render soft "queued (retrying)" and
     // firm up next cycle once _graphqlCache repopulates.
     const parsed = loadGithubParsed(projectId);
-    items = issueNumbers.map((n) => terminalRows.get(n) || progressFromGithubFile(parsed, n) || softRetryingRow(n));
+    items = issueNumbers.map((n) => progressFromGithubFile(parsed, n) || terminalRows.get(n) || softRetryingRow(n));
   }
   const summary = summarizeItems(items);
   // #350: treat CLOSED-without-PR items as complete alongside merged


### PR DESCRIPTION
Fixes #950

## Summary
- Persist merged/closed batch-progress rows in `batch-progress-cache.json` and reuse them before snapshot/REST fallback.
- Return stale rendered batch-progress cache immediately and run one background refresh per project.
- Add regression coverage for terminal-cache reuse and cache-served-then-recompute behavior.

## Verification
- `node server/routes.batchProgressTerminalCache.test.js` PASS (13/0)
- `node server/routes.batchProgressColdCache.test.js` PASS (40/0)
- `npx tsc --noEmit` PASS
- `node --check server/routes.js && node --check server/routes.batchProgressTerminalCache.test.js` PASS
- `npm run build` PASS
- `npm test` discovered 51 files; batch-progress tests passed, but 11 unrelated temp-file-writing tests failed with `errno -122` / write errors before reaching assertions.