### PR TITLE
[#976] Add CI test-gate, release gate, and pack-smoke asset coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+# CI test-gate (#976, EPIC #967 Phase 0). Runs the server discovery suite on
+# every PR and on push to main so a red suite blocks merge. Node 24.x matches
+# the VPS runtime. `npm test` runs `node server/run-tests.js`, which includes
+# the pack-smoke guard (#937/#939) that only ran on manual invocation before.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Reference: [plotlink at `pre-design-overhaul`](https://github.com/realproject7/p
 
 - AgentChattr: external dependency, cloned to `~/.quadwork/agentchattr` and run via `.venv/bin/python run.py`
 - Telegram bridge: external (`realproject7/agentchattr-telegram`), optional
-- Any new shared module `require`d by Node runtime code (`bin/`, `server/`) must live under a shipped dir or be added to `package.json` `files` — otherwise it's missing from the published tarball and crash-loops on fresh install (#937/#939). `server/pack-smoke.test.js` guards this in CI.
+- Any new shared module `require`d by Node runtime code (`bin/`, `server/`) must live under a shipped dir or be added to `package.json` `files` — otherwise it's missing from the published tarball and crash-loops on fresh install (#937/#939). `server/pack-smoke.test.js` guards this; CI (`.github/workflows/ci.yml`) runs the suite on every PR and push to main (#976).
 
 ## Running locally
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint",
     "server": "node server/",
     "test": "node server/run-tests.js",
+    "prepublishOnly": "npm test",
     "prepack": "npm run build",
     "release:patch": "npm version patch && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",
     "release:minor": "npm version minor && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",

--- a/server/pack-smoke.test.js
+++ b/server/pack-smoke.test.js
@@ -106,9 +106,44 @@ const REQUIRE_RE = /require\(\s*["'](\.[^"']*)["']\s*\)/g;
     'src/lib/injectMode.js is require()d by runtime code and must stay in the tarball (#937)',
   );
 
+  // 5) fs-loaded / dynamically-required assets the literal-require scan can't
+  //    see (#976). These are read at runtime by path (seed reseeding reads the
+  //    template files; the operator MCP loads its tool modules dynamically), so
+  //    a `files` regression that drops them wouldn't trip the require scan above
+  //    — it would only surface as a broken install. Assert they ship.
+  const assetTargets = [];
+
+  // Seed templates: every AGENTS.md seed + the top-level CLAUDE.md template.
+  const seedDir = path.join(ROOT, "templates", "seeds");
+  const seedFiles = fs
+    .readdirSync(seedDir)
+    .filter((f) => f.endsWith(".AGENTS.md"))
+    .map((f) => `templates/seeds/${f}`);
+  assert.ok(seedFiles.length > 0, "found template AGENTS.md seeds to check");
+  assetTargets.push(...seedFiles, "templates/CLAUDE.md");
+
+  // Operator MCP tool modules (dynamically loaded, not literal-required).
+  const toolsDir = path.join(ROOT, "server", "mcp-operator", "tools");
+  const toolFiles = fs
+    .readdirSync(toolsDir)
+    .filter((f) => f.endsWith(".js") && !f.endsWith(".test.js"))
+    .map((f) => `server/mcp-operator/tools/${f}`);
+  assert.ok(toolFiles.length > 0, "found operator MCP tool modules to check");
+  assetTargets.push(...toolFiles);
+
+  const missingAssets = assetTargets.filter((t) => !shipped.has(t));
+  assert.deepEqual(
+    missingAssets,
+    [],
+    `Runtime assets missing from the npm tarball — published install would be ` +
+      `broken (#976). Add the path(s) to package.json "files":\n` +
+      missingAssets.map((m) => `  ${m} (NOT in tarball)`).join("\n"),
+  );
+
   console.log(
     `PASS: pack-smoke — ${shippedNodeSrc.length} shipped Node files scanned, ` +
-      `all relative requires resolve inside the tarball`,
+      `all relative requires resolve inside the tarball; ` +
+      `${assetTargets.length} runtime assets present`,
   );
   console.log("server/pack-smoke.test.js: all assertions passed");
   process.exit(0);


### PR DESCRIPTION
Closes #976

## Summary
Phase 0 of EPIC #967 — the repo had **no CI**, so the pack-smoke crash-loop guard (#937/#939) only ran on manual `npm test`, and the `release:*` scripts published with no test step. This adds real CI + a publish gate, and extends pack-smoke to cover assets the literal-`require` scan can't see.

- **`.github/workflows/ci.yml`** — runs `npm test` (`node server/run-tests.js`) on every PR and on push to `main`. Node 24.x (matches the VPS), `npm ci` with npm cache.
- **`package.json`** — adds `"prepublishOnly": "npm test"`. `npm publish` runs `prepublishOnly` before `prepack`, so a red suite aborts publish (and before the expensive `next build`) across the `release:*` path.
- **`server/pack-smoke.test.js`** — new assertion block: `templates/seeds/*.AGENTS.md`, `templates/CLAUDE.md`, and the operator MCP tool modules (`server/mcp-operator/tools/*.js`, excluding `.test.js`) must appear in the `npm pack` file list. These are fs-loaded / dynamically-required at runtime, so a `files` regression that drops them wouldn't trip the existing literal-`require` scan.
- **`CLAUDE.md`** — corrects the false "guards this in CI" claim to reference the new workflow now that CI exists.

No runtime code changes. Does not touch port 8400 / the live orchestrator.

## EPIC Alignment
Parent epic: **#967 — QuadWork v2.4.0 hardening & quality pass**. This is the epic's **Phase 0 safety net**: it makes PRs actually run the existing `server/run-tests.js` discovery suite so every later sub-ticket is guarded against regressions. Respects the epic contract — runs the existing runner unchanged, no test-semantics changes. Per the epic plan, **this must merge before any other sub-ticket dispatches.**

## Self-Verification
- [x] `npm test` locally: **52 passed, 0 failed, 2 skipped** (the two Jest-style tests skipped per #836 scope). Ticket cited 45; the suite has grown since.
- [x] Extended `server/pack-smoke.test.js` passes: `11 runtime assets present` (4 AGENTS.md seeds + `templates/CLAUDE.md` + 6 operator MCP tool modules), all confirmed in the `npm pack --dry-run --json` output.
- [x] `.github/workflows/ci.yml` validated as well-formed YAML; no untrusted input used in `run:` steps (no injection surface).
- [x] `prepublishOnly` gates publish: it runs on `npm publish` only (not on `npm pack --ignore-scripts`, so it doesn't perturb the pack-smoke test).
- [x] Existing 45+ tests still pass; no runtime files changed (`CLAUDE.md`, `package.json`, `pack-smoke.test.js`, `ci.yml` only).
- [x] Staged explicit paths only — unrelated untracked `AGENTS.md`/`DESIGN-GUIDE.md` kept out of the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)