### PR TITLE
[#970] Guard activity/log, bridge sender, reviewer-token path

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -137,6 +137,17 @@ function _expandTilde(p) {
   return p;
 }
 
+// #970: a worktree-sourced reviewer-token path comes from agent-writable
+// AGENTS.md (`GH_TOKEN=$(cat <path>)`), so the server would otherwise
+// readFileSync an arbitrary attacker-chosen path — an existence/validity
+// oracle. Confine it to under ~/.quadwork or the project's own worktree.
+function _reviewerTokenPathAllowed(absPath, wtDir) {
+  return [CONFIG_DIR, path.resolve(wtDir)].some((root) => {
+    const rel = path.relative(root, absPath);
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  });
+}
+
 function _resolveReviewerTokenPath(projectId) {
   let cfg = {};
   try { cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")); } catch { /* default-config / unreadable */ }
@@ -152,7 +163,15 @@ function _resolveReviewerTokenPath(projectId) {
         const extracted = _extractReviewerTokenPath(agentsMd);
         // #897: expand `~` here (not in _extractReviewerTokenPath — reseed needs
         // the raw value) so the read + cache key use an absolute path.
-        if (extracted) return { path: _expandTilde(extracted), source: "worktree" };
+        if (extracted) {
+          const abs = path.resolve(t.wtDir, _expandTilde(extracted));
+          // #970: only honor the agent-supplied path if it stays under an
+          // allowed root; otherwise ignore it and fall through to the operator
+          // config / default token (a crafted path can't become a read oracle).
+          if (_reviewerTokenPathAllowed(abs, t.wtDir)) {
+            return { path: abs, source: "worktree" };
+          }
+        }
       } catch { /* worktree / AGENTS.md missing → try next role */ }
     }
   }
@@ -843,6 +862,13 @@ function activityLogPath(projectId) {
 router.post("/api/activity/log", (req, res) => {
   const { project, agent, type, timestamp } = req.body || {};
   if (typeof project !== "string" || !project) return res.status(400).json({ error: "Missing project" });
+  // #970: `project` flows into path.join(CONFIG_DIR, project, "activity.jsonl")
+  // (mkdir + appendFileSync). Restrict it to a configured project id so a
+  // crafted value like "../../tmp/x" can't become an arbitrary-path write
+  // primitive (matches the project-scoping other write routes already apply).
+  if (!(readConfigFile().projects || []).some((p) => p.id === project)) {
+    return res.status(400).json({ error: "Invalid project" });
+  }
   if (typeof agent !== "string" || !agent) return res.status(400).json({ error: "Missing agent" });
   if (type !== "start" && type !== "end") return res.status(400).json({ error: "type must be start|end" });
   const ts = typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : Date.now();
@@ -978,6 +1004,13 @@ router.post("/api/chat", (req, res) => {
     sender = shimSender;
     selfMentionSkip = shimSender;
   } else if (bridgeSender && isLocalhost(req.ip)) {
+    // #970: the bridge relays external chat over localhost with no auth token;
+    // it must not be able to post under a reserved agent identity
+    // (head/dev/re1/re2/…), mirroring the reserved-sender denial on the
+    // history-import path.
+    if (RESERVED_HISTORY_SENDERS.has(bridgeSender.toLowerCase())) {
+      return res.status(403).json({ error: "Reserved sender" });
+    }
     sender = bridgeSender;
   }
   // #940: thread image attachments through. Persist only the `name`
@@ -4875,6 +4908,8 @@ module.exports._extractReviewerTokenPath = _extractReviewerTokenPath;
 // #886/#893: expose the project-aware reviewer rate-limit resolver/poll/payload
 // for tests.
 module.exports._resolveReviewerTokenPath = _resolveReviewerTokenPath;
+// #970: expose the reviewer-token-path containment predicate for the guard test.
+module.exports._reviewerTokenPathAllowed = _reviewerTokenPathAllowed;
 module.exports.getReviewerRateLimit = getReviewerRateLimit;
 module.exports.reviewerRateLimitPayload = reviewerRateLimitPayload;
 // #856: expose the auto-reseed startup hook + supporting state/version

--- a/server/routes.reviewerRateLimit.test.js
+++ b/server/routes.reviewerRateLimit.test.js
@@ -84,26 +84,28 @@ function reset() {
   // ── Resolution (pure _resolveReviewerTokenPath — no gh, no cache) ────────
 
   // custom worktree path (re1) wins
+  // #970: the worktree-sourced path is now confined to under the worktree (or
+  // ~/.quadwork), so custom paths in these fixtures live under /wt/p-re1|re2.
   reset();
   configJson = JSON.stringify({ reviewer_github_user: "interns", projects: [PROJECT] });
-  files.set(RE1_AGENTS, ghTokenLine("/custom/reviewer-token"));
+  files.set(RE1_AGENTS, ghTokenLine("/wt/p-re1/reviewer-token"));
   let r = _resolveReviewerTokenPath("p");
-  ok(r.path === "/custom/reviewer-token" && r.source === "worktree", "resolves custom worktree token path (re1) with source=worktree");
+  ok(r.path === "/wt/p-re1/reviewer-token" && r.source === "worktree", "resolves custom worktree token path (re1) with source=worktree");
 
   // worktree wins over cfg.reviewer_token_path
   reset();
   configJson = JSON.stringify({ reviewer_token_path: "/cfg/reviewer-token", projects: [PROJECT] });
-  files.set(RE1_AGENTS, ghTokenLine("/wtwins/reviewer-token"));
+  files.set(RE1_AGENTS, ghTokenLine("/wt/p-re1/wtwins-token"));
   r = _resolveReviewerTokenPath("p");
-  ok(r.path === "/wtwins/reviewer-token" && r.source === "worktree", "worktree path WINS over cfg.reviewer_token_path (reseed preservation order)");
+  ok(r.path === "/wt/p-re1/wtwins-token" && r.source === "worktree", "worktree path WINS over cfg.reviewer_token_path (reseed preservation order)");
 
   // re2 fallback when re1 AGENTS.md has no GH_TOKEN line
   reset();
   configJson = JSON.stringify({ projects: [PROJECT] });
   files.set(RE1_AGENTS, "no token here\n");
-  files.set(RE2_AGENTS, ghTokenLine("/re2/reviewer-token"));
+  files.set(RE2_AGENTS, ghTokenLine("/wt/p-re2/reviewer-token"));
   r = _resolveReviewerTokenPath("p");
-  ok(r.path === "/re2/reviewer-token" && r.source === "worktree", "falls back to re2 worktree when re1 has no GH_TOKEN line");
+  ok(r.path === "/wt/p-re2/reviewer-token" && r.source === "worktree", "falls back to re2 worktree when re1 has no GH_TOKEN line");
 
   // no project → cfg.reviewer_token_path
   reset();
@@ -158,8 +160,8 @@ function reset() {
   // custom worktree token → polled with that token; login OMITTED (stale-login guard)
   reset();
   configJson = JSON.stringify({ reviewer_github_user: "interns", projects: [PROJECT] });
-  files.set(RE1_AGENTS, ghTokenLine("/customA/reviewer-token"));
-  files.set("/customA/reviewer-token", "ghp_customA\n");
+  files.set(RE1_AGENTS, ghTokenLine("/wt/p-re1/customA-token")); // #970: under the worktree
+  files.set("/wt/p-re1/customA-token", "ghp_customA\n");
   payload = reviewerRateLimitPayload(await getReviewerRateLimit("p"));
   ok(capturedEnvToken === "ghp_customA", "polls the CUSTOM worktree token via GH_TOKEN");
   ok(payload && payload.graphql && payload.graphql.remaining === 37, "custom-path reviewer payload surfaced (graphql bucket)");
@@ -177,7 +179,7 @@ function reset() {
   reset();
   capturedEnvToken = null;
   configJson = JSON.stringify({ projects: [PROJECT] });
-  files.set(RE1_AGENTS, ghTokenLine("/notoken/reviewer-token")); // token file NOT added → ENOENT
+  files.set(RE1_AGENTS, ghTokenLine("/wt/p-re1/notoken-token")); // #970: under the worktree; token file NOT added → ENOENT
   payload = reviewerRateLimitPayload(await getReviewerRateLimit("p"));
   ok(payload === null, "no reviewer token at resolved path → payload null (omitted)");
   ok(capturedEnvToken === null, "no token → NO reviewer gh poll fired");

--- a/server/routes.securityGuards.test.js
+++ b/server/routes.securityGuards.test.js
@@ -1,0 +1,186 @@
+// #970: three isolated local-attack-surface guards in routes.js.
+//   1. POST /api/activity/log — `project` must be a configured id, else a
+//      crafted value (e.g. "../../tmp/x") is an arbitrary-path write primitive
+//      (path.join(CONFIG_DIR, project, "activity.jsonl") → mkdir + append).
+//   2. POST /api/chat over the X-Bridge-Sender path — a localhost bridge
+//      process must not be able to post under a reserved agent identity.
+//   3. _resolveReviewerTokenPath — a worktree-sourced token path (from
+//      agent-writable AGENTS.md) must stay under ~/.quadwork or the worktree,
+//      or the server would readFileSync an arbitrary path (existence oracle).
+//
+// Plain node:assert script — run with `node server/routes.securityGuards.test.js`.
+
+const assert = require("node:assert/strict");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const TEST_DIR = path.join(os.tmpdir(), `routes-secguards-${process.pid}-${Date.now()}`);
+
+// Override HOME BEFORE requiring routes/config so CONFIG_DIR resolves under the
+// temp dir (real fs, no stubbing).
+const origHome = os.homedir;
+os.homedir = () => TEST_DIR;
+
+const CONFIG_DIR = path.join(TEST_DIR, ".quadwork");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+const PROJECT = "secguards-project";
+
+// A project whose re1 worktree lives under the temp dir; its AGENTS.md is
+// written per-scenario in the guard-3 section.
+const WT_DIR = path.join(TEST_DIR, "wt", `${PROJECT}-re1`);
+fs.mkdirSync(WT_DIR, { recursive: true });
+fs.mkdirSync(CONFIG_DIR, { recursive: true });
+fs.writeFileSync(
+  CONFIG_PATH,
+  JSON.stringify({
+    projects: [{ id: PROJECT, working_dir: path.join(TEST_DIR, "wt", PROJECT), agents: { re1: { cwd: WT_DIR } } }],
+  }),
+);
+
+const fileChat = require("./file-chat");
+const routes = require("./routes");
+const { _resolveReviewerTokenPath, _reviewerTokenPathAllowed } = routes;
+const express = require("express");
+
+function cleanup() {
+  os.homedir = origHome;
+  try { fs.rmSync(TEST_DIR, { recursive: true, force: true }); } catch {}
+}
+process.on("exit", cleanup);
+
+function req(server, { method = "GET", urlPath, body, headers = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address();
+    const payload = body === undefined ? null : Buffer.from(JSON.stringify(body));
+    const r = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method,
+        path: urlPath,
+        headers: {
+          ...(payload ? { "content-type": "application/json", "content-length": payload.length } : {}),
+          ...headers,
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+      },
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+let passed = 0;
+const ok = (c, m) => { assert.ok(c, m); passed++; console.log(`  PASS: ${m}`); };
+
+(async () => {
+  fileChat.initProject(PROJECT);
+
+  const app = express();
+  app.use(express.json());
+  app.use(routes);
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+
+  try {
+    // ── Guard 1: activity/log path traversal ────────────────────────────────
+    // A valid project logs a completed session (start then end appends a row).
+    let s = await req(server, {
+      method: "POST", urlPath: "/api/activity/log",
+      body: { project: PROJECT, agent: "dev", type: "start", timestamp: 1000 },
+    });
+    ok(s.status === 200, "activity/log start for a configured project → 200");
+    s = await req(server, {
+      method: "POST", urlPath: "/api/activity/log",
+      body: { project: PROJECT, agent: "dev", type: "end", timestamp: 2000 },
+    });
+    ok(s.status === 200, "activity/log end for a configured project → 200");
+    ok(
+      fs.existsSync(path.join(CONFIG_DIR, PROJECT, "activity.jsonl")),
+      "valid project session row is appended under CONFIG_DIR/<project>/",
+    );
+
+    // A traversing project is rejected on both start and end, and writes nothing.
+    for (const type of ["start", "end"]) {
+      const trav = await req(server, {
+        method: "POST", urlPath: "/api/activity/log",
+        body: { project: "../../../tmp/x", agent: "dev", type, timestamp: 3000 },
+      });
+      ok(trav.status === 400, `activity/log ${type} with a traversing project → 400`);
+    }
+    ok(
+      !fs.existsSync(path.join(TEST_DIR, "tmp", "x", "activity.jsonl")) &&
+        !fs.existsSync(path.join(os.tmpdir(), "x", "activity.jsonl")),
+      "traversing project produced no out-of-tree write",
+    );
+    // An unconfigured (but non-traversing) project id is also rejected.
+    const ghost = await req(server, {
+      method: "POST", urlPath: "/api/activity/log",
+      body: { project: "not-a-configured-project", agent: "dev", type: "start" },
+    });
+    ok(ghost.status === 400, "activity/log with an unconfigured project id → 400");
+
+    // ── Guard 2: bridge reserved-sender ─────────────────────────────────────
+    for (const reserved of ["head", "dev", "re1", "re2", "HEAD", "system"]) {
+      const r = await req(server, {
+        method: "POST", urlPath: `/api/chat?project=${PROJECT}`,
+        headers: { "x-bridge-sender": reserved },
+        body: { text: `posing as ${reserved}` },
+      });
+      ok(r.status === 403, `bridge message claiming reserved sender "${reserved}" → 403`);
+    }
+    // A non-reserved bridge sender is accepted and attributed to that name.
+    const okBridge = await req(server, {
+      method: "POST", urlPath: `/api/chat?project=${PROJECT}`,
+      headers: { "x-bridge-sender": "discord-user" },
+      body: { text: "hello from discord" },
+    });
+    ok(okBridge.status === 200, "non-reserved bridge sender → 200");
+    ok(JSON.parse(okBridge.body).message.sender === "discord-user", "bridge sender attributed to the header name");
+
+    // ── Guard 3: reviewer-token-path scoping ────────────────────────────────
+    // Predicate: under ~/.quadwork or the worktree is allowed; anything else refused.
+    ok(_reviewerTokenPathAllowed(path.join(CONFIG_DIR, "reviewer-token"), WT_DIR), "token under ~/.quadwork allowed");
+    ok(_reviewerTokenPathAllowed(path.join(WT_DIR, "reviewer-token"), WT_DIR), "token under the worktree allowed");
+    ok(!_reviewerTokenPathAllowed("/etc/passwd", WT_DIR), "token at /etc/passwd refused");
+    ok(!_reviewerTokenPathAllowed(path.join(os.homedir(), ".ssh", "id_rsa"), WT_DIR), "token at ~/.ssh/id_rsa refused");
+    ok(!_reviewerTokenPathAllowed(path.resolve(WT_DIR, "../../../etc/passwd"), WT_DIR), "traversal out of the worktree refused");
+
+    // Integration: an out-of-root path in the worktree AGENTS.md is NOT used;
+    // resolution falls through to the default token instead.
+    fs.writeFileSync(path.join(WT_DIR, "AGENTS.md"), "export GH_TOKEN=$(cat /etc/passwd)\n");
+    let resolved = _resolveReviewerTokenPath(PROJECT);
+    ok(
+      resolved.path !== "/etc/passwd" && resolved.source !== "worktree",
+      "worktree AGENTS.md pointing at /etc/passwd is refused (falls back to default)",
+    );
+    ok(
+      resolved.path === path.join(CONFIG_DIR, "reviewer-token") && resolved.source === "default",
+      "refused worktree path → default ~/.quadwork/reviewer-token",
+    );
+
+    // An in-root worktree path IS honored.
+    const inRoot = path.join(WT_DIR, "reviewer-token");
+    fs.writeFileSync(path.join(WT_DIR, "AGENTS.md"), `export GH_TOKEN=$(cat ${inRoot})\n`);
+    resolved = _resolveReviewerTokenPath(PROJECT);
+    ok(
+      resolved.path === inRoot && resolved.source === "worktree",
+      "in-worktree token path is honored (source=worktree)",
+    );
+
+    console.log(`\n${passed} passed`);
+    console.log("server/routes.securityGuards.test.js: all assertions passed");
+  } finally {
+    server.close();
+  }
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #970

## Summary
EPIC #967 Phase 1 (security). Three confirmed, isolated local-attack-surface gaps in `server/routes.js`, each closed with a test. No unrelated routes touched.

**1. Path traversal — `POST /api/activity/log`** (`routes.js:863`)
`project` had only a non-empty-string check, then flowed into `path.join(CONFIG_DIR, project, "activity.jsonl")` → `mkdir` + `appendFileSync` — an arbitrary-path write primitive (`project: "../../../tmp/x"`). Now validated against configured project ids (`readConfigFile().projects`), which also rejects `.`/`..` and unconfigured ids.

**2. Bridge reserved-sender** (`routes.js:1004`)
The localhost `X-Bridge-Sender` path trusted the header with no reserved-name check, so a local process could post as `head`/`dev`/`re1`/`re2`. Now rejects `RESERVED_HISTORY_SENDERS` (403), mirroring the history-import denial. Non-reserved bridge senders are unaffected.

**3. Reviewer-token-path scoping** (`routes.js:150-177`)
The reviewer token path is read from agent-writable `AGENTS.md` (`GH_TOKEN=$(cat <path>)`), so a crafted path made the server `readFileSync` an arbitrary file (existence/validity oracle; contents never returned). A **worktree-sourced** path is now confined to under `~/.quadwork` or the project's own worktree; otherwise it's ignored and resolution falls through to the operator config / default token. The operator-set `cfg.reviewer_token_path` is deliberately **not** restricted — it isn't agent-writable and is the supported way to point at a custom location.

## EPIC Alignment
Parent epic **#967 — QuadWork v2.4.0 hardening & quality pass**, Phase 1 (security). Closes three isolated `routes.js` gaps; matches the existing project-scoping / `path.basename` guards other routes use. Depends on #976 (CI, now live and gating this PR). Out of scope (later): the WS auth layer (#968). Backend-only — no Design Fidelity section.

## Self-Verification
- [x] New `server/routes.securityGuards.test.js` (23 assertions) exercises all three guards end-to-end against a real Express app + real fs: valid project logs / traversing + unconfigured project → 400 with no out-of-tree write; reserved bridge senders (incl. `HEAD`, `system`) → 403 and a normal sender → 200 attributed correctly; the containment predicate + `_resolveReviewerTokenPath` refuse `/etc/passwd`, `~/.ssh/id_rsa`, and worktree traversal, honor in-root paths, and fall back to the default when refused.
- [x] `server/routes.reviewerRateLimit.test.js` fixtures updated from out-of-root paths (`/custom`, `/wtwins`, `/re2`, `/customA`, `/notoken`) to in-root worktree paths — each test's **intent preserved** (worktree wins, re2 fallback, custom-token login omitted); all 19 still pass. This is the one existing test whose assertions encoded the pre-fix (now-disallowed) behavior.
- [x] Full suite: **54 passed / 0 failed / 2 skipped** (`node server/run-tests.js`) — was 53; +1 new file. The existing 45 (now 53) still pass.
- [x] No runtime behavior change outside the three guards; branched off current main `97b9d9f`; staged explicit paths only (unrelated untracked `AGENTS.md`/`DESIGN-GUIDE.md` kept out).
- [x] `eslint` introduces no new problems (the `server/` CommonJS `require`/unused findings are pre-existing repo-wide — the eslint config targets the Next frontend; CI gates on `npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)