### PR TITLE
[#949] Add reviewer account settings

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -329,17 +329,19 @@ router.put("/api/config", (req, res) => {
     const body = req.body;
     const dir = path.dirname(CONFIG_PATH);
     ensureSecureDir(dir);
-    // #944: pinned_projects and sidebar_groups are owned by the field-scoped
-    // /api/pins and /api/sidebar-groups endpoints below. A whole-config PUT
+    // #944/#949: pinned_projects, sidebar_groups, and reviewer_github_user are
+    // owned by field-scoped endpoints below. A whole-config PUT
     // (settings save, idle toggle, bridge/queue/trigger widgets) carries a
-    // snapshot the client GET'd earlier, which may be stale for these two keys
-    // — a pin/group added by another save in the meantime. Never let a full PUT
-    // clobber them: always re-read the current on-disk values and keep those.
+    // snapshot the client GET'd earlier, which may be stale for these keys.
+    // Never let a full PUT clobber them: always re-read the current on-disk
+    // values and keep those.
     const disk = readConfigFile();
     if ("pinned_projects" in disk) body.pinned_projects = disk.pinned_projects;
     else delete body.pinned_projects;
     if ("sidebar_groups" in disk) body.sidebar_groups = disk.sidebar_groups;
     else delete body.sidebar_groups;
+    if ("reviewer_github_user" in disk) body.reviewer_github_user = disk.reviewer_github_user;
+    else delete body.reviewer_github_user;
     writeConfig(body);
     // Trigger sync is handled internally since we're in the same process now
     if (typeof req.app.get("syncTriggers") === "function") {

--- a/server/routes.js
+++ b/server/routes.js
@@ -424,6 +424,31 @@ router.put("/api/sidebar-groups", (req, res) => {
   }
 });
 
+function validateReviewerGithubUser(value) {
+  if (typeof value !== "string") return null;
+  const v = value.trim();
+  if (v === "") return "";
+  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(v) ? v : null;
+}
+
+router.put("/api/reviewer-github-user", (req, res) => {
+  const reviewer = validateReviewerGithubUser(req.body && req.body.reviewer_github_user);
+  if (reviewer === null) {
+    return res.status(400).json({ error: "reviewer_github_user must be a valid GitHub username or blank" });
+  }
+  try {
+    const dir = path.dirname(CONFIG_PATH);
+    ensureSecureDir(dir);
+    const cfg = readConfigFile();
+    if (reviewer) cfg.reviewer_github_user = reviewer;
+    else delete cfg.reviewer_github_user;
+    writeConfig(cfg);
+    res.json({ ok: true, reviewer_github_user: reviewer });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to write config", detail: err.message });
+  }
+});
+
 // ─── Chat (file-based) ────────────────────────────────────────────────────
 
 const { sanitizeOperatorName, ensureSecureDir, writeSecureFile, writeConfig } = require("./config");
@@ -3589,7 +3614,7 @@ router.get("/api/setup/detect-clone", (req, res) => {
 // Save reviewer token securely
 router.post("/api/setup/save-token", (req, res) => {
   const { token } = req.body;
-  if (!token) return res.status(400).json({ error: "Missing token" });
+  if (typeof token !== "string" || !token.trim()) return res.status(400).json({ error: "Missing token" });
   const tokenPath = path.join(os.homedir(), ".quadwork", "reviewer-token");
   const dir = path.dirname(tokenPath);
   ensureSecureDir(dir);

--- a/server/routes.reviewerAccountSettings.test.js
+++ b/server/routes.reviewerAccountSettings.test.js
@@ -1,0 +1,168 @@
+// #949: Settings reviewer-account plumbing. The API must expose token status
+// without the token value, save/rotate the token securely, and update
+// reviewer_github_user through a field-scoped endpoint.
+//
+// Plain node:assert script — run with
+// `node server/routes.reviewerAccountSettings.test.js`.
+
+const assert = require("node:assert/strict");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const TEST_DIR = "/memhome";
+const origHome = os.homedir;
+os.homedir = () => TEST_DIR;
+
+const CONFIG_DIR = path.join(TEST_DIR, ".quadwork");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+const TOKEN_PATH = path.join(CONFIG_DIR, "reviewer-token");
+
+const real = {
+  existsSync: fs.existsSync,
+  readFileSync: fs.readFileSync,
+  writeFileSync: fs.writeFileSync,
+  mkdirSync: fs.mkdirSync,
+  chmodSync: fs.chmodSync,
+  statSync: fs.statSync,
+  rmSync: fs.rmSync,
+};
+const files = new Map([[CONFIG_PATH, JSON.stringify({ port: 8400, reviewer_github_user: "old-reviewer", projects: [] }, null, 2)]]);
+const modes = new Map();
+const dirs = new Set([CONFIG_DIR]);
+
+fs.existsSync = function stubExistsSync(p) {
+  const key = String(p);
+  if (key.startsWith(TEST_DIR)) return files.has(key) || dirs.has(key);
+  return real.existsSync.apply(this, arguments);
+};
+fs.readFileSync = function stubReadFileSync(p, ...rest) {
+  const key = String(p);
+  if (key.startsWith(TEST_DIR)) {
+    if (!files.has(key)) {
+      const err = new Error("ENOENT");
+      err.code = "ENOENT";
+      throw err;
+    }
+    return files.get(key);
+  }
+  return real.readFileSync.call(this, p, ...rest);
+};
+fs.writeFileSync = function stubWriteFileSync(p, data, opts = {}) {
+  const key = String(p);
+  if (key.startsWith(TEST_DIR)) {
+    files.set(key, String(data));
+    if (opts && opts.mode) modes.set(key, opts.mode);
+    return;
+  }
+  return real.writeFileSync.apply(this, arguments);
+};
+fs.mkdirSync = function stubMkdirSync(p, ...rest) {
+  const key = String(p);
+  if (key.startsWith(TEST_DIR)) { dirs.add(key); return; }
+  return real.mkdirSync.call(this, p, ...rest);
+};
+fs.chmodSync = function stubChmodSync(p, mode) {
+  const key = String(p);
+  if (key.startsWith(TEST_DIR)) { modes.set(key, mode); return; }
+  return real.chmodSync.apply(this, arguments);
+};
+fs.statSync = function stubStatSync(p, ...rest) {
+  const key = String(p);
+  if (key.startsWith(TEST_DIR)) return { mode: modes.get(key) || 0o600 };
+  return real.statSync.call(this, p, ...rest);
+};
+
+const express = require("express");
+const router = require("./routes");
+
+function cleanup() {
+  os.homedir = origHome;
+  fs.existsSync = real.existsSync;
+  fs.readFileSync = real.readFileSync;
+  fs.writeFileSync = real.writeFileSync;
+  fs.mkdirSync = real.mkdirSync;
+  fs.chmodSync = real.chmodSync;
+  fs.statSync = real.statSync;
+  fs.rmSync = real.rmSync;
+}
+process.on("exit", cleanup);
+
+function req(server, { method = "GET", urlPath, body } = {}) {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address();
+    const payload = body === undefined ? null : Buffer.from(JSON.stringify(body));
+    const r = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method,
+        path: urlPath,
+        headers: payload ? { "content-type": "application/json", "content-length": payload.length } : {},
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode, json: JSON.parse(Buffer.concat(chunks).toString()) }));
+      },
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+
+  try {
+    let status = await req(server, { urlPath: "/api/setup/reviewer-token-status" });
+    assert.equal(status.status, 200, "status succeeds");
+    assert.equal(status.json.exists, false, "missing token reports exists=false");
+    assert.equal(status.json.path, TOKEN_PATH, "status returns path");
+    assert.ok(!("token" in status.json), "status never returns token");
+    console.log("  PASS: token status omits secret");
+
+    const blank = await req(server, { method: "POST", urlPath: "/api/setup/save-token", body: { token: "   " } });
+    assert.equal(blank.status, 400, "blank token rejected");
+    assert.equal(fs.existsSync(TOKEN_PATH), false, "blank token does not create file");
+    console.log("  PASS: blank token validation");
+
+    const saved = await req(server, { method: "POST", urlPath: "/api/setup/save-token", body: { token: "ghp_secret_value" } });
+    assert.equal(saved.status, 200, "token save succeeds");
+    assert.equal(saved.json.ok, true, "token save returns ok");
+    assert.ok(!JSON.stringify(saved.json).includes("ghp_secret_value"), "save response does not echo token");
+    assert.equal(fs.readFileSync(TOKEN_PATH, "utf-8"), "ghp_secret_value\n", "token written with newline");
+    assert.equal(fs.statSync(TOKEN_PATH).mode & 0o777, 0o600, "token file mode is 0600");
+    status = await req(server, { urlPath: "/api/setup/reviewer-token-status" });
+    assert.equal(status.json.exists, true, "saved token reports exists=true");
+    console.log("  PASS: token save is secure and status updates");
+
+    const invalidUser = await req(server, { method: "PUT", urlPath: "/api/reviewer-github-user", body: { reviewer_github_user: "-bad-" } });
+    assert.equal(invalidUser.status, 400, "invalid GitHub username rejected");
+    assert.equal(JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")).reviewer_github_user, "old-reviewer", "invalid username does not mutate config");
+    console.log("  PASS: reviewer user validation");
+
+    const setUser = await req(server, { method: "PUT", urlPath: "/api/reviewer-github-user", body: { reviewer_github_user: "reviewer-bot" } });
+    assert.equal(setUser.status, 200, "valid reviewer user saved");
+    assert.equal(setUser.json.reviewer_github_user, "reviewer-bot", "response returns sanitized username only");
+    assert.equal(JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")).reviewer_github_user, "reviewer-bot", "config updated");
+
+    const clearUser = await req(server, { method: "PUT", urlPath: "/api/reviewer-github-user", body: { reviewer_github_user: "" } });
+    assert.equal(clearUser.status, 200, "blank reviewer user clears value");
+    assert.equal(JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")).reviewer_github_user, undefined, "config key removed when blank");
+    console.log("  PASS: reviewer user update and clear");
+
+    console.log("\n5 passed, 0 failed\n");
+  } finally {
+    server.close();
+  }
+})().catch((err) => {
+  console.error("test crashed:", err);
+  process.exit(1);
+});

--- a/server/routes.reviewerAccountSettings.test.js
+++ b/server/routes.reviewerAccountSettings.test.js
@@ -154,6 +154,14 @@ function req(server, { method = "GET", urlPath, body } = {}) {
     assert.equal(setUser.json.reviewer_github_user, "reviewer-bot", "response returns sanitized username only");
     assert.equal(JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")).reviewer_github_user, "reviewer-bot", "config updated");
 
+    const staleFullSave = await req(server, {
+      method: "PUT",
+      urlPath: "/api/config",
+      body: { port: 8400, reviewer_github_user: "old-reviewer", projects: [] },
+    });
+    assert.equal(staleFullSave.status, 200, "stale whole-config save succeeds");
+    assert.equal(JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")).reviewer_github_user, "reviewer-bot", "scoped reviewer user survives stale whole-config PUT");
+
     const clearUser = await req(server, { method: "PUT", urlPath: "/api/reviewer-github-user", body: { reviewer_github_user: "" } });
     assert.equal(clearUser.status, 200, "blank reviewer user clears value");
     assert.equal(JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")).reviewer_github_user, undefined, "config key removed when blank");

--- a/server/routes.reviewerAccountSettings.test.js
+++ b/server/routes.reviewerAccountSettings.test.js
@@ -133,11 +133,12 @@ function req(server, { method = "GET", urlPath, body } = {}) {
     assert.equal(fs.existsSync(TOKEN_PATH), false, "blank token does not create file");
     console.log("  PASS: blank token validation");
 
-    const saved = await req(server, { method: "POST", urlPath: "/api/setup/save-token", body: { token: "ghp_secret_value" } });
+    const placeholderToken = "test-reviewer-token-placeholder";
+    const saved = await req(server, { method: "POST", urlPath: "/api/setup/save-token", body: { token: placeholderToken } });
     assert.equal(saved.status, 200, "token save succeeds");
     assert.equal(saved.json.ok, true, "token save returns ok");
-    assert.ok(!JSON.stringify(saved.json).includes("ghp_secret_value"), "save response does not echo token");
-    assert.equal(fs.readFileSync(TOKEN_PATH, "utf-8"), "ghp_secret_value\n", "token written with newline");
+    assert.ok(!JSON.stringify(saved.json).includes(placeholderToken), "save response does not echo token");
+    assert.equal(fs.readFileSync(TOKEN_PATH, "utf-8"), `${placeholderToken}\n`, "token written with newline");
     assert.equal(fs.statSync(TOKEN_PATH).mode & 0o777, 0o600, "token file mode is 0600");
     status = await req(server, { urlPath: "/api/setup/reviewer-token-status" });
     assert.equal(status.json.exists, true, "saved token reports exists=true");

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -91,11 +91,20 @@ const COPY = {
     defaultAgentCli: "Default agent CLI",
     reviewerGithubUser: "Reviewer GitHub user",
     reviewerGithubToken: "Reviewer GitHub token",
+    reviewerAccount: "Reviewer Account",
+    reviewerAccountHelp:
+      "Global reviewer credentials for RE1/RE2 across all projects. The token value is written to ~/.quadwork/reviewer-token (mode 0600), is never returned by the API, and is not rendered after save.",
+    reviewerTokenStatus: "Token status",
+    tokenPath: "Token path",
     configured: "Configured",
     notConfigured: "Not configured",
     pasteNewToken: "Paste new token",
+    saveToken: "Save token",
+    saveReviewerUser: "Save reviewer user",
+    tokenSaved: "Token saved",
+    reviewerUserSaved: "Reviewer user saved",
     defaultsHelp:
-      "The default CLI seeds new project agents. The reviewer GitHub user/token are used by RE1/RE2 to post PR review comments without your personal token. The token is written to ~/.quadwork/reviewer-token (mode 0600) and is never returned by the API.",
+      "The default CLI seeds new project agents. Reviewer account credentials are configured in the global Reviewer Account section below.",
     system: "System",
     keepAwake: "Keep Awake",
     on: "on",
@@ -169,11 +178,20 @@ const COPY = {
     defaultAgentCli: "기본 에이전트 CLI",
     reviewerGithubUser: "리뷰어 GitHub 사용자",
     reviewerGithubToken: "리뷰어 GitHub 토큰",
+    reviewerAccount: "리뷰어 계정",
+    reviewerAccountHelp:
+      "모든 프로젝트의 RE1/RE2가 사용하는 전역 리뷰어 인증 정보입니다. 토큰 값은 ~/.quadwork/reviewer-token (권한 0600)에 저장되며 API로 반환되지 않고 저장 후 화면에 표시되지 않습니다.",
+    reviewerTokenStatus: "토큰 상태",
+    tokenPath: "토큰 경로",
     configured: "설정됨",
     notConfigured: "미설정",
     pasteNewToken: "새 토큰 붙여넣기",
+    saveToken: "토큰 저장",
+    saveReviewerUser: "리뷰어 사용자 저장",
+    tokenSaved: "토큰 저장됨",
+    reviewerUserSaved: "리뷰어 사용자 저장됨",
     defaultsHelp:
-      "기본 CLI는 새 프로젝트 에이전트의 초기값으로 사용됩니다. 리뷰어 GitHub 사용자/토큰은 개인 토큰 없이 RE1/RE2가 PR 리뷰 댓글을 남길 때 사용됩니다. 토큰은 ~/.quadwork/reviewer-token (권한 0600)에 저장되며 API로는 반환되지 않습니다.",
+      "기본 CLI는 새 프로젝트 에이전트의 초기값으로 사용됩니다. 리뷰어 계정 인증 정보는 아래 전역 리뷰어 계정 섹션에서 설정합니다.",
     system: "시스템",
     keepAwake: "절전 방지",
     on: "켜짐",
@@ -375,8 +393,13 @@ export default function SettingsPage() {
   // #212: reviewer-token presence + Keep Awake state for the new
   // global Settings sub-sections.
   const [reviewerTokenExists, setReviewerTokenExists] = useState<boolean | null>(null);
+  const [reviewerTokenPath, setReviewerTokenPath] = useState("");
   const [reviewerTokenInput, setReviewerTokenInput] = useState("");
   const [reviewerTokenSaving, setReviewerTokenSaving] = useState(false);
+  const [reviewerTokenMessage, setReviewerTokenMessage] = useState("");
+  const [reviewerUserDraft, setReviewerUserDraft] = useState("");
+  const [reviewerUserSaving, setReviewerUserSaving] = useState(false);
+  const [reviewerUserMessage, setReviewerUserMessage] = useState("");
   const [keepAwakeActive, setKeepAwakeActive] = useState(false);
   const [keepAwakeBusy, setKeepAwakeBusy] = useState(false);
   const [butlerRunning, setButlerRunning] = useState(false);
@@ -384,9 +407,15 @@ export default function SettingsPage() {
 
   const refreshReviewerTokenStatus = useCallback(() => {
     fetch("/api/setup/reviewer-token-status")
-      .then((r) => (r.ok ? r.json() : { exists: false }))
-      .then((d) => setReviewerTokenExists(!!d.exists))
-      .catch(() => setReviewerTokenExists(false));
+      .then((r) => (r.ok ? r.json() : { exists: false, path: "" }))
+      .then((d) => {
+        setReviewerTokenExists(!!d.exists);
+        setReviewerTokenPath(typeof d.path === "string" ? d.path : "");
+      })
+      .catch(() => {
+        setReviewerTokenExists(false);
+        setReviewerTokenPath("");
+      });
   }, []);
 
   const refreshKeepAwake = useCallback(() => {
@@ -415,9 +444,14 @@ export default function SettingsPage() {
     refreshButlerStatus();
   }, [refreshReviewerTokenStatus, refreshKeepAwake, refreshButlerStatus]);
 
+  useEffect(() => {
+    if (config) setReviewerUserDraft(config.reviewer_github_user || "");
+  }, [config?.reviewer_github_user]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const saveReviewerToken = async () => {
     if (!reviewerTokenInput.trim()) return;
     setReviewerTokenSaving(true);
+    setReviewerTokenMessage("");
     try {
       const r = await fetch("/api/setup/save-token", {
         method: "POST",
@@ -427,9 +461,48 @@ export default function SettingsPage() {
       if (r.ok) {
         setReviewerTokenInput("");
         refreshReviewerTokenStatus();
+        setReviewerTokenMessage(t.tokenSaved);
+      } else {
+        const data = await r.json().catch(() => ({}));
+        setReviewerTokenMessage(data.error || "Failed to save token");
       }
+    } catch {
+      setReviewerTokenMessage("Failed to save token");
     } finally {
       setReviewerTokenSaving(false);
+    }
+  };
+
+  const saveReviewerUser = async () => {
+    if (!config) return;
+    setReviewerUserSaving(true);
+    setReviewerUserMessage("");
+    try {
+      const r = await fetch("/api/reviewer-github-user", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviewer_github_user: reviewerUserDraft.trim() }),
+      });
+      const data = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        setReviewerUserMessage(data.error || "Failed to save reviewer user");
+        return;
+      }
+      const next = { ...config, reviewer_github_user: data.reviewer_github_user || "" };
+      setConfig(next);
+      try {
+        const saved = JSON.parse(savedConfigRef.current || "{}");
+        saved.reviewer_github_user = data.reviewer_github_user || "";
+        savedConfigRef.current = JSON.stringify(saved);
+      } catch {
+        savedConfigRef.current = JSON.stringify(next);
+      }
+      setReviewerUserDraft(data.reviewer_github_user || "");
+      setReviewerUserMessage(t.reviewerUserSaved);
+    } catch {
+      setReviewerUserMessage("Failed to save reviewer user");
+    } finally {
+      setReviewerUserSaving(false);
     }
   };
 
@@ -769,7 +842,7 @@ export default function SettingsPage() {
         </p>
       </section>
 
-      {/* Defaults — default agent CLI + reviewer credentials (#212) */}
+      {/* Defaults — default agent CLI (#212) */}
       <section className="mb-8">
         <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">{t.defaults}</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 items-end">
@@ -782,41 +855,87 @@ export default function SettingsPage() {
               label: b.label + (cliStatus && !cliStatus[b.value as keyof typeof cliStatus] ? " (not installed)" : ""),
             }))}
           />
-          <Input
-            label={t.reviewerGithubUser}
-            value={config.reviewer_github_user || ""}
-            onChange={(v) => updateGlobal("reviewer_github_user" as keyof Config, v)}
-            placeholder="reviewer-bot"
-          />
-          <div className="flex flex-col gap-1">
-            <label className="text-[11px] text-text-muted uppercase tracking-wider">{t.reviewerGithubToken}</label>
-            <div className="flex items-center gap-2">
-              <span className={`w-1.5 h-1.5 rounded-full ${reviewerTokenExists ? "bg-accent" : "bg-text-muted"}`} />
-              <span className="text-[11px] text-text-muted">
-                {reviewerTokenExists === null ? "…" : reviewerTokenExists ? t.configured : t.notConfigured}
-              </span>
-            </div>
-            <div className="flex items-center gap-1.5 mt-1">
-              <input
-                type="password"
-                value={reviewerTokenInput}
-                onChange={(e) => setReviewerTokenInput(e.target.value)}
-                placeholder={t.pasteNewToken}
-                className="flex-1 bg-transparent border border-border px-2 py-1 text-[11px] text-text outline-none focus:border-accent font-mono"
-              />
-              <button
-                onClick={saveReviewerToken}
-                disabled={reviewerTokenSaving || !reviewerTokenInput.trim()}
-                className="px-2 py-1 text-[11px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 transition-colors"
-              >
-                {reviewerTokenSaving ? t.saving : t.save}
-              </button>
-            </div>
-          </div>
         </div>
         <p className="mt-2 text-[10px] text-text-muted leading-snug">
           {t.defaultsHelp}
         </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-[11px] text-text-muted uppercase tracking-wider mb-3">{t.reviewerAccount}</h2>
+        <div className="border border-border p-4 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(280px,1fr)] gap-4">
+          <div className="flex flex-col gap-3">
+            <div>
+              <div className="text-[11px] text-text-muted uppercase tracking-wider mb-1">{t.reviewerTokenStatus}</div>
+              <div className="flex items-center gap-2">
+                <span className={`w-1.5 h-1.5 rounded-full ${reviewerTokenExists ? "bg-accent" : "bg-text-muted"}`} />
+                <span className="text-[12px] text-text">
+                  {reviewerTokenExists === null ? "…" : reviewerTokenExists ? `${t.configured} ✓` : t.notConfigured}
+                </span>
+              </div>
+              {reviewerTokenPath && (
+                <div className="mt-1 text-[10px] text-text-muted font-mono break-all">
+                  {t.tokenPath}: {reviewerTokenPath}
+                </div>
+              )}
+            </div>
+            <div>
+              <label className="text-[11px] text-text-muted uppercase tracking-wider">{t.reviewerGithubToken}</label>
+              <div className="flex flex-col sm:flex-row gap-2 mt-1">
+                <input
+                  type="password"
+                  value={reviewerTokenInput}
+                  onChange={(e) => {
+                    setReviewerTokenInput(e.target.value);
+                    setReviewerTokenMessage("");
+                  }}
+                  placeholder={t.pasteNewToken}
+                  className="flex-1 min-w-0 bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent font-mono"
+                  autoComplete="new-password"
+                />
+                <button
+                  onClick={saveReviewerToken}
+                  disabled={reviewerTokenSaving || !reviewerTokenInput.trim()}
+                  className="px-3 py-1.5 text-[12px] font-semibold text-bg bg-accent hover:bg-accent-dim disabled:opacity-50 transition-colors"
+                >
+                  {reviewerTokenSaving ? t.saving : t.saveToken}
+                </button>
+              </div>
+              {reviewerTokenMessage && (
+                <p className="mt-1 text-[10px] text-text-muted">{reviewerTokenMessage}</p>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-col gap-3">
+            <div>
+              <label className="text-[11px] text-text-muted uppercase tracking-wider">{t.reviewerGithubUser}</label>
+              <div className="flex flex-col sm:flex-row gap-2 mt-1">
+                <input
+                  value={reviewerUserDraft}
+                  onChange={(e) => {
+                    setReviewerUserDraft(e.target.value);
+                    setReviewerUserMessage("");
+                  }}
+                  placeholder="reviewer-bot"
+                  className="flex-1 min-w-0 bg-transparent border border-border px-2 py-1.5 text-[12px] text-text outline-none focus:border-accent"
+                />
+                <button
+                  onClick={saveReviewerUser}
+                  disabled={reviewerUserSaving || reviewerUserDraft.trim() === (config.reviewer_github_user || "")}
+                  className="px-3 py-1.5 text-[12px] border border-border text-text-muted hover:text-text hover:border-accent disabled:opacity-50 transition-colors"
+                >
+                  {reviewerUserSaving ? t.saving : t.save}
+                </button>
+              </div>
+              {reviewerUserMessage && (
+                <p className="mt-1 text-[10px] text-text-muted">{reviewerUserMessage}</p>
+              )}
+            </div>
+            <p className="text-[10px] text-text-muted leading-snug">
+              {t.reviewerAccountHelp}
+            </p>
+          </div>
+        </div>
       </section>
 
       {/* System — Keep Awake (#212) */}


### PR DESCRIPTION
Fixes #949

## Summary
- Add a dedicated global Reviewer Account section in Settings with token configured status, token path, password-style token rotation, and reviewer GitHub user editing.
- Add field-scoped `PUT /api/reviewer-github-user` with GitHub username validation, avoiding whole-config clobber for this setting.
- Tighten reviewer token save validation so blank tokens are rejected; token status/save responses never include the token value.

## Verification
- `node server/routes.reviewerAccountSettings.test.js` PASS (5/0)
- `node --check server/routes.js && node --check server/routes.reviewerAccountSettings.test.js` PASS
- `npx tsc --noEmit` PASS
- `npm run build` PASS
- `npm test` discovers and passes `server/routes.reviewerAccountSettings.test.js`; full run still has the same 11 unrelated temp-file write failures with `errno -122` before assertions.