### PR TITLE
[#951] Link batch progress via native close events

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -3036,9 +3036,33 @@ async function findLinkedPrByTitle(repo, n, search = _searchLinkedPrItems, opts 
   return pickLinkedPrFromSearch(items, n, opts);
 }
 
+function prNumberFromApiUrl(url) {
+  const m = String(url || "").match(/\/pulls\/(\d+)(?:\b|$)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function pickClosingPrFromTimeline(events) {
+  const candidates = [];
+  for (const ev of Array.isArray(events) ? events : []) {
+    if (!ev || ev.event !== "closed") continue;
+    const issue = ev.source && ev.source.issue;
+    const pr = issue && issue.pull_request;
+    const n = (issue && Number.isInteger(issue.number) && pr && issue.number) || prNumberFromApiUrl(pr && pr.url);
+    if (Number.isInteger(n)) candidates.push(n);
+  }
+  if (candidates.length === 0) return null;
+  return candidates.sort((a, b) => b - a)[0];
+}
+
+async function findClosingPrByTimeline(repo, issueNumber) {
+  const events = await ghJsonExecAsync(["api", `repos/${repo}/issues/${issueNumber}/timeline?per_page=100`]);
+  return pickClosingPrFromTimeline(events);
+}
+
 // Authoritative by-number resolution for an active-batch issue the board
-// snapshot can't prove (outside / truncated window, or absent). #828 P1: REST +
-// Search ONLY — zero `gh issue view` / `gh pr view` (GraphQL). Bucket mapping
+// snapshot can't prove (outside / truncated window, or absent). REST-only:
+// issue/PR endpoints + Search/title convention + native issue timeline
+// close-link — zero `gh issue view` / `gh pr view` (GraphQL). Bucket mapping
 // matches progressFromSnapshot exactly.
 async function progressForItemRest(repo, issueNumber) {
   // Load-bearing call: the issue's own state via REST. If gh can't read it at
@@ -3052,14 +3076,22 @@ async function progressForItemRest(repo, issueNumber) {
     state: (raw.state || "").toUpperCase(),
     url: raw.html_url,
   };
-  // Throws (→ route's soft "queued (retrying)" row, #943) if Search itself
-  // fails, so a could-not-determine is NEVER mistaken for proof of no linked PR.
-  // A null
-  // here means Search SUCCEEDED with zero strict [#N] matches — authoritative.
-  // #864/RE1: pass issue.state so the picker only prefers a merged duplicate
-  // for CLOSED issues; OPEN/reopened issues keep legacy freshest-wins, so a
-  // newer active duplicate PR isn't masked by an older merged one.
-  const prNumber = await findLinkedPrByTitle(repo, issueNumber, _searchLinkedPrItems, { issueState: issue.state });
+  // Title convention first; for CLOSED issues, fall back to GitHub's native
+  // issue timeline close-link. A lookup failure must not make a CLOSED issue
+  // flap to "queued (retrying)" — terminal-ness comes from the issue state.
+  let prNumber = null;
+  try {
+    prNumber = await findLinkedPrByTitle(repo, issueNumber, _searchLinkedPrItems, { issueState: issue.state });
+  } catch (err) {
+    if (issue.state !== "CLOSED") throw err;
+  }
+  if (prNumber == null && issue.state === "CLOSED") {
+    try {
+      prNumber = await findClosingPrByTimeline(repo, issueNumber);
+    } catch {
+      // Degrade below to Closed (no PR) ✓. The item is still terminal.
+    }
+  }
   // No linked PR (authoritative). #350: honor the issue's own state — a CLOSED
   // issue with no linked PR is fully done (superseded/not-planned/runbook) →
   // 100% ✓; only a truly OPEN issue with no PR is queued.
@@ -3076,6 +3108,7 @@ async function progressForItemRest(repo, issueNumber) {
     // soft fall-through to the in_review row below
   }
   if (!prData) {
+    if (issue.state === "CLOSED") return buildNoPrRow(issue);
     return {
       issue_number: issue.number,
       title: issue.title,
@@ -4830,6 +4863,8 @@ module.exports.closedPagesComplete = closedPagesComplete;
 module.exports.closedPrIssueNumsFromPages = closedPrIssueNumsFromPages;
 module.exports.pickLinkedPrFromSearch = pickLinkedPrFromSearch;
 module.exports.findLinkedPrByTitle = findLinkedPrByTitle;
+module.exports.pickClosingPrFromTimeline = pickClosingPrFromTimeline;
+module.exports.progressForItemRest = progressForItemRest;
 // #827: expose the GITHUB.md writer for the idle-no-op regression test. No
 // production callers outside this file.
 module.exports.writeGithubFileFromSnapshot = writeGithubFileFromSnapshot;

--- a/server/routes.nativeCloseLink.test.js
+++ b/server/routes.nativeCloseLink.test.js
@@ -1,0 +1,167 @@
+// #951: batch-progress must link CLOSED issues to PRs via GitHub's native
+// close-link, not only the `[#N]` title convention. It must also keep CLOSED
+// issues terminal when lookup fails, and #950's terminal cache must stop
+// repeated Search calls after a settled native-linked item is cached.
+//
+// Plain node:assert script — run with
+// `node server/routes.nativeCloseLink.test.js`.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const cp = require("child_process");
+
+const CONFIG_PATH = path.join(os.homedir(), ".quadwork", "config.json");
+
+let searchMode = "empty";
+let timelineMode = "native";
+let prMode = "ok";
+let ghCalls = [];
+const realRunner = cp.execFile;
+cp.execFile = function stubRunner(file, args, opts, cb) {
+  const done = typeof opts === "function" ? opts : cb;
+  if (file !== "gh" || typeof done !== "function") return realRunner.apply(this, arguments);
+  ghCalls.push(args.slice());
+  const target = args.find((a) => typeof a === "string" && a.startsWith("repos/"));
+  const ok = (json) => done(null, { stdout: JSON.stringify(json), stderr: "" });
+  setImmediate(() => {
+    if (target === "repos/o/r/issues/488") {
+      return ok({ number: 488, title: "native closed", state: "closed", html_url: "https://x/i/488" });
+    }
+    if (target && target.startsWith("repos/o/r/issues/488/timeline")) {
+      if (timelineMode === "fail") return done(new Error("timeline failed"), "", "timeline failed");
+      return ok([
+        {
+          event: "closed",
+          source: {
+            issue: {
+              number: 491,
+              pull_request: { url: "https://api.github.com/repos/o/r/pulls/491", html_url: "https://x/p/491" },
+            },
+          },
+        },
+      ]);
+    }
+    if (target === "repos/o/r/pulls/491") {
+      if (prMode === "fail") return done(new Error("pr failed"), "", "pr failed");
+      return ok({ number: 491, merged: true, html_url: "https://x/p/491" });
+    }
+    if (target === "repos/o/r/pulls/491/reviews?per_page=100") {
+      return ok([]);
+    }
+    if (args.includes("search/issues")) {
+      if (searchMode === "fail") return done(new Error("search failed"), "", "search failed");
+      return ok({ items: [] });
+    }
+    return done(new Error(`unexpected gh call: ${args.join(" ")}`), "", "");
+  });
+};
+
+const real = { readFileSync: fs.readFileSync };
+let cfgJson = JSON.stringify({ projects: [] });
+let queueText = "";
+let snapshotJson = null;
+fs.readFileSync = function stubReadFileSync(p, ...rest) {
+  if (p === CONFIG_PATH) return cfgJson;
+  if (typeof p === "string" && p.endsWith("OVERNIGHT-QUEUE.md")) return queueText;
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) {
+    if (snapshotJson !== null) return snapshotJson;
+    const err = new Error("ENOENT (test stub)");
+    err.code = "ENOENT";
+    throw err;
+  }
+  if (typeof p === "string" && p.endsWith("GITHUB.md")) return "";
+  return real.readFileSync(p, ...rest);
+};
+fs.writeFileSync = function stubWriteFileSync(p, data) {
+  if (typeof p === "string" && p.endsWith("batch-progress-cache.json")) snapshotJson = String(data);
+};
+fs.mkdirSync = () => {};
+fs.statSync = () => ({ mode: 0o700, isDirectory: () => true });
+fs.renameSync = () => {};
+fs.unlinkSync = () => { snapshotJson = null; };
+
+const {
+  getOrComputeBatchProgress,
+  pickClosingPrFromTimeline,
+  progressForItemRest,
+  _batchProgressCache,
+  _batchProgressRefreshes,
+  _graphqlCache,
+} = require("./routes");
+
+function searchCalls() {
+  return ghCalls.filter((args) => args.includes("search/issues"));
+}
+
+(async () => {
+  let passed = 0, failed = 0;
+  const ok = (c, m) => { if (c) { passed++; console.log(`  PASS: ${m}`); } else { failed++; console.error(`  FAIL: ${m}`); } };
+
+  {
+    const n = pickClosingPrFromTimeline([
+      { event: "commented" },
+      { event: "closed", source: { issue: { number: 491, pull_request: { url: "https://api.github.com/repos/o/r/pulls/491" } } } },
+    ]);
+    ok(n === 491, "A: timeline closed event yields native closing PR number");
+    ok(pickClosingPrFromTimeline([{ event: "closed", source: { issue: {} } }]) === null, "A: timeline without PR link → null");
+  }
+
+  {
+    searchMode = "empty";
+    timelineMode = "native";
+    ghCalls = [];
+    const row = await progressForItemRest("o/r", 488);
+    ok(row.status === "merged" && row.pr_number === 491, "B: CLOSED issue + native close-link PR with no title match → Merged ✓");
+    ok(searchCalls().length === 1, "B: title Search ran once before native fallback");
+  }
+
+  {
+    searchMode = "fail";
+    timelineMode = "fail";
+    prMode = "ok";
+    ghCalls = [];
+    const row = await progressForItemRest("o/r", 488);
+    ok(row.status === "closed", "C: CLOSED issue stays terminal when Search/timeline fail");
+    ok(row.label === "Closed (no PR) ✓", "C: lookup failure degrades label, not terminal status");
+  }
+
+  {
+    searchMode = "empty";
+    timelineMode = "native";
+    prMode = "fail";
+    ghCalls = [];
+    const row = await progressForItemRest("o/r", 488);
+    ok(row.status === "closed", "C2: CLOSED issue stays terminal when linked PR fetch fails");
+    prMode = "ok";
+  }
+
+  {
+    searchMode = "empty";
+    timelineMode = "native";
+    ghCalls = [];
+    snapshotJson = null;
+    _batchProgressCache.clear();
+    _batchProgressRefreshes.clear();
+    _graphqlCache.clear();
+    cfgJson = JSON.stringify({ projects: [{ id: "native-proj", repo: "o/r", idle: false }] });
+    queueText = "# Queue\n\n## Active Batch\n\n**Batch:** 951\n\n- #488 native link\n";
+    _graphqlCache.set("o/r", { ts: Date.now(), issues: [], prs: [], closedIssues: [], mergedPrs: [] });
+
+    const first = await getOrComputeBatchProgress("native-proj");
+    ok(first.items[0].status === "merged" && first.items[0].pr_number === 491, "D: first compute resolves native-linked merged PR");
+    ok(searchCalls().length === 1, "D: first compute did one Search");
+
+    ghCalls = [];
+    _batchProgressCache.clear();
+    const second = await getOrComputeBatchProgress("native-proj");
+    ok(second.items[0].status === "merged" && second.items[0].pr_number === 491, "D: second compute stays merged from terminal cache");
+    ok(searchCalls().length === 0, "D: terminal cache prevents repeated Search calls after native-linked item is settled");
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})().catch((err) => {
+  console.error("test crashed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes #951

## Summary
- Add REST issue-timeline fallback so CLOSED issues can link to the PR that closed them even when the PR title lacks `[#N]`.
- Keep CLOSED issues terminal when title Search, timeline lookup, or linked-PR fetch fails; lookup failures degrade the label instead of flapping to `queued (retrying)`.
- Preserve #950 terminal-cache behavior so settled native-linked items are cached and not repeatedly searched.

## Verification
- `node server/routes.nativeCloseLink.test.js` PASS (11/0)
- `node server/routes.restMigration828.test.js` PASS (43/0)
- `node server/routes.batchProgressTerminalCache.test.js` PASS (18/0)
- `node --check server/routes.js && node --check server/routes.nativeCloseLink.test.js` PASS
- `npx tsc --noEmit` PASS
- `npm run build` PASS
- `npm test` discovers and passes the new native-close test; full run still has the same 11 unrelated temp-file write failures with `errno -122` before assertions.