### PR TITLE
[#964] 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "2.3.9",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "2.3.9",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "2.3.9",
+  "version": "2.4.0",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js",


### PR DESCRIPTION
Fixes #964

## EPIC Alignment
- **Parent:** none — standalone
- **Epic goal:** n/a
- **This PR's role:** Version bump 2.3.9 → 2.4.0 so the merged agent-guidelines-v7 templates (#962 / PR #963) ship and trigger auto-reseed (#856) on upgraded installs.
- **Contracts consumed/exposed:** version fields only; minor bump per standing convention (no major without operator confirmation)
- **Fits with merged siblings:** follows PR #963 (the release payload); no other unreleased changes on main

## Self-Verification
- Bump: `npm version minor --no-git-tag-version` → v2.4.0; diff = package.json + package-lock.json only (+3/−3)
- Tests: `node --test server/pack-smoke.test.js` → pass 1, fail 0
- Kill-list scan: clean (version fields only)

## Deviations
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
