### PR TITLE
[#958] Add Fable 5 (claude-fable-5) to the agent model catalog

### DIFF
--- a/server/agentModels.test.js
+++ b/server/agentModels.test.js
@@ -53,6 +53,7 @@ ok(sanitizeModel("codex", "sonnet") === "gpt-5.4", "#931 core: saving a codex ag
 ok(sanitizeModel("gemini", "opus") === "gemini-2.5-pro", "sanitizeModel heals a Claude model on a gemini agent");
 ok(sanitizeModel("codex", "gpt-4o") === "gpt-4o", "sanitizeModel keeps an already-valid codex model");
 ok(sanitizeModel("claude", "claude-opus-4-8") === "claude-opus-4-8", "sanitizeModel keeps a valid pinned claude model");
+ok(sanitizeModel("claude", "claude-fable-5") === "claude-fable-5", "#958: sanitizeModel keeps claude-fable-5 (new family, not covered by the opus/sonnet aliases)");
 ok(sanitizeModel("codex", "") === "", "sanitizeModel keeps '' (CLI default) — valid for every CLI, never clobbered");
 ok(sanitizeModel("gemini", undefined) === "", "sanitizeModel maps undefined → '' (CLI default), not a fabricated model");
 

--- a/src/lib/agentModels.ts
+++ b/src/lib/agentModels.ts
@@ -22,6 +22,11 @@ export const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> =
     // want a specific version locked in.
     { value: "opus", label: "opus (latest)" },
     { value: "sonnet", label: "sonnet (latest)" },
+    // #958: Fable 5 is a new model family, so the opus/sonnet aliases above
+    // never resolve to it — it needs its own pinned row. Deliberately NOT the
+    // first concrete row: modelsForBackend("claude")[0] ("opus") is the
+    // default/heal target and must stay put (#931).
+    { value: "claude-fable-5", label: "claude-fable-5" },
     { value: "claude-opus-4-8", label: "claude-opus-4-8" },
     { value: "claude-opus-4-7", label: "claude-opus-4-7" },
     { value: "claude-opus-4-6", label: "claude-opus-4-6" },


### PR DESCRIPTION
Fixes #958

## What

Adds `claude-fable-5` as a pinned row in `MODEL_OPTIONS.claude` (`src/lib/agentModels.ts`), so Fable 5 is selectable in the Agent Models widget, the Settings inline dropdowns, and the Butler model picker.

## Why

Fable 5 is a new model **family** — the existing `opus`/`sonnet` "latest" aliases never resolve to it, so it needs an explicit catalog entry (#958).

## Safety (per the #958 risk review)

- **Ordering preserved**: added AFTER the `opus`/`sonnet` aliases — `modelsForBackend("claude")[0]` stays `opus`, so the default/heal target is unchanged (no #931 regression). Guard test still passes.
- **Frontend-only**: the server never imports the catalog; it forwards the slug verbatim as `--model claude-fable-5` (`server/index.js`). No server change.
- **New test**: `sanitizeModel("claude", "claude-fable-5")` keeps the value (assertion added to `server/agentModels.test.js`).

## Verification

- `node server/run-tests.js` → **52 files passed, 0 failed** (new assertion confirmed PASS in `agentModels.test.js`: 27 assertions).
- `npm run build` → succeeds; dropdown options ship in `out/` at next publish (`out/` is gitignored, built at prepack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)