### PR TITLE
[#947] Refresh setup clones before worktrees

### DIFF
--- a/bin/quadwork.js
+++ b/bin/quadwork.js
@@ -67,8 +67,58 @@ function run(cmd, args = [], opts = {}) {
   }
 }
 
+function runResult(cmd, args = [], opts = {}) {
+  try {
+    const out = execFileSync(cmd, args, { encoding: "utf-8", stdio: "pipe", ...opts });
+    return { ok: true, output: out.trim() };
+  } catch (err) {
+    return { ok: false, output: String(err.stderr || err.stdout || err.message || "").trim() };
+  }
+}
+
 function which(cmd) {
   return run("which", [cmd]) !== null;
+}
+
+function ensureGitHeadForSetup(absDir, repo) {
+  if (!fs.existsSync(path.join(absDir, ".git"))) {
+    const clone = runResult("gh", ["repo", "clone", repo, absDir]);
+    if (!clone.ok) return { ok: false, error: `Clone failed: ${clone.output}` };
+  } else {
+    const fetch = runResult("git", ["-C", absDir, "fetch", "origin", "--prune"]);
+    if (!fetch.ok) return { ok: false, error: `Fetch failed: ${fetch.output}` };
+  }
+
+  let headCheck = runResult("git", ["-C", absDir, "rev-parse", "--verify", "HEAD"]);
+  if (!headCheck.ok) {
+    const remoteHead = runResult("git", ["-C", absDir, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]);
+    let remoteBranch = remoteHead.ok ? remoteHead.output.replace(/^origin\//, "") : "";
+    if (!remoteBranch) {
+      for (const candidate of ["main", "master"]) {
+        const hasBranch = runResult("git", ["-C", absDir, "rev-parse", "--verify", `origin/${candidate}`]);
+        if (hasBranch.ok) { remoteBranch = candidate; break; }
+      }
+    }
+    if (remoteBranch) {
+      const checkout = runResult("git", ["-C", absDir, "checkout", "-B", remoteBranch, `origin/${remoteBranch}`]);
+      if (!checkout.ok) return { ok: false, error: `Checkout failed after fetch: ${checkout.output}` };
+      headCheck = runResult("git", ["-C", absDir, "rev-parse", "--verify", "HEAD"]);
+    }
+  }
+  if (headCheck.ok) return { ok: true };
+
+  const seed = runResult("git", [
+    "-C", absDir,
+    "-c", "user.name=QuadWork",
+    "-c", "user.email=quadwork@localhost",
+    "commit", "--allow-empty", "-m", "Initial commit (created by QuadWork setup)",
+  ]);
+  if (!seed.ok) return { ok: false, error: `Repository is empty and could not be initialized: ${seed.output}` };
+  const branchResult = runResult("git", ["-C", absDir, "symbolic-ref", "--short", "HEAD"]);
+  const defaultBranch = branchResult.ok ? branchResult.output : "main";
+  const push = runResult("git", ["-C", absDir, "push", "origin", defaultBranch]);
+  if (!push.ok) return { ok: false, error: `Initial commit created but push failed: ${push.output}` };
+  return { ok: true };
 }
 
 
@@ -537,17 +587,6 @@ async function setupAgents(rl, repo) {
   const projectDir = await ask(rl, "Project directory", process.cwd());
   const absDir = path.resolve(projectDir);
 
-  if (!fs.existsSync(absDir)) {
-    fail(`Directory not found: ${absDir}`);
-    return null;
-  }
-
-  // Check if it's a git repo
-  if (!fs.existsSync(path.join(absDir, ".git"))) {
-    fail(`Not a git repo: ${absDir}`);
-    return null;
-  }
-
   // Prompt for reviewer credentials (optional)
   log("A separate reviewer account lets RE1/RE2 approve PRs independently. You can set this up later in Settings.");
   const wantReviewer = await askYN(rl, "Use a separate GitHub account for reviewers (RE1/RE2)?", false);
@@ -564,12 +603,11 @@ async function setupAgents(rl, repo) {
   log(`Project: ${projectName}`);
   const wtSpinner = spinner("Creating worktrees and seeding files...");
 
-  // Empty repos have no commits — git worktree add requires at least one.
-  const headCheck = run("git", ["-C", absDir, "rev-parse", "HEAD"]);
-  if (!headCheck || headCheck.includes("fatal")) {
-    run("git", ["-C", absDir, "commit", "--allow-empty", "-m", "Initial commit (created by QuadWork setup)"]);
-    const defaultBranch = run("git", ["-C", absDir, "symbolic-ref", "--short", "HEAD"]) || "main";
-    run("git", ["-C", absDir, "push", "origin", defaultBranch]);
+  const ready = ensureGitHeadForSetup(absDir, repo);
+  if (!ready.ok) {
+    wtSpinner.stop(false);
+    fail(ready.error);
+    return null;
   }
 
   const worktrees = {};
@@ -578,7 +616,8 @@ async function setupAgents(rl, repo) {
     const wtDir = path.join(path.dirname(absDir), `${projectName}-${agent}`);
     if (!fs.existsSync(wtDir)) {
       const branchName = `worktree-${agent}`;
-      run("git", ["-C", absDir, "branch", branchName, "HEAD"]);
+      const branch = runResult("git", ["-C", absDir, "branch", branchName, "HEAD"]);
+      if (!branch.ok) { wtFailed = `${agent}: branch failed: ${branch.output}`; break; }
       const result = run("git", ["-C", absDir, "worktree", "add", wtDir, branchName]);
       if (!result) {
         const result2 = run("git", ["-C", absDir, "worktree", "add", "--detach", wtDir, "HEAD"]);

--- a/server/routes.js
+++ b/server/routes.js
@@ -3473,8 +3473,53 @@ function exec(cmd, args, opts) {
     const out = execFileSync(cmd, args, { encoding: "utf-8", timeout: 30000, ...opts });
     return { ok: true, output: out.trim() };
   } catch (err) {
-    return { ok: false, output: err.message };
+    return { ok: false, output: String(err.stderr || err.stdout || err.message || "").trim() };
   }
+}
+
+function ensureGitHeadForSetup(workingDir, repo) {
+  const gitDir = path.join(workingDir, ".git");
+  if (!fs.existsSync(gitDir)) {
+    if (!fs.existsSync(workingDir)) ensureSecureDir(workingDir);
+    if (!REPO_RE.test(repo)) return { ok: false, error: "Invalid repo" };
+    const clone = exec("gh", ["repo", "clone", repo, workingDir]);
+    if (!clone.ok) return { ok: false, error: `Clone failed: ${clone.output}` };
+  } else {
+    const fetch = exec("git", ["fetch", "origin", "--prune"], { cwd: workingDir });
+    if (!fetch.ok) return { ok: false, error: `Fetch failed: ${fetch.output}` };
+  }
+
+  let headCheck = exec("git", ["rev-parse", "--verify", "HEAD"], { cwd: workingDir });
+  if (!headCheck.ok) {
+    const remoteHead = exec("git", ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], { cwd: workingDir });
+    let remoteBranch = remoteHead.ok ? remoteHead.output.replace(/^origin\//, "") : "";
+    if (!remoteBranch) {
+      for (const candidate of ["main", "master"]) {
+        const hasBranch = exec("git", ["rev-parse", "--verify", `origin/${candidate}`], { cwd: workingDir });
+        if (hasBranch.ok) { remoteBranch = candidate; break; }
+      }
+    }
+    if (remoteBranch) {
+      const checkout = exec("git", ["checkout", "-B", remoteBranch, `origin/${remoteBranch}`], { cwd: workingDir });
+      if (!checkout.ok) return { ok: false, error: `Checkout failed after fetch: ${checkout.output}` };
+      headCheck = exec("git", ["rev-parse", "--verify", "HEAD"], { cwd: workingDir });
+    }
+  }
+  if (headCheck.ok) return { ok: true };
+
+  const seed = exec("git", [
+    "-c", "user.name=QuadWork",
+    "-c", "user.email=quadwork@localhost",
+    "commit", "--allow-empty", "-m", "Initial commit (created by QuadWork setup)",
+  ], { cwd: workingDir });
+  if (!seed.ok) {
+    return { ok: false, error: `Repository is empty and could not be initialized: ${seed.output}` };
+  }
+  const branchResult = exec("git", ["symbolic-ref", "--short", "HEAD"], { cwd: workingDir });
+  const defaultBranch = branchResult.ok ? branchResult.output : "main";
+  const push = exec("git", ["push", "origin", defaultBranch], { cwd: workingDir });
+  if (!push.ok) return { ok: false, error: `Initial commit created but push failed: ${push.output}` };
+  return { ok: true };
 }
 
 // ─── GitHub helpers for Setup Wizard ──────────────────────────────────────
@@ -3586,20 +3631,8 @@ router.post("/api/setup", (req, res) => {
     case "create-worktrees": {
       const workingDir = body.workingDir;
       if (!workingDir) return res.json({ ok: false, error: "Missing working directory" });
-      if (!fs.existsSync(path.join(workingDir, ".git"))) {
-        if (!fs.existsSync(workingDir)) ensureSecureDir(workingDir);
-        if (!REPO_RE.test(body.repo)) return res.json({ ok: false, error: "Invalid repo" });
-        const clone = exec("gh", ["repo", "clone", body.repo, workingDir]);
-        if (!clone.ok) return res.json({ ok: false, error: `Clone failed: ${clone.output}` });
-      }
-      // Empty repos have no commits — git worktree add requires at least one.
-      const headCheck = exec("git", ["rev-parse", "HEAD"], { cwd: workingDir });
-      if (!headCheck.ok) {
-        exec("git", ["commit", "--allow-empty", "-m", "Initial commit (created by QuadWork setup)"], { cwd: workingDir });
-        const branchResult = exec("git", ["symbolic-ref", "--short", "HEAD"], { cwd: workingDir });
-        const defaultBranch = branchResult.ok ? branchResult.output : "main";
-        exec("git", ["push", "origin", defaultBranch], { cwd: workingDir });
-      }
+      const ready = ensureGitHeadForSetup(workingDir, body.repo);
+      if (!ready.ok) return res.json({ ok: false, error: ready.error });
       // Sibling dirs: ../projectName-head/, ../projectName-re1/, etc. (matches CLI wizard)
       const projectName = path.basename(workingDir);
       const parentDir = path.dirname(workingDir);
@@ -3610,7 +3643,11 @@ router.post("/api/setup", (req, res) => {
         const wtDir = path.join(parentDir, `${projectName}-${agent}`);
         if (fs.existsSync(wtDir)) { created.push(`${agent} (exists)`); continue; }
         const branchName = `worktree-${agent}`;
-        exec("git", ["branch", branchName, "HEAD"], { cwd: workingDir });
+        const branch = exec("git", ["branch", branchName, "HEAD"], { cwd: workingDir });
+        if (!branch.ok) {
+          errors.push(`${agent}: branch failed: ${branch.output}`);
+          continue;
+        }
         const result = exec("git", ["worktree", "add", wtDir, branchName], { cwd: workingDir });
         if (result.ok) {
           created.push(agent);
@@ -4865,6 +4902,7 @@ module.exports.pickLinkedPrFromSearch = pickLinkedPrFromSearch;
 module.exports.findLinkedPrByTitle = findLinkedPrByTitle;
 module.exports.pickClosingPrFromTimeline = pickClosingPrFromTimeline;
 module.exports.progressForItemRest = progressForItemRest;
+module.exports.ensureGitHeadForSetup = ensureGitHeadForSetup;
 // #827: expose the GITHUB.md writer for the idle-no-op regression test. No
 // production callers outside this file.
 module.exports.writeGithubFileFromSnapshot = writeGithubFileFromSnapshot;

--- a/server/routes.setupWorktrees.test.js
+++ b/server/routes.setupWorktrees.test.js
@@ -1,0 +1,121 @@
+// #947: setup wizard worktree creation must refresh stale existing clones
+// before HEAD checks and initialize genuinely empty repos with inline identity.
+//
+// Plain node:assert script — run with
+// `node server/routes.setupWorktrees.test.js`.
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+
+const realExecFileSync = cp.execFileSync;
+const realExistsSync = fs.existsSync;
+const realMkdirSync = fs.mkdirSync;
+const realChmodSync = fs.chmodSync;
+
+let existing = new Set();
+let commands = [];
+let mode = "stale";
+
+cp.execFileSync = function stubExecFileSync(cmd, args, opts = {}) {
+  commands.push({ cmd, args: args.slice(), cwd: opts.cwd || null });
+  if (cmd !== "git" && cmd !== "gh") return realExecFileSync.apply(this, arguments);
+  const joined = args.join(" ");
+  if (cmd === "gh" && joined.startsWith("repo clone")) return "";
+  if (cmd === "git" && joined === "fetch origin --prune") return "";
+  if (cmd === "git" && joined === "rev-parse --verify HEAD") {
+    if ((mode === "stale" || mode === "stale-no-origin-head") && commands.some((c) => c.args.join(" ") === "checkout -B main origin/main")) return "abc123\n";
+    if (mode === "ready") return "abc123\n";
+    const err = new Error("fatal: ambiguous argument 'HEAD'");
+    err.stderr = Buffer.from("fatal: ambiguous argument 'HEAD'\n");
+    throw err;
+  }
+  if (cmd === "git" && joined === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
+    if (mode === "stale") return "origin/main\n";
+    const err = new Error("fatal: ref not found");
+    err.stderr = Buffer.from("fatal: ref not found\n");
+    throw err;
+  }
+  if (cmd === "git" && joined === "rev-parse --verify origin/main") {
+    if (mode === "stale-no-origin-head") return "abc123\n";
+    const err = new Error("fatal: bad revision");
+    err.stderr = Buffer.from("fatal: bad revision\n");
+    throw err;
+  }
+  if (cmd === "git" && joined === "rev-parse --verify origin/master") {
+    const err = new Error("fatal: bad revision");
+    err.stderr = Buffer.from("fatal: bad revision\n");
+    throw err;
+  }
+  if (cmd === "git" && joined === "checkout -B main origin/main") return "";
+  if (cmd === "git" && joined.includes("-c user.name=QuadWork -c user.email=quadwork@localhost commit --allow-empty")) return "";
+  if (cmd === "git" && joined === "symbolic-ref --short HEAD") return "main\n";
+  if (cmd === "git" && joined === "push origin main") return "";
+  const err = new Error(`unexpected command: ${cmd} ${joined}`);
+  err.stderr = Buffer.from(err.message);
+  throw err;
+};
+
+fs.existsSync = function stubExistsSync(p) {
+  return existing.has(path.normalize(p));
+};
+fs.mkdirSync = () => {};
+fs.chmodSync = () => {};
+
+const { ensureGitHeadForSetup } = require("./routes");
+
+function reset() {
+  commands = [];
+  existing = new Set();
+  mode = "stale";
+}
+
+try {
+  reset();
+  existing.add(path.normalize("/tmp/proj/.git"));
+  let result = ensureGitHeadForSetup("/tmp/proj", "owner/repo");
+  assert.equal(result.ok, true, "stale existing clone with remote commits becomes ready");
+  assert.ok(commands.some((c) => c.args.join(" ") === "fetch origin --prune"), "existing clone is fetched before HEAD handling");
+  assert.ok(commands.some((c) => c.args.join(" ") === "checkout -B main origin/main"), "remote default branch is checked out when local HEAD is unborn");
+  assert.ok(!commands.some((c) => c.args.includes("commit")), "stale clone with remote commits does not seed an empty commit");
+  console.log("  PASS: stale empty local clone fetches/checks out remote default branch");
+
+  reset();
+  existing.add(path.normalize("/tmp/proj/.git"));
+  mode = "stale-no-origin-head";
+  result = ensureGitHeadForSetup("/tmp/proj", "owner/repo");
+  assert.equal(result.ok, true, "stale clone without origin/HEAD checks out origin/main");
+  assert.ok(commands.some((c) => c.args.join(" ") === "rev-parse --verify origin/main"), "origin/main fallback is checked");
+  assert.ok(commands.some((c) => c.args.join(" ") === "checkout -B main origin/main"), "origin/main fallback is checked out");
+  console.log("  PASS: stale clone falls back to origin/main when origin/HEAD is missing");
+
+  reset();
+  existing.add(path.normalize("/tmp/empty/.git"));
+  mode = "empty";
+  result = ensureGitHeadForSetup("/tmp/empty", "owner/repo");
+  assert.equal(result.ok, true, "genuinely empty repo is initialized");
+  const commit = commands.find((c) => c.args.includes("commit") && c.args.includes("--allow-empty"));
+  assert.ok(commit, "empty repo path creates seed commit");
+  assert.ok(commit.args.includes("user.name=QuadWork"), "seed commit uses inline user.name");
+  assert.ok(commit.args.includes("user.email=quadwork@localhost"), "seed commit uses inline user.email");
+  assert.ok(commands.some((c) => c.args.join(" ") === "push origin main"), "seed commit is pushed to default branch");
+  console.log("  PASS: empty repo seeds with inline identity and pushes");
+
+  reset();
+  mode = "ready";
+  result = ensureGitHeadForSetup("/tmp/new", "owner/repo");
+  assert.equal(result.ok, true, "missing local clone is cloned and verified");
+  assert.ok(commands.some((c) => c.cmd === "gh" && c.args.join(" ") === "repo clone owner/repo /tmp/new"), "missing clone is cloned via gh");
+  console.log("  PASS: missing clone path still clones via gh");
+
+  console.log("\n4 passed, 0 failed\n");
+} catch (err) {
+  console.error("test failed:", err);
+  process.exitCode = 1;
+} finally {
+  cp.execFileSync = realExecFileSync;
+  fs.existsSync = realExistsSync;
+  fs.mkdirSync = realMkdirSync;
+  fs.chmodSync = realChmodSync;
+}


### PR DESCRIPTION
Fixes #947

## Summary
- Refresh existing setup clones with `git fetch origin --prune` before checking HEAD.
- If local HEAD is unborn after fetch, check out the remote default branch (`origin/HEAD`, then `origin/main`/`origin/master`) before seeding.
- Seed truly empty repos with inline git identity and check seed/branch/push failures so the real cause surfaces instead of `invalid reference: worktree-*`.
- Mirror the same flow in the packaged CLI wizard.

## Verification
- `node server/routes.setupWorktrees.test.js` PASS (4/0)
- `node --check server/routes.js && node --check bin/quadwork.js && node --check server/routes.setupWorktrees.test.js` PASS
- `npx tsc --noEmit` PASS
- `npm run build` PASS
- `npm test` discovers and passes `server/routes.setupWorktrees.test.js`; full run still has the same 11 unrelated temp-file write failures with `errno -122` before assertions.