### PR TITLE
[#968] Auth the terminal WS + PTY-write endpoints (Origin + session token)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -141,16 +141,23 @@ are authenticated (#968). Two checks run:
    in `~/.quadwork/config.json` on first start) must accompany every terminal
    WS and PTY-write request.
 
-**Normal local use needs no action.** The dashboard fetches the token from the
-localhost-only `GET /api/session-token` endpoint and attaches it automatically.
-This also works behind a same-host reverse proxy (e.g. the nginx setup in the
-[VPS guide](install-vps.md)), because the proxy connects to QuadWork over
-`127.0.0.1`.
+**Normal local use needs no action.** When you open the dashboard on
+`http://127.0.0.1:<port>` (or `localhost`) — directly, or through an SSH tunnel
+— the dashboard fetches the token from `GET /api/session-token` and attaches it
+automatically.
+
+`/api/session-token` deliberately hands the token out **only** to a request
+whose socket, `Host`, and `Origin` are all loopback. This is on purpose: a
+malicious page using DNS rebinding, or a reverse proxy forwarding a public
+domain, keeps the socket on `127.0.0.1` while the browser's `Host` is a remote
+name — so IP alone is not enough, and those requests are refused. The token
+never leaves the box automatically.
 
 **Symptom:** Terminals show "connecting…" and never attach, or typing does
-nothing, when the dashboard is served from a **different origin** than the
-QuadWork API (e.g. a separately hosted frontend, or a proxy that rewrites the
-Origin), so `/api/session-token` isn't reachable same-origin.
+nothing, when you reach the dashboard by anything other than a loopback host —
+a **reverse proxy / domain** (e.g. the nginx setup in the
+[VPS guide](install-vps.md)), a **tailnet / LAN address**, or a separately
+hosted frontend. In those cases `GET /api/session-token` returns 403 by design.
 
 **Fix:** Set the token manually in the browser, once per browser:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,3 +124,50 @@ chmod 440 /etc/sudoers.d/quadwork
 
 See the [VPS Installation Guide](install-vps.md#step-2-create-non-root-user-critical) for full setup.
 
+
+---
+
+## Terminals won't attach (session token / cross-origin) — #968
+
+**Background:** The terminal WebSocket (`/ws/terminal`, `/ws/butler`) and the
+PTY-write endpoints (`POST /api/agents/:project/:agent/write`, `/interrupt`)
+are authenticated (#968). Two checks run:
+
+1. **Origin allowlist** — the WebSocket upgrade is rejected unless the browser's
+   `Origin` is a localhost address or matches the server's own host. This blocks
+   a malicious web page you happen to visit from opening a socket to your local
+   QuadWork and injecting keystrokes into an agent shell.
+2. **Session token** — a shared token (`session_token`, auto-generated and stored
+   in `~/.quadwork/config.json` on first start) must accompany every terminal
+   WS and PTY-write request.
+
+**Normal local use needs no action.** The dashboard fetches the token from the
+localhost-only `GET /api/session-token` endpoint and attaches it automatically.
+This also works behind a same-host reverse proxy (e.g. the nginx setup in the
+[VPS guide](install-vps.md)), because the proxy connects to QuadWork over
+`127.0.0.1`.
+
+**Symptom:** Terminals show "connecting…" and never attach, or typing does
+nothing, when the dashboard is served from a **different origin** than the
+QuadWork API (e.g. a separately hosted frontend, or a proxy that rewrites the
+Origin), so `/api/session-token` isn't reachable same-origin.
+
+**Fix:** Set the token manually in the browser, once per browser:
+
+```js
+// In the browser devtools console, on the QuadWork tab:
+localStorage.setItem("quadwork_session_token", "<value from ~/.quadwork/config.json>");
+// then reload the page.
+```
+
+Read the value on the server with:
+
+```bash
+grep session_token ~/.quadwork/config.json
+```
+
+**Security note:** keep `session_token` private and keep QuadWork behind your
+existing network controls (127.0.0.1 bind + SSH tunnel, tailnet ACL, or the
+nginx Basic Auth from the VPS guide). The token + Origin allowlist are
+defence-in-depth against browser-based cross-origin attacks, not a substitute
+for network-level access control.

--- a/server/index.js
+++ b/server/index.js
@@ -15,8 +15,27 @@ const selfHeal = require("./self-heal");
 const { injectModeForCommand } = require("../src/lib/injectMode.js");
 
 const net = require("net");
+const crypto = require("crypto");
 const config = readConfig();
 const PORT = config.port || 8400;
+
+// #968: shared session token gating the PTY-driving surface (/ws/terminal,
+// /ws/butler, /write, /interrupt). Auto-provisioned + persisted to config.json
+// so the LOCAL dashboard attaches it with zero operator friction; tailnet/LAN
+// exposure must supply it out-of-band (see docs/*). Kept out of any response
+// except the localhost-only /api/session-token endpoint.
+let SESSION_TOKEN =
+  typeof config.session_token === "string" && config.session_token
+    ? config.session_token
+    : null;
+if (!SESSION_TOKEN) {
+  SESSION_TOKEN = crypto.randomBytes(32).toString("hex");
+  try {
+    writeConfig({ ...config, session_token: SESSION_TOKEN });
+  } catch (err) {
+    console.warn(`[auth] could not persist session token to config: ${err.message || err}`);
+  }
+}
 
 function emitSystemMessage(projectId, text) {
   try {
@@ -53,6 +72,16 @@ app.get("/api/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
+// #968: hand the shared session token to the LOCAL dashboard only, so it can
+// auto-attach it to WS + PTY-write calls with no operator action. Non-localhost
+// callers (tailnet/LAN) get 403 and must configure the token out-of-band — the
+// token is never leaked off-box. `req.ip` is the real socket address because we
+// deliberately do NOT trust proxy headers.
+app.get("/api/session-token", (req, res) => {
+  if (!isLocalhost(req.ip)) return res.status(403).json({ error: "Local access only" });
+  res.json({ token: SESSION_TOKEN });
+});
+
 // --- Safe PTY write helper (#670) ---
 
 function safeWrite(term, data) {
@@ -62,6 +91,37 @@ function safeWrite(term, data) {
     if (err.code === "EIO") return false;
     throw err;
   }
+}
+
+// --- #968: PTY-surface auth (Origin allowlist + shared session token) ---
+
+function isLocalhost(ip) {
+  return ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+}
+
+// A cross-origin web page CAN open a WebSocket to 127.0.0.1 (browsers don't
+// enforce same-origin on WS), so the upgrade handler must vet Origin itself.
+// Allow any localhost origin (the local dashboard, incl. dev on :3000) and a
+// request whose Origin host matches the server Host (direct tailnet/LAN access
+// to this very port). Absent Origin → reject (browsers always send it on WS).
+function isAllowedWsOrigin(req) {
+  const origin = req.headers.origin;
+  if (!origin) return false;
+  let u;
+  try { u = new URL(origin); } catch { return false; }
+  if (u.hostname === "127.0.0.1" || u.hostname === "localhost" || u.hostname === "::1") return true;
+  return !!req.headers.host && u.host === req.headers.host;
+}
+
+function tokenMatches(token) {
+  return typeof token === "string" && token.length > 0 && token === SESSION_TOKEN;
+}
+
+// REST guard for the PTY-write endpoints. Token travels in X-Session-Token.
+function requireSessionToken(req, res) {
+  if (tokenMatches(req.headers["x-session-token"])) return true;
+  res.status(401).json({ ok: false, error: "Invalid or missing session token" });
+  return false;
 }
 
 // --- CLI status detection ---
@@ -823,6 +883,7 @@ app.post("/api/agents/:project/:agent/restart", async (req, res) => {
 // --- #706: Manual interrupt — send Ctrl+C to agent PTY ---
 
 app.post("/api/agents/:project/:agent/interrupt", (req, res) => {
+  if (!requireSessionToken(req, res)) return; // #968
   const key = `${req.params.project}/${req.params.agent}`;
   const session = agentSessions.get(key);
   if (!session || !session.term) {
@@ -834,6 +895,7 @@ app.post("/api/agents/:project/:agent/interrupt", (req, res) => {
 });
 
 app.post("/api/agents/:project/interrupt-all", (req, res) => {
+  if (!requireSessionToken(req, res)) return; // #968
   const { project } = req.params;
   let count = 0;
   for (const [key, session] of agentSessions) {
@@ -864,6 +926,7 @@ app.get("/api/sessions", (_req, res) => {
 // --- Write to active PTY session ---
 
 app.post("/api/agents/:project/:agent/write", (req, res) => {
+  if (!requireSessionToken(req, res)) return; // #968
   const { project, agent } = req.params;
   const key = `${project}/${agent}`;
   const session = agentSessions.get(key);
@@ -878,7 +941,10 @@ app.post("/api/agents/:project/:agent/write", (req, res) => {
   }
 
   try {
-    session.term.write(text);
+    // #968 (C2): route through safeWrite so a write to a just-exited PTY
+    // surfaces EIO as a clean 409 instead of an unhandled 500.
+    const ok = safeWrite(session.term, text);
+    if (!ok) return res.status(409).json({ ok: false, error: "PTY not writable (exited)" });
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ ok: false, error: err.message });
@@ -1526,17 +1592,33 @@ const { scrubSecrets, scrubScrollback } = require("./scrub-secrets");
 const wss = new WebSocketServer({ noServer: true });
 
 server.on("upgrade", (req, socket, head) => {
-  const pathname = new URL(req.url, "http://localhost").pathname;
+  const url = new URL(req.url, "http://localhost");
+  const pathname = url.pathname;
+  if (pathname !== "/ws/terminal" && pathname !== "/ws/butler") {
+    socket.destroy();
+    return;
+  }
+  // #968: a cross-origin page can open a WS to 127.0.0.1 and inject keystrokes
+  // into an agent PTY (remote shell over tailnet). Vet Origin, then require the
+  // shared session token (passed as ?token= since browsers can't set WS headers).
+  if (!isAllowedWsOrigin(req)) {
+    socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+  if (!tokenMatches(url.searchParams.get("token"))) {
+    socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+    socket.destroy();
+    return;
+  }
   if (pathname === "/ws/terminal") {
     wss.handleUpgrade(req, socket, head, (ws) => {
       wss.emit("connection:terminal", ws, req);
     });
-  } else if (pathname === "/ws/butler") {
+  } else {
     wss.handleUpgrade(req, socket, head, (ws) => {
       wss.emit("connection:butler", ws, req);
     });
-  } else {
-    socket.destroy();
   }
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -73,12 +73,13 @@ app.get("/api/health", (_req, res) => {
 });
 
 // #968: hand the shared session token to the LOCAL dashboard only, so it can
-// auto-attach it to WS + PTY-write calls with no operator action. Non-localhost
-// callers (tailnet/LAN) get 403 and must configure the token out-of-band — the
-// token is never leaked off-box. `req.ip` is the real socket address because we
-// deliberately do NOT trust proxy headers.
+// auto-attach it to WS + PTY-write calls with no operator action. The guard
+// checks socket IP + Host + Origin are all loopback (see isLocalTokenRequest)
+// so a DNS-rebinding page or a same-host reverse proxy can't pull the token to
+// a remote origin. Non-loopback (tailnet/LAN/proxied) callers get 403 and must
+// configure the token out-of-band — it is never leaked off-box.
 app.get("/api/session-token", (req, res) => {
-  if (!isLocalhost(req.ip)) return res.status(403).json({ error: "Local access only" });
+  if (!isLocalTokenRequest(req)) return res.status(403).json({ error: "Local access only" });
   res.json({ token: SESSION_TOKEN });
 });
 
@@ -97,6 +98,36 @@ function safeWrite(term, data) {
 
 function isLocalhost(ip) {
   return ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+}
+
+// True when `host` (an `Origin`/`Host` header value, "name[:port]") resolves to
+// a loopback name. Used to keep the session token on-box.
+function isLoopbackHostHeader(host) {
+  if (!host) return false;
+  let hostname;
+  try { hostname = new URL(`http://${host}`).hostname; } catch { return false; }
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+}
+
+// #968 (hardened per review): the session token is a bearer secret, so only
+// hand it to a request that is unambiguously this machine's own loopback.
+// `req.ip` alone is insufficient — a DNS-rebinding page (attacker domain rebound
+// to 127.0.0.1) or a same-host reverse proxy keeps `req.ip` at 127.0.0.1 while
+// the browser's Host/Origin is a REMOTE name. Require the socket IP AND the Host
+// header AND the Origin (when the browser sends one) to all be loopback.
+// Remote/proxied/tailnet access uses the out-of-band localStorage token instead.
+function isLocalTokenRequest(req) {
+  if (!isLocalhost(req.ip)) return false;
+  if (!isLoopbackHostHeader(req.headers.host)) return false;
+  // Origin (present on cross-origin/CORS requests) is a full URL, not a bare
+  // host — parse it directly and require loopback too.
+  const origin = req.headers.origin;
+  if (origin) {
+    let o;
+    try { o = new URL(origin); } catch { return false; }
+    if (o.hostname !== "127.0.0.1" && o.hostname !== "localhost" && o.hostname !== "::1") return false;
+  }
+  return true;
 }
 
 // A cross-origin web page CAN open a WebSocket to 127.0.0.1 (browsers don't

--- a/server/mcp-operator/context.js
+++ b/server/mcp-operator/context.js
@@ -7,8 +7,22 @@
 // gives the conflict-free tool modules (#791–#795) a single import surface.
 
 const http = require("http");
+const { readConfig } = require("../config");
 
 const DEFAULT_TIMEOUT_MS = 5000;
+
+// #968: the interrupt / interrupt-all endpoints now require the shared session
+// token. The operator MCP runs on the same host, so it reads the token straight
+// from config.json (no extra HTTP round-trip) and attaches it to every request;
+// unguarded endpoints ignore it. Cached after first read.
+let _sessionToken;
+function sessionToken() {
+  if (_sessionToken === undefined) {
+    try { _sessionToken = readConfig().session_token || ""; }
+    catch { _sessionToken = ""; }
+  }
+  return _sessionToken;
+}
 
 /**
  * Build the context handed to every tool handler.
@@ -28,12 +42,15 @@ function createContext(port, opts = {}) {
   function httpRequest(method, urlPath, body) {
     return new Promise((resolve, reject) => {
       const url = new URL(urlPath, BASE);
+      const headers = { "Content-Type": "application/json" };
+      const t = sessionToken();
+      if (t) headers["X-Session-Token"] = t; // #968
       const reqOpts = {
         hostname: url.hostname,
         port: url.port,
         path: url.pathname + url.search,
         method,
-        headers: { "Content-Type": "application/json" },
+        headers,
         signal: AbortSignal.timeout(timeoutMs),
       };
       const req = http.request(reqOpts, (res) => {

--- a/server/routes.js
+++ b/server/routes.js
@@ -336,6 +336,9 @@ router.get("/api/config", (_req, res) => {
     // chat actually sends. This also makes a hand-edited file with
     // garbage characters self-correct visibly on next reload.
     parsed.operator_name = sanitizeOperatorName(parsed.operator_name);
+    // #968: never expose the PTY session token here — it's handed to the local
+    // dashboard only, via the localhost-gated GET /api/session-token.
+    delete parsed.session_token;
     res.json(parsed);
   } catch (err) {
     if (err.code === "ENOENT") return res.json(DEFAULT_CONFIG);
@@ -361,6 +364,10 @@ router.put("/api/config", (req, res) => {
     else delete body.sidebar_groups;
     if ("reviewer_github_user" in disk) body.reviewer_github_user = disk.reviewer_github_user;
     else delete body.reviewer_github_user;
+    // #968: session_token is redacted from GET, so a whole-config PUT snapshot
+    // never carries it — re-read and preserve it (same reason as the keys above).
+    if ("session_token" in disk) body.session_token = disk.session_token;
+    else delete body.session_token;
     writeConfig(body);
     // Trigger sync is handled internally since we're in the same process now
     if (typeof req.app.get("syncTriggers") === "function") {

--- a/server/wsPtyAuth.test.js
+++ b/server/wsPtyAuth.test.js
@@ -112,6 +112,17 @@ const ok = (c, m) => { assert.ok(c, m); passed++; console.log(`  PASS: ${m}`); }
   const token = JSON.parse(tokRes.body).token;
   ok(typeof token === "string" && token.length >= 32, "session token is a non-trivial secret");
 
+  // The token must NOT leak to a request whose Host/Origin is a remote name even
+  // when the socket is loopback (DNS rebinding / same-host reverse proxy).
+  const rebindHost = await httpReq(PORT, { path: "/api/session-token", headers: { host: "evil.example" } });
+  ok(rebindHost.status === 403, "GET /api/session-token with a hostile Host header (DNS-rebind) → 403");
+  const rebindHostPort = await httpReq(PORT, { path: "/api/session-token", headers: { host: "attacker.tld:8400" } });
+  ok(rebindHostPort.status === 403, "GET /api/session-token with a hostile Host:port → 403");
+  const rebindOrigin = await httpReq(PORT, { path: "/api/session-token", headers: { origin: "http://evil.example" } });
+  ok(rebindOrigin.status === 403, "GET /api/session-token with a hostile Origin → 403");
+  const loopbackHost = await httpReq(PORT, { path: "/api/session-token", headers: { host: `localhost:${PORT}` } });
+  ok(loopbackHost.status === 200, "GET /api/session-token with a loopback Host (localhost) → 200 (local dashboard unaffected)");
+
   // ── WS upgrade auth ──────────────────────────────────────────────────────
   const wsPath = `/ws/terminal?project=x&agent=head`;
   const foreign = await tryWs(`ws://127.0.0.1:${PORT}${wsPath}&token=${token}`, { origin: "http://evil.example" });

--- a/server/wsPtyAuth.test.js
+++ b/server/wsPtyAuth.test.js
@@ -1,0 +1,165 @@
+// #968: WS/PTY auth — Origin allowlist + shared session token on the
+// terminal WebSocket and the PTY-write REST endpoints (EPIC #967 Phase 1).
+//
+// Boots the REAL server as a subprocess on a THROWAWAY port with a temp HOME
+// (empty config, no projects, never port 8400 / the live orchestrator) and
+// drives the actual server.on("upgrade") handler + routes over the wire:
+//   - GET /api/session-token (localhost) hands out the auto-provisioned token.
+//   - WS upgrade with a foreign Origin        → 403 (no open).
+//   - WS upgrade with a valid Origin, no token → 401 (no open).
+//   - WS upgrade with valid Origin + token     → 101 (opens).
+//   - POST /write, /interrupt without a token  → 401.
+//   - POST /write with a token, no session     → 404 (token accepted).
+//
+// Plain node:assert script — run with `node server/wsPtyAuth.test.js`.
+
+const assert = require("node:assert/strict");
+const { spawn } = require("child_process");
+const http = require("http");
+const net = require("net");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const WebSocket = require("ws");
+
+const ROOT = path.resolve(__dirname, "..");
+const TMP_HOME = path.join(os.tmpdir(), `ws-pty-auth-${process.pid}-${Date.now()}`);
+const CONFIG_DIR = path.join(TMP_HOME, ".quadwork");
+
+let child;
+function cleanup() {
+  try { if (child && !child.killed) child.kill("SIGKILL"); } catch {}
+  try { fs.rmSync(TMP_HOME, { recursive: true, force: true }); } catch {}
+}
+process.on("exit", cleanup);
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function waitForListen(proc, port) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("server did not start in time")), 15000);
+    const onData = (buf) => {
+      if (buf.toString().includes(`listening on http://127.0.0.1:${port}`)) {
+        clearTimeout(timer);
+        proc.stdout.off("data", onData);
+        resolve();
+      }
+    };
+    proc.stdout.on("data", onData);
+    proc.on("exit", (code) => { clearTimeout(timer); reject(new Error(`server exited early (${code})`)); });
+  });
+}
+
+function httpReq(port, { method = "GET", path: p, headers = {}, body } = {}) {
+  return new Promise((resolve, reject) => {
+    const payload = body === undefined ? null : Buffer.from(body);
+    const req = http.request(
+      { host: "127.0.0.1", port, method, path: p,
+        headers: { ...(payload ? { "content-type": "application/json", "content-length": payload.length } : {}), ...headers } },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function tryWs(url, headers) {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(url, { headers, handshakeTimeout: 5000 });
+    let settled = false;
+    const done = (r) => { if (!settled) { settled = true; try { ws.terminate(); } catch {} resolve(r); } };
+    ws.on("open", () => done({ open: true }));
+    ws.on("unexpected-response", (_req, res) => done({ open: false, status: res.statusCode }));
+    ws.on("error", (err) => done({ open: false, error: String(err.message || err) }));
+  });
+}
+
+let passed = 0;
+const ok = (c, m) => { assert.ok(c, m); passed++; console.log(`  PASS: ${m}`); };
+
+(async () => {
+  const PORT = await freePort();
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(path.join(CONFIG_DIR, "config.json"), JSON.stringify({ port: PORT, projects: [] }));
+
+  child = spawn(process.execPath, [path.join(ROOT, "server", "index.js")], {
+    cwd: ROOT,
+    env: { ...process.env, HOME: TMP_HOME, USERPROFILE: TMP_HOME },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr.on("data", () => {}); // drain
+
+  await waitForListen(child, PORT);
+  const origin = `http://127.0.0.1:${PORT}`;
+
+  // Token is auto-provisioned and handed to the local dashboard.
+  const tokRes = await httpReq(PORT, { path: "/api/session-token" });
+  ok(tokRes.status === 200, "GET /api/session-token (localhost) → 200");
+  const token = JSON.parse(tokRes.body).token;
+  ok(typeof token === "string" && token.length >= 32, "session token is a non-trivial secret");
+
+  // ── WS upgrade auth ──────────────────────────────────────────────────────
+  const wsPath = `/ws/terminal?project=x&agent=head`;
+  const foreign = await tryWs(`ws://127.0.0.1:${PORT}${wsPath}&token=${token}`, { origin: "http://evil.example" });
+  ok(foreign.open === false && foreign.status === 403, "WS with a foreign Origin → 403, not opened");
+
+  const noOrigin = await tryWs(`ws://127.0.0.1:${PORT}${wsPath}&token=${token}`, {});
+  ok(noOrigin.open === false && noOrigin.status === 403, "WS with absent Origin → 403, not opened");
+
+  const noToken = await tryWs(`ws://127.0.0.1:${PORT}${wsPath}`, { origin });
+  ok(noToken.open === false && noToken.status === 401, "WS with valid Origin but no token → 401, not opened");
+
+  const badToken = await tryWs(`ws://127.0.0.1:${PORT}${wsPath}&token=wrong`, { origin });
+  ok(badToken.open === false && badToken.status === 401, "WS with a wrong token → 401, not opened");
+
+  const good = await tryWs(`ws://127.0.0.1:${PORT}${wsPath}&token=${token}`, { origin });
+  ok(good.open === true, "WS with valid Origin + token → upgrade accepted (opens)");
+
+  // ── REST PTY-write auth ──────────────────────────────────────────────────
+  const writeNoTok = await httpReq(PORT, { method: "POST", path: "/api/agents/x/head/write", body: JSON.stringify({ text: "hi\n" }) });
+  ok(writeNoTok.status === 401, "POST /write without a token → 401");
+
+  const writeBadTok = await httpReq(PORT, { method: "POST", path: "/api/agents/x/head/write", headers: { "x-session-token": "wrong" }, body: JSON.stringify({ text: "hi\n" }) });
+  ok(writeBadTok.status === 401, "POST /write with a wrong token → 401");
+
+  const writeTok = await httpReq(PORT, { method: "POST", path: "/api/agents/x/head/write", headers: { "x-session-token": token }, body: JSON.stringify({ text: "hi\n" }) });
+  ok(writeTok.status === 404, "POST /write with a valid token but no session → 404 (token accepted, then no session)");
+
+  const interruptNoTok = await httpReq(PORT, { method: "POST", path: "/api/agents/x/head/interrupt" });
+  ok(interruptNoTok.status === 401, "POST /interrupt without a token → 401");
+
+  const interruptTok = await httpReq(PORT, { method: "POST", path: "/api/agents/x/head/interrupt", headers: { "x-session-token": token } });
+  ok(interruptTok.status === 200, "POST /interrupt with a valid token → 200 (token accepted)");
+
+  // ── The token must never leak through GET /api/config ────────────────────
+  const cfgGet = await httpReq(PORT, { path: "/api/config" });
+  const cfgObj = JSON.parse(cfgGet.body);
+  ok(!("session_token" in cfgObj), "GET /api/config does NOT expose session_token");
+
+  // ── A whole-config PUT (which never carries the redacted token) preserves it ─
+  const putRes = await httpReq(PORT, { method: "PUT", path: "/api/config", body: JSON.stringify(cfgObj) });
+  ok(putRes.status === 200, "PUT /api/config (redacted snapshot) → 200");
+  const tokAfter = await httpReq(PORT, { path: "/api/session-token" });
+  ok(JSON.parse(tokAfter.body).token === token, "session_token survives a whole-config PUT (not clobbered)");
+
+  console.log(`\n${passed} passed`);
+  console.log("server/wsPtyAuth.test.js: all assertions passed");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/src/components/ButlerChat.tsx
+++ b/src/components/ButlerChat.tsx
@@ -5,6 +5,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { useLocale } from "@/components/LocaleProvider";
+import { sessionTokenParam } from "@/lib/sessionToken";
 
 const COPY = {
   en: {
@@ -162,7 +163,8 @@ export default function ButlerChat() {
       const base = await resolveBase();
       if (cancelled) return;
 
-      const ws = new WebSocket(`${base}/ws/butler`);
+      const tok = await sessionTokenParam(); // #968: auth the butler WS
+      const ws = new WebSocket(`${base}/ws/butler${tok ? `?${tok}` : ""}`);
       wsRef.current = ws;
 
       ws.onopen = () => {

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -11,6 +11,7 @@ import {
   getNotificationBackgroundOnly,
   setNotificationBackgroundOnly,
 } from "../lib/notificationSound";
+import { sessionTokenHeaders } from "@/lib/sessionToken";
 import { useLocale } from "@/components/LocaleProvider";
 
 const COPY = {
@@ -172,7 +173,7 @@ function ServerSection({ projectId }: { projectId: string }) {
       : `/api/agents/${encodeURIComponent(projectId)}/interrupt-all`;
     setLoading("interrupt");
     try {
-      const r = await fetch(url, { method: "POST" });
+      const r = await fetch(url, { method: "POST", headers: await sessionTokenHeaders() }); // #968
       const d = await r.json();
       if (agent) {
         setFeedback(d.ok ? t.interrupted(agent) : (d.error || t.failed));

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
+import { sessionTokenParam, sessionTokenHeaders } from "@/lib/sessionToken";
 
 interface Issue {
   number: number;
@@ -121,10 +122,14 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
       if (!cfgRes.ok) throw new Error("config");
       const cfg = await cfgRes.json();
 
+      // #968: auth the PTY-driving calls (WS + writes).
+      const auth = await sessionTokenHeaders();
+      const tok = await sessionTokenParam();
+
       // Same-origin: all API calls go to the same host
       let res = await fetch(`/api/agents/${projectId}/head/write`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...auth },
         body: JSON.stringify({ text: prompt + "\n" }),
       });
 
@@ -141,7 +146,7 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
         const wsHost = (currentPort && currentPort !== backendPort)
           ? `${window.location.hostname}:${backendPort}`
           : window.location.host;
-        const wsUrl = `${wsProto}//${wsHost}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=head`;
+        const wsUrl = `${wsProto}//${wsHost}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=head${tok ? `&${tok}` : ""}`;
         const ws = new WebSocket(wsUrl);
         await new Promise<void>((resolve, reject) => {
           ws.onopen = () => resolve();
@@ -155,7 +160,7 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
         // Start the Head agent CLI in the PTY shell
         await fetch(`/api/agents/${projectId}/head/write`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", ...auth },
           body: JSON.stringify({ text: `${headCommand}\n` }),
         });
 
@@ -165,7 +170,7 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
         // Now write the queue prompt to the running agent
         res = await fetch(`/api/agents/${projectId}/head/write`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", ...auth },
           body: JSON.stringify({ text: prompt + "\n" }),
         });
       }

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import TerminalPanel from "./TerminalPanel";
+import { sessionTokenHeaders } from "@/lib/sessionToken";
 
 // #399 / quadwork#264: how long an agent stays "active" after its
 // last PTY output before the activity ring stops pulsing.
@@ -206,10 +207,12 @@ export default function TerminalGrid({
                 >↻</button>
                 {agentStates[agent.id] === "running" && (
                   <button
-                    onClick={() => {
+                    onClick={async () => {
+                      // #968: auth the PTY write
+                      const auth = await sessionTokenHeaders();
                       fetch(`/api/agents/${encodeURIComponent(projectId)}/${encodeURIComponent(agent.id)}/write`, {
                         method: "POST",
-                        headers: { "Content-Type": "application/json" },
+                        headers: { "Content-Type": "application/json", ...auth },
                         body: JSON.stringify({ text: "/compact\n" }),
                       }).catch(() => {});
                     }}

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
+import { sessionTokenParam } from "@/lib/sessionToken";
 
 interface TerminalPanelProps {
   projectId: string;
@@ -187,7 +188,8 @@ export default function TerminalPanel({
       const base = await resolveBase();
       if (cancelled) return;
 
-      const endpoint = `${base}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}`;
+      const tok = await sessionTokenParam(); // #968: auth the terminal WS
+      const endpoint = `${base}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=${encodeURIComponent(agentId)}${tok ? `&${tok}` : ""}`;
       const ws = new WebSocket(endpoint);
       wsRef.current = ws;
 

--- a/src/lib/sessionToken.ts
+++ b/src/lib/sessionToken.ts
@@ -1,0 +1,41 @@
+// #968: shared session token for the PTY-driving surface (terminal/butler
+// WebSockets + /write + /interrupt). The server auto-provisions it and hands it
+// to the LOCAL dashboard via GET /api/session-token, so the operator sees no
+// change. For tailnet/LAN access (where that endpoint 403s), set
+// localStorage["quadwork_session_token"] to the value from ~/.quadwork/config.json
+// (see docs/troubleshooting.md).
+
+let cached: string | null = null;
+let inflight: Promise<string> | null = null;
+
+async function getSessionToken(): Promise<string> {
+  if (cached) return cached;
+  try {
+    const override = window.localStorage.getItem("quadwork_session_token");
+    if (override) { cached = override; return cached; }
+  } catch { /* localStorage unavailable (SSR) */ }
+  if (!inflight) {
+    inflight = fetch("/api/session-token")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        const t = d && typeof d.token === "string" ? d.token : "";
+        if (t) cached = t; // only cache a real token so a transient failure can retry
+        return t;
+      })
+      .catch(() => "")
+      .finally(() => { inflight = null; });
+  }
+  return inflight;
+}
+
+/** Bare `token=<value>` query param (no leading separator), or "" if unknown. */
+export async function sessionTokenParam(): Promise<string> {
+  const t = await getSessionToken();
+  return t ? `token=${encodeURIComponent(t)}` : "";
+}
+
+/** Header object for authenticated PTY-write / interrupt fetches. */
+export async function sessionTokenHeaders(): Promise<Record<string, string>> {
+  const t = await getSessionToken();
+  return t ? { "X-Session-Token": t } : {};
+}


### PR DESCRIPTION
Closes #968

## Summary
The terminal WebSocket (`/ws/terminal`) and the PTY-write REST endpoints had **no auth and no Origin check**. Browsers don't enforce same-origin on WebSockets, so any web page the operator visited could `new WebSocket("ws://127.0.0.1:8400/ws/terminal?project=X&agent=head")` and inject keystrokes into an agent PTY running `claude --dangerously-skip-permissions` — remote shell over a tailnet. Two auditors flagged this as the #1 issue.

**Backend (`server/index.js`):**
- `server.on("upgrade")` now enforces an **Origin allowlist** (localhost, or an Origin whose host matches the server's own `Host`; absent Origin rejected) **and** a **shared session token** (`?token=`, since browsers can't set WS headers) before upgrading `/ws/terminal` + `/ws/butler`.
- `POST /write`, `/interrupt`, `/interrupt-all` require the token via `X-Session-Token`.
- `/write` now routes through `safeWrite` → a write to a just-exited PTY returns **409** instead of an unhandled **500** (C2).
- `SESSION_TOKEN` is auto-generated (`crypto.randomBytes(32)`) and **persisted to `config.json`**; handed to the **local dashboard only** via the localhost-gated `GET /api/session-token`.
- `routes.js`: **redact** `session_token` from `GET /api/config`, and **preserve** it across a whole-config `PUT` (same pattern as `pinned_projects`/#949).

**Zero operator friction locally:** new `src/lib/sessionToken.ts` fetches the token from `/api/session-token` and attaches it; wired into `TerminalPanel`, `ButlerChat`, `QueueManager`, `TerminalGrid`, `ControlBar`. Tailnet/LAN access sets `localStorage["quadwork_session_token"]` — documented in `docs/troubleshooting.md`.

**Back-compat for the operator MCP:** `mcp-operator/context.js` reads the token from `config.json` and attaches `X-Session-Token`, so `agent_control interrupt` / `interrupt_all` keep working.

## EPIC Alignment
Parent epic **#967 — v2.4.0 hardening**, **Phase 1** and the epic's top security item. Depends on #976 (CI, now gating this PR). Touches-core-loop (the terminal viewer path), so auth is added **back-compat**: the local dashboard is unaffected (token auto-provisioned + auto-attached), and I live-verified a full terminal cycle on a throwaway port before submitting. Out of scope (later): per-chunk secret scrubbing (#968 body).

## Self-Verification
- [x] **Automated** — new `server/wsPtyAuth.test.js` boots the **real server as a subprocess on a throwaway port** (never 8400) with a temp HOME and asserts: foreign-origin WS → 403; absent-origin WS → 403; no/invalid-token WS → 401; valid Origin+token WS → **101 (opens)**; `/write` & `/interrupt` without token → 401, with token → accepted; `/write` no-session → 404; `GET /api/config` does **not** expose `session_token`; token **survives a whole-config PUT**. **15/15.**
- [x] Full suite **55 passed / 0 failed / 2 skipped** (`node server/run-tests.js`); operator-MCP tool tests still pass with the token attached. `tsc --noEmit` clean.
- [x] **Live-verify on a THROWAWAY port (45123, never 8400):**
  - Real `bash`-backed project; authed WS **attached**, `resize` applied, typed `echo QW968_LIVE_OK` → **PTY echoed the command + output** (attach + type + resize). Foreign-origin WS → HTTP 403; no-token WS → HTTP 401.
  - **Real browser** (Chrome via Playwright) against the freshly **built** frontend on the throwaway port: the dashboard issued `GET /api/session-token → 200` and the terminal **attached in-browser** (live prompt `quadwork@quadwork-vps:~/work$` rendered in xterm — an unauthenticated WS would have been rejected). `GET /api/config` confirmed **no** `session_token` over the wire.
  - The live 8400 orchestrator was **never touched** (it runs from the global npm install, cwd `/home/quadwork`; `/api/health` confirmed healthy before and after).
- [x] Staged explicit paths only (unrelated untracked `AGENTS.md`/`DESIGN-GUIDE.md` kept out); branched off current main `48f7892`.

## Design Fidelity
No visible UI change. The token is attached transparently to existing WebSocket URLs and `fetch` headers via a shared helper; terminals, the butler panel, the queue "Send to Head", the `/compact` and interrupt controls behave exactly as before for the local operator. The only new user-facing surface is a documented `localStorage` key for remote (tailnet) access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)