### PR TITLE
[#969] Fix QueueManager markdown XSS via react-markdown

### DIFF
--- a/server/queueManagerXss.test.js
+++ b/server/queueManagerXss.test.js
@@ -1,0 +1,117 @@
+// #969: QueueManager markdown XSS guard (EPIC #967 Phase 1).
+//
+// QueueManager's preview used to build HTML with a hand-rolled `renderMarkdown`
+// and inject it via `dangerouslySetInnerHTML`. GitHub issue titles flow into
+// that markdown (generateTemplate, line ~50: `... — ${issue.title}`), so a
+// title like `[x](javascript:alert(1))` or one with an attribute-breakout
+// (`" onmouseover=...`) produced a live, executable link. The fix replaces the
+// renderer with react-markdown (no rehype-raw), matching the safe pattern in
+// OvernightQueueWidget.tsx.
+//
+// This test has two halves:
+//   (A) Static guard — the component must not regress back to raw-HTML
+//       injection or the hand-rolled renderer.
+//   (B) Behavioral guard — render react-markdown (the renderer QueueManager now
+//       uses) over a queue line carrying a malicious issue title and assert the
+//       output is inert (no javascript: href, no raw HTML element), while
+//       ordinary markdown still renders as real tags.
+//
+// Runs under the plain-node runner: react-markdown is ESM (dynamic import) and
+// react-dom/server renders to a string with no DOM. Run with
+// `node server/queueManagerXss.test.js`.
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+const ROOT = path.resolve(__dirname, "..");
+const COMPONENT = path.join(ROOT, "src", "components", "QueueManager.tsx");
+
+// (A) Static guard: no raw-HTML injection path survives in the component.
+function staticGuard() {
+  const src = fs.readFileSync(COMPONENT, "utf8");
+  assert.ok(
+    !/dangerouslySetInnerHTML/.test(src),
+    "QueueManager must not use dangerouslySetInnerHTML (#969)",
+  );
+  assert.ok(
+    !/function\s+renderMarkdown/.test(src),
+    "QueueManager must not reintroduce the hand-rolled renderMarkdown (#969)",
+  );
+  assert.ok(
+    /from\s+["']react-markdown["']/.test(src) && /<ReactMarkdown/.test(src),
+    "QueueManager must render the preview via react-markdown (#969)",
+  );
+}
+
+// (B) Behavioral guard against the actual renderer.
+async function behavioralGuard() {
+  const { default: ReactMarkdown } = await import("react-markdown");
+  const render = (md) => renderToStaticMarkup(React.createElement(ReactMarkdown, null, md));
+
+  // Malicious issue titles, embedded exactly as generateTemplate does
+  // (`${i + 1}. [${repo}#${n}](url) — ${issue.title}`).
+  const line = (n, title) =>
+    `${n}. [o/r#${n}](https://github.com/o/r/issues/${n}) — ${title}`;
+
+  const attackTitles = [
+    "Fix [click me](javascript:alert(1)) crash", // javascript: link
+    'Broken "](javascript:alert(2)) title', // attribute-breakout attempt
+    '<img src=x onerror=alert(3)> title', // raw HTML element
+    'title with onmouseover="alert(4)" attr', // event-handler attribute
+  ];
+
+  for (const [i, title] of attackTitles.entries()) {
+    const html = render(line(i + 1, title));
+    // No anchor may carry a javascript: (or other unsafe) URL.
+    assert.ok(
+      !/href\s*=\s*["']\s*javascript:/i.test(html),
+      `malicious title #${i + 1} produced a javascript: href: ${html}`,
+    );
+    // Raw HTML must be escaped, never emitted as real elements/handlers.
+    assert.ok(!/<img/i.test(html), `raw <img> survived for title #${i + 1}: ${html}`);
+    assert.ok(!/<script/i.test(html), `raw <script> survived for title #${i + 1}: ${html}`);
+    // An event handler is only dangerous inside a real opening tag; escaped
+    // text like `&lt;img onerror=...&gt;` is inert. Match on*= only within `<…>`.
+    assert.ok(
+      !/<[a-z][a-z0-9]*\b[^>]*\son[a-z]+\s*=/i.test(html),
+      `live event-handler attribute survived for title #${i + 1}: ${html}`,
+    );
+  }
+
+  // The raw-HTML title must be escaped (rendered as text, not a live element).
+  assert.match(
+    render(line(3, "<img src=x onerror=alert(3)> title")),
+    /&lt;img src=x onerror=alert\(3\)&gt;/,
+    "raw HTML in a title must be escaped to inert text",
+  );
+
+  // The specific javascript: link is neutralized to an empty href, not dropped
+  // to plain text — proves react-markdown's URL sanitization is the mechanism.
+  const neutralized = render(line(1, "Fix [click me](javascript:alert(1)) crash"));
+  assert.ok(
+    /<a href="">click me<\/a>/.test(neutralized),
+    `expected the javascript: link to be neutralized to an empty href: ${neutralized}`,
+  );
+
+  // Positive control: legitimate markdown still renders as real tags so the
+  // preview keeps working (headings, lists, bold, code, safe links).
+  const ok = render("# H1\n\n## H2\n\n- item **bold** `code` [link](https://ok.com)");
+  assert.match(ok, /<h1>H1<\/h1>/, "heading renders");
+  assert.match(ok, /<h2>H2<\/h2>/, "subheading renders");
+  assert.match(ok, /<li>.*<strong>bold<\/strong>/s, "list item + bold render");
+  assert.match(ok, /<code>code<\/code>/, "inline code renders");
+  assert.match(ok, /<a href="https:\/\/ok\.com">link<\/a>/, "safe link renders");
+}
+
+(async () => {
+  staticGuard();
+  await behavioralGuard();
+  console.log("server/queueManagerXss.test.js: all assertions passed");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -1,24 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
-
-/** Simple markdown to HTML for preview (headings, lists, bold, code, links) */
-function renderMarkdown(md: string): string {
-  return md
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/^### (.+)$/gm, '<h3 class="text-sm font-semibold text-text mt-3 mb-1">$1</h3>')
-    .replace(/^## (.+)$/gm, '<h2 class="text-sm font-semibold text-accent mt-4 mb-1">$1</h2>')
-    .replace(/^# (.+)$/gm, '<h1 class="text-base font-bold text-text mt-2 mb-2">$1</h1>')
-    .replace(/^\d+\. (.+)$/gm, '<div class="pl-4 text-text">• $1</div>')
-    .replace(/^- (.+)$/gm, '<div class="pl-4 text-text-muted">– $1</div>')
-    .replace(/\*\*(.+?)\*\*/g, '<strong class="text-text">$1</strong>')
-    .replace(/`([^`]+)`/g, '<code class="text-accent text-[11px] bg-bg px-1">$1</code>')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener" class="text-accent hover:underline">$1</a>')
-    .replace(/\n\n/g, '<div class="h-2"></div>')
-    .replace(/\n/g, "<br>");
-}
+import { useState, useEffect, useCallback } from "react";
+import ReactMarkdown from "react-markdown";
 
 interface Issue {
   number: number;
@@ -124,7 +107,6 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
     URL.revokeObjectURL(url);
   };
 
-  const renderedPreview = useMemo(() => renderMarkdown(content), [content]);
   const prompt = generatePrompt(content, repo);
 
   const copyPrompt = async () => {
@@ -247,7 +229,22 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
           </div>
           <div className="flex-1 overflow-y-auto p-3 text-[12px] text-text">
             {content ? (
-              <div dangerouslySetInnerHTML={{ __html: renderedPreview }} />
+              // react-markdown (no raw-HTML/rehype-raw) renders untrusted GitHub
+              // issue titles inertly — javascript: hrefs are stripped and any raw
+              // HTML is escaped (#969). Mirrors the safe pattern in
+              // OvernightQueueWidget.tsx.
+              <div className="text-[12px] text-text
+                [&_h1]:text-base [&_h1]:font-bold [&_h1]:text-text [&_h1]:mt-2 [&_h1]:mb-2
+                [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-accent [&_h2]:mt-4 [&_h2]:mb-1
+                [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-text [&_h3]:mt-3 [&_h3]:mb-1
+                [&_p]:my-1.5
+                [&_ul]:my-1.5 [&_ul]:pl-4 [&_ul]:list-disc [&_ul]:text-text-muted
+                [&_ol]:my-1.5 [&_ol]:pl-4 [&_ol]:list-decimal
+                [&_li]:my-0.5 [&_strong]:text-text
+                [&_code]:text-accent [&_code]:text-[11px] [&_code]:bg-bg [&_code]:px-1
+                [&_a]:text-accent [&_a]:hover:underline">
+                <ReactMarkdown>{content}</ReactMarkdown>
+              </div>
             ) : (
               <span className="text-text-muted">Preview will appear here...</span>
             )}

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -243,7 +243,19 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
                 [&_li]:my-0.5 [&_strong]:text-text
                 [&_code]:text-accent [&_code]:text-[11px] [&_code]:bg-bg [&_code]:px-1
                 [&_a]:text-accent [&_a]:hover:underline">
-                <ReactMarkdown>{content}</ReactMarkdown>
+                <ReactMarkdown
+                  components={{
+                    // Preserve the prior new-tab behavior so clicking a preview
+                    // link doesn't navigate away from (and discard) the queue
+                    // editor. react-markdown still sanitizes the href.
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- drop react-markdown's `node` prop; it's not a valid DOM attr
+                    a: ({ node, ...props }) => (
+                      <a {...props} target="_blank" rel="noopener noreferrer" />
+                    ),
+                  }}
+                >
+                  {content}
+                </ReactMarkdown>
               </div>
             ) : (
               <span className="text-text-muted">Preview will appear here...</span>


### PR DESCRIPTION
Closes #969

## Summary
`QueueManager`'s preview built HTML with a hand-rolled `renderMarkdown` and injected it via `dangerouslySetInnerHTML`. GitHub issue titles flow into that markdown (`generateTemplate`, line ~50: `… — ${issue.title}`), so a malicious title — e.g. `[x](javascript:alert(1))` or an attribute-breakout like `" onmouseover=…` — rendered as a **live, executable link**.

- **`src/components/QueueManager.tsx`** — replace `renderMarkdown` + `dangerouslySetInnerHTML` with `<ReactMarkdown>` (already a dependency; no `rehype-raw`), mirroring the safe pattern in `OvernightQueueWidget.tsx:189`. react-markdown strips `javascript:` URLs (→ empty `href`) and escapes all raw HTML. Preview still renders headings/lists/bold/code/links, styled via Tailwind prose arbitrary-variant classes that preserve the panel's accent look. A `components.a` override keeps links opening in a new tab (prior behavior).
- **`server/queueManagerXss.test.js`** — new test: (A) a **static guard** asserting the component no longer uses `dangerouslySetInnerHTML` / the hand-rolled renderer and does render via `react-markdown`; (B) a **behavioral guard** that renders the actual renderer (`react-dom/server`) over queue lines carrying malicious issue titles and asserts the output is inert (no `javascript:` href, no raw `<img>`/`<script>`, no event-handler attribute inside a tag), plus a positive control proving normal markdown still renders real tags.

No new dependency (`react-markdown@^10.1.0` already present). No `dangerouslySetInnerHTML` remains in `QueueManager`. Only `QueueManager.tsx` touched among components.

## EPIC Alignment
Parent epic: **#967 — QuadWork v2.4.0 hardening & quality pass**. This is **Phase 1 (security)**: it closes the stored/reflected XSS in the queue preview where untrusted GitHub issue titles reach the DOM. Isolated blast radius — one component + one test, no runtime/server changes. Depends on Phase 0 (#976) CI, which now gates this PR automatically.

## Self-Verification
- [x] `node server/queueManagerXss.test.js` passes; verified the malicious `[click](javascript:alert(1))` title neutralizes to `<a href="">click</a>`, and `<img onerror=…>` / `onmouseover="…"` titles render as escaped inert text.
- [x] Full suite: **53 passed / 0 failed / 2 skipped** (`node server/run-tests.js`) — the new test raised the count from 52.
- [x] `npx tsc --noEmit` clean; `npx eslint src/components/QueueManager.tsx` clean (0 problems).
- [x] No `dangerouslySetInnerHTML` left in `QueueManager` (asserted by the test); no new dependency; no other component touched.
- [x] Branched off current main `f6aead0`; staged explicit paths only (unrelated untracked `AGENTS.md`/`DESIGN-GUIDE.md` kept out).

## Design Fidelity
Security refactor of the preview renderer; the pane is intended to look and behave as before, with rendering now done safely by react-markdown. Parity is preserved by reproducing the prior element styling as Tailwind arbitrary-variant classes on the wrapper, and a `components.a` override restores new-tab links. No layout, container, or design-token changes.

| UI element / concern | Before (hand-rolled `renderMarkdown`) | After (react-markdown) | Evidence (`file:line`) | Parity |
| --- | --- | --- | --- | --- |
| Preview container & scroll | `flex-1 overflow-y-auto p-3 text-[12px] text-text` | unchanged (same wrapper) | `src/components/QueueManager.tsx:230` | Identical |
| Split layout (editor \| preview) | `grid grid-cols-2` panel | unchanged | `src/components/QueueManager.tsx:211` | Identical |
| `# h1` | `text-base font-bold text-text mt-2 mb-2` | `[&_h1]:text-base [&_h1]:font-bold [&_h1]:text-text [&_h1]:mt-2 [&_h1]:mb-2` | `src/components/QueueManager.tsx:237` | Identical |
| `## h2` (accent) | `text-sm font-semibold text-accent mt-4 mb-1` | `[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-accent [&_h2]:mt-4 [&_h2]:mb-1` | `src/components/QueueManager.tsx:238` | Identical |
| `### h3` | `text-sm font-semibold text-text mt-3 mb-1` | `[&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-text [&_h3]:mt-3 [&_h3]:mb-1` | `src/components/QueueManager.tsx:239` | Identical |
| Ordered list (`1.`) | flattened to `pl-4 text-text` div w/ `•` | real `<ol>`: `[&_ol]:my-1.5 [&_ol]:pl-4 [&_ol]:list-decimal` | `src/components/QueueManager.tsx:242` | Improved (true numbered list; same indent) |
| Unordered list (`-`) | flattened to `pl-4 text-text-muted` div w/ `–` | real `<ul>`: `[&_ul]:pl-4 [&_ul]:list-disc [&_ul]:text-text-muted` | `src/components/QueueManager.tsx:241` | Equivalent (muted, indented bullets) |
| Bold `**` | `text-text` | `[&_strong]:text-text` | `src/components/QueueManager.tsx:243` | Identical |
| Inline `code` | `text-accent text-[11px] bg-bg px-1` | `[&_code]:text-accent [&_code]:text-[11px] [&_code]:bg-bg [&_code]:px-1` | `src/components/QueueManager.tsx:244` | Identical |
| Link styling | `text-accent hover:underline` | `[&_a]:text-accent [&_a]:hover:underline` | `src/components/QueueManager.tsx:245` | Identical |
| Link new-tab behavior | `target="_blank" rel="noopener"` | `components.a` → `target="_blank" rel="noopener noreferrer"` | `src/components/QueueManager.tsx:252-253` | Identical (parity restored) |
| Empty state | `text-text-muted` placeholder | unchanged | `src/components/QueueManager.tsx:261` | Identical |
| Security rendering (the fix) | `javascript:`/raw-HTML injected live via `dangerouslySetInnerHTML` | `<ReactMarkdown>` strips `javascript:` href, escapes raw HTML | `src/components/QueueManager.tsx:246` | Intended change |

Notes:
- **Font/theme:** Geist Mono, dark-mode-only, accent `#00ff88`, sharp corners, thin borders — all inherited from the unchanged container and global tokens; no changes here.
- The only intended behavioral change is the security fix (row: *Security rendering*). All visual/interaction parity above is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)