### PR TITLE
[#973] Frontend correctness bundle

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -190,6 +190,15 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
   const isComposingRef = useRef(false);
   const shouldAutoScroll = useRef(true);
   const authRetryRef = useRef(0);
+  // #973: the latest projectId, read by in-flight polls to detect a
+  // project switch. A poll started for the previous project must not
+  // append its messages / advance the cursor after the operator has
+  // switched — the fetch captures the request's project and compares
+  // against this ref on resolve (mirrors the stale-read guard in
+  // ProjectDashboard). Assigned during render so it's current even
+  // before the reset effect below runs.
+  const projectRef = useRef(projectId);
+  projectRef.current = projectId;
 
   // Reset cursor when project changes
   useEffect(() => {
@@ -197,15 +206,27 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
     setMessages([]);
     setLoaded(false);
     initialRetryRef.current = 0;
+    // #973: reset the auth-failure counter so a fresh project starts
+    // clean and doesn't inherit the previous project's 403 tally.
+    authRetryRef.current = 0;
     if (retryTimerRef.current) { clearTimeout(retryTimerRef.current); retryTimerRef.current = null; }
   }, [projectId]);
 
   // Poll messages via proxy
   const fetchMessages = useCallback(() => {
+    // #973: capture the project this poll is for so a response that
+    // resolves after a project switch is dropped instead of polluting
+    // the new project's message list and cursor.
+    const reqProject = projectId;
     const url = `/api/chat?path=/api/messages&channel=${encodeURIComponent(channel)}&cursor=${cursorRef.current}${projectId ? `&project=${encodeURIComponent(projectId)}` : ""}`;
     fetch(url)
       .then((r) => {
         if (r.status === 403) {
+          // #973: actually count the auth failures — the ref was read
+          // but never incremented, so the banner branch below was dead
+          // code and the "403" warning could never surface. Increment
+          // here so it shows once the retry budget is spent.
+          authRetryRef.current += 1;
           if (authRetryRef.current < 3) setAuthError(null);
           else setAuthError("Chat authentication failed (403). Check project chat configuration in Settings.");
           throw new Error("auth failed");
@@ -214,7 +235,11 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
         return r.json();
       })
       .then((data) => {
+        // #973: a since-switched project — drop this stale response.
+        if (reqProject !== projectRef.current) return;
         setAuthError(null);
+        // #973: a clean poll clears the auth-failure tally.
+        authRetryRef.current = 0;
         const msgs: Message[] = Array.isArray(data) ? data : data.messages || [];
         if (msgs.length > 0) {
           setMessages((prev) => {
@@ -228,6 +253,8 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
         setLoaded(true);
       })
       .catch(() => {
+        // #973: don't schedule a retry into a project we've left.
+        if (reqProject !== projectRef.current) return;
         if (!loaded && initialRetryRef.current < MAX_INITIAL_RETRIES) {
           initialRetryRef.current += 1;
           retryTimerRef.current = setTimeout(fetchMessages, INITIAL_RETRY_DELAY_MS);
@@ -474,9 +501,11 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
               {renderMessageWithMentions(msg.text)}
               {msg.attachments && msg.attachments.length > 0 && (
                 <span className="flex gap-2 mt-1">
-                  {msg.attachments.map((att) => (
+                  {msg.attachments.map((att, i) => (
                     <a
-                      key={att.name}
+                      // #973: name alone collides when a message carries
+                      // two attachments of the same filename — key by index too.
+                      key={`${att.name}-${i}`}
                       href={`/api/uploads/${encodeURIComponent(projectId || "")}/${encodeURIComponent(att.name)}`}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -509,7 +538,10 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
                 const KNOWN_AGENTS = new Set(["head", "dev", "re1", "re2"]);
                 if (KNOWN_AGENTS.has(msg.sender.toLowerCase())) {
                   const prefix = `@${msg.sender} `;
-                  setInput((prev) => (prev.startsWith(prefix) ? prev : prefix));
+                  // #973: prepend the mention rather than replacing the
+                  // buffer — the old assignment discarded whatever draft
+                  // the operator had already typed.
+                  setInput((prev) => (prev.startsWith(prefix) ? prev : prefix + prev));
                 }
                 inputRef.current?.focus();
               }}
@@ -711,7 +743,8 @@ function ChatPanelAPI({ projectId, filterSystem = false }: { projectId?: string;
         {(attachments.length > 0 || uploading) && (
           <div className="flex gap-2 px-2 py-1 flex-wrap">
             {attachments.map((att, i) => (
-              <div key={att.name} className="relative group">
+              // #973: composite key — two pending uploads can share a filename.
+              <div key={`${att.name}-${i}`} className="relative group">
                 <img
                   src={`/api/uploads/${encodeURIComponent(projectId || "")}/${encodeURIComponent(att.name)}`}
                   alt={att.name}

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -19,6 +19,7 @@ const COPY = {
     server: {
       title: "Server",
       resetAgents: "Reset Agents",
+      confirmResetAgents: "Reset all 4 agents?",
       failed: "Failed",
       error: "Error",
       resetResult: (restarted: number, total: number) => `Reset — ${restarted} of ${total} agent${total !== 1 ? "s" : ""} restarted`,
@@ -71,6 +72,7 @@ const COPY = {
     server: {
       title: "서버",
       resetAgents: "에이전트 초기화",
+      confirmResetAgents: "에이전트 4개를 모두 초기화할까요?",
       failed: "실패",
       error: "오류",
       resetResult: (restarted: number, total: number) => `초기화 완료 — ${total}개 중 ${restarted}개 에이전트 재시작됨`,
@@ -129,10 +131,17 @@ function ServerSection({ projectId }: { projectId: string }) {
   const [loading, setLoading] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [confirmFullReset, setConfirmFullReset] = useState(false);
+  // #973: two-click confirm for Reset Agents — a single click used to
+  // kill all four agents with no guard, unlike every other destructive
+  // button here (Full Reset, Re-seed).
+  const [confirmReset, setConfirmReset] = useState(false);
   const [confirmReseed, setConfirmReseed] = useState(false);
   const [showInterrupt, setShowInterrupt] = useState(false);
   const [agentStates, setAgentStates] = useState<Record<string, string>>({});
   const interruptRef = useRef<HTMLDivElement>(null);
+  // #973: single feedback-clear timer, cleared before re-arm and on
+  // unmount so rapid actions don't stack timers that setState after unmount.
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const AGENT_IDS = ["head", "dev", "re1", "re2"];
 
@@ -188,8 +197,10 @@ function ServerSection({ projectId }: { projectId: string }) {
   };
 
   const clearFeedback = () => {
-    setTimeout(() => setFeedback(null), 3000);
+    if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current);
+    feedbackTimerRef.current = setTimeout(() => setFeedback(null), 3000);
   };
+  useEffect(() => () => { if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current); }, []);
 
   useEffect(() => {
     if (!confirmFullReset) return;
@@ -202,6 +213,14 @@ function ServerSection({ projectId }: { projectId: string }) {
     const timer = setTimeout(() => setConfirmReseed(false), 4000);
     return () => clearTimeout(timer);
   }, [confirmReseed]);
+
+  // #973: auto-clear the Reset Agents confirm prompt after 4s (mirrors
+  // Full Reset / Re-seed) so a stray first click doesn't stay armed.
+  useEffect(() => {
+    if (!confirmReset) return;
+    const timer = setTimeout(() => setConfirmReset(false), 4000);
+    return () => clearTimeout(timer);
+  }, [confirmReset]);
 
   const handleFullReset = async () => {
     if (!confirmFullReset) {
@@ -224,6 +243,11 @@ function ServerSection({ projectId }: { projectId: string }) {
   };
 
   const handleReset = async () => {
+    if (!confirmReset) {
+      setConfirmReset(true);
+      return;
+    }
+    setConfirmReset(false);
     setLoading("reset");
     try {
       const r = await fetch(
@@ -281,9 +305,13 @@ function ServerSection({ projectId }: { projectId: string }) {
         <button
           onClick={handleReset}
           disabled={!!loading}
-          className="px-1.5 py-0.5 text-[10px] text-text-muted border border-border hover:text-accent hover:border-accent/40 transition-colors disabled:opacity-50"
+          className={`px-1.5 py-0.5 text-[10px] border transition-colors disabled:opacity-50 ${
+            confirmReset
+              ? "text-error border-error/60 bg-error/10 hover:bg-error/20"
+              : "text-text-muted border-border hover:text-accent hover:border-accent/40"
+          }`}
         >
-          {loading === "reset" ? "..." : t.resetAgents}
+          {loading === "reset" ? "..." : confirmReset ? t.confirmResetAgents : t.resetAgents}
         </button>
         <button
           onClick={handleFullReset}

--- a/src/components/QueueManager.tsx
+++ b/src/components/QueueManager.tsx
@@ -148,31 +148,62 @@ export default function QueueManager({ projectId }: QueueManagerProps) {
           : window.location.host;
         const wsUrl = `${wsProto}//${wsHost}/ws/terminal?project=${encodeURIComponent(projectId)}&agent=head${tok ? `&${tok}` : ""}`;
         const ws = new WebSocket(wsUrl);
-        await new Promise<void>((resolve, reject) => {
-          ws.onopen = () => resolve();
-          ws.onerror = () => reject(new Error("WebSocket failed"));
-          setTimeout(() => reject(new Error("WebSocket timeout")), 5000);
-        });
+        try {
+          await new Promise<void>((resolve, reject) => {
+            ws.onopen = () => resolve();
+            ws.onerror = () => reject(new Error("WebSocket failed"));
+            setTimeout(() => reject(new Error("WebSocket timeout")), 5000);
+          });
 
-        // Wait for shell to initialize
-        await new Promise((r) => setTimeout(r, 500));
+          // #973: poll /api/sessions until the PTY the WS just spawned is
+          // registered, instead of a fixed 500ms sleep a slow spawn on a
+          // busy event loop could outrun — which would write the head
+          // command into a shell that isn't ready yet.
+          const sessionReady = await new Promise<boolean>((resolve) => {
+            const deadline = Date.now() + 5000;
+            const probe = async () => {
+              try {
+                const sres = await fetch("/api/sessions");
+                if (sres.ok) {
+                  const list = await sres.json();
+                  if (Array.isArray(list) && list.some((s) => s && s.projectId === projectId && s.agentId === "head")) {
+                    resolve(true);
+                    return;
+                  }
+                }
+              } catch { /* transient — keep probing */ }
+              if (Date.now() < deadline) setTimeout(probe, 150);
+              else resolve(false);
+            };
+            probe();
+          });
+          if (!sessionReady) throw new Error("session did not come up");
 
-        // Start the Head agent CLI in the PTY shell
-        await fetch(`/api/agents/${projectId}/head/write`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", ...auth },
-          body: JSON.stringify({ text: `${headCommand}\n` }),
-        });
+          // Start the Head agent CLI in the PTY shell
+          await fetch(`/api/agents/${projectId}/head/write`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", ...auth },
+            body: JSON.stringify({ text: `${headCommand}\n` }),
+          });
 
-        // Wait for agent to initialize
-        await new Promise((r) => setTimeout(r, 3000));
+          // Wait for the agent CLI to initialize before sending the prompt.
+          // There's no liveness signal for CLI readiness (the session is
+          // already live), so this stays a short fixed warm-up.
+          await new Promise((r) => setTimeout(r, 3000));
 
-        // Now write the queue prompt to the running agent
-        res = await fetch(`/api/agents/${projectId}/head/write`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", ...auth },
-          body: JSON.stringify({ text: prompt + "\n" }),
-        });
+          // Now write the queue prompt to the running agent
+          res = await fetch(`/api/agents/${projectId}/head/write`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", ...auth },
+            body: JSON.stringify({ text: prompt + "\n" }),
+          });
+        } finally {
+          // #973: the bootstrap WS existed only to spawn the PTY; the real
+          // Head terminal attaches as its own viewer. Close it so it doesn't
+          // leak open for the lifetime of the page. (The server keeps the
+          // PTY alive with zero viewers — it's torn down only on stop/reset.)
+          try { ws.close(); } catch { /* already closing */ }
+        }
       }
 
       if (res.ok) {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -74,6 +74,8 @@ const BACKENDS: { value: string; label: string }[] = [
 const COPY = {
   en: {
     loading: "Loading...",
+    loadError: "Couldn't load settings.",
+    retry: "Retry",
     title: "Settings",
     save: "Save",
     saving: "Saving...",
@@ -161,6 +163,8 @@ const COPY = {
   },
   ko: {
     loading: "로딩 중...",
+    loadError: "설정을 불러오지 못했습니다.",
+    retry: "다시 시도",
     title: "설정",
     save: "저장",
     saving: "저장 중...",
@@ -298,6 +302,10 @@ export default function SettingsPage() {
   const t = COPY[locale];
   const searchParams = useSearchParams();
   const [config, setConfig] = useState<Config | null>(null);
+  // #973: distinguish "still loading" from "load failed" so a failed
+  // initial /api/config read shows an error + Retry instead of the
+  // "Loading..." placeholder spinning forever (the .catch swallowed it).
+  const [loadError, setLoadError] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const savedConfigRef = useRef<string>("");
@@ -317,6 +325,27 @@ export default function SettingsPage() {
       const saved = JSON.parse(savedConfigRef.current);
       const sp = (saved.projects || []).find((p: { id: string }) => p.id === projectId);
       if (sp) { sp.idle = idle; savedConfigRef.current = JSON.stringify(saved); }
+    } catch { /* no saved snapshot yet */ }
+  }, []);
+
+  // #973: advance the saved snapshot's name after a debounced rename
+  // persists, instead of reloading the whole config. A full load() would
+  // overwrite any unsaved edits the operator made in other fields while
+  // the 800ms debounce was pending; the optimistic update already put the
+  // new name in local state, so this just keeps dirty-tracking honest.
+  const syncSavedProjectName = useCallback((projectId: string, name: string) => {
+    try {
+      const saved = JSON.parse(savedConfigRef.current);
+      const sp = (saved.projects || []).find((p: { id: string }) => p.id === projectId);
+      if (sp) { sp.name = name; savedConfigRef.current = JSON.stringify(saved); }
+    } catch { /* no saved snapshot yet */ }
+  }, []);
+
+  const syncSavedAgentName = useCallback((projectId: string, agentId: string, displayName: string) => {
+    try {
+      const saved = JSON.parse(savedConfigRef.current);
+      const sp = (saved.projects || []).find((p: { id: string }) => p.id === projectId);
+      if (sp?.agents?.[agentId]) { sp.agents[agentId].display_name = displayName; savedConfigRef.current = JSON.stringify(saved); }
     } catch { /* no saved snapshot yet */ }
   }, []);
 
@@ -359,6 +388,7 @@ export default function SettingsPage() {
   const [portDraft, setPortDraft] = useState<string>("8400");
 
   const load = useCallback(() => {
+    setLoadError(false);
     fetch("/api/config")
       .then((r) => {
         if (!r.ok) throw new Error(`${r.status}`);
@@ -377,7 +407,11 @@ export default function SettingsPage() {
         savedConfigRef.current = JSON.stringify(cfg);
         return setConfig(cfg);
       })
-      .catch(() => {});
+      // #973: surface the failure instead of swallowing it — otherwise a
+      // failed initial read leaves config null and the "Loading..."
+      // placeholder spins forever. load() only runs on mount + Retry, so
+      // config is always null here on failure.
+      .catch(() => setLoadError(true));
   }, []);
 
   useEffect(() => { load(); }, [load]);
@@ -722,7 +756,10 @@ export default function SettingsPage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ type: "project", projectId: project.id, oldName, newName }),
         })
-          .then(() => load())
+          // #973: merge just the renamed field into the saved snapshot
+          // rather than load()-ing the whole config, which would clobber
+          // other fields the operator edited during the debounce window.
+          .then(() => syncSavedProjectName(project.id, newName))
           .catch(() => {});
       }
       delete originalNames.current[key];
@@ -751,7 +788,8 @@ export default function SettingsPage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ type: "agent", projectId: project.id, agentId, oldName, newName }),
         })
-          .then(() => load())
+          // #973: merge just the renamed field (see renameProject).
+          .then(() => syncSavedAgentName(project.id, agentId, newName))
           .catch(() => {});
       }
       delete originalNames.current[key];
@@ -796,6 +834,22 @@ export default function SettingsPage() {
     }
   };
 
+  // #973: failed initial load → error + Retry instead of an endless spinner.
+  if (!config && loadError) {
+    return (
+      <div className="p-6 flex flex-col items-start gap-3">
+        <div className="border border-error/30 bg-error/5 text-error text-[11px] px-3 py-2">
+          {t.loadError}
+        </div>
+        <button
+          onClick={load}
+          className="px-3 py-1.5 text-[12px] border border-border text-text-muted hover:text-text hover:border-accent transition-colors"
+        >
+          {t.retry}
+        </button>
+      </div>
+    );
+  }
   if (!config) return <div className="p-6 text-text-muted text-xs">{t.loading}</div>;
 
   const isDirty = savedConfigRef.current !== "" && JSON.stringify(config) !== savedConfigRef.current;

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -40,18 +40,29 @@ export default function TerminalPanel({
   const onActivityRef = useRef(onActivity);
   useEffect(() => { onActivityRef.current = onActivity; }, [onActivity]);
 
+  // #973: last dimensions actually sent to the backend. fit() runs once
+  // per animation frame during output bursts, but the terminal size
+  // rarely changes — only send a resize when cols/rows actually differ
+  // so a busy agent doesn't flood the PTY with identical resize frames.
+  const lastSentSizeRef = useRef<{ cols: number; rows: number }>({ cols: 0, rows: 0 });
+
   const fit = useCallback(() => {
     if (fitRef.current && termRef.current && containerRef.current) {
       try {
         fitRef.current.fit();
         // Notify backend of new dimensions
         const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) {
+        const { cols, rows } = termRef.current;
+        if (
+          ws && ws.readyState === WebSocket.OPEN &&
+          (cols !== lastSentSizeRef.current.cols || rows !== lastSentSizeRef.current.rows)
+        ) {
+          lastSentSizeRef.current = { cols, rows };
           ws.send(
             JSON.stringify({
               type: "resize",
-              cols: termRef.current.cols,
-              rows: termRef.current.rows,
+              cols,
+              rows,
             })
           );
         }
@@ -202,6 +213,9 @@ export default function TerminalPanel({
             rows: term.rows,
           })
         );
+        // #973: record the size just sent so fit()'s change-guard is
+        // seeded against reality and doesn't immediately resend it.
+        lastSentSizeRef.current = { cols: term.cols, rows: term.rows };
         ws.send(JSON.stringify({ type: "replay" }));
       };
 


### PR DESCRIPTION
Closes #973

Frontend correctness bundle — 7 confirmed frontend-only bugs + 3 folded lows across the dashboard components. No server endpoints touched; existing patterns matched throughout.

## Changes

**ChatPanel.tsx**
1. **403 auth banner was dead code** — `authRetryRef` was read (`< 3`) but never incremented, so the "Chat authentication failed (403)" banner could never surface. Now increments on each 403, shows once the retry budget is spent, and resets the tally on a clean poll and on project switch.
2. **Project-switch poll race** — an in-flight poll for the *old* project could resolve after the operator switched and append its messages / advance the cursor into the *new* project. The fetch now captures its `reqProject` and drops stale responses (and stale retries), mirroring the `cancelled`/stale-read guard in `ProjectDashboard.tsx:154-166`.
3. *(fold)* Reply button prepended `@sender` by **replacing** the input, discarding any draft; now prepends without discarding. Message + preview attachment `key`s are index-composited so two attachments sharing a filename don't collide.

**SettingsPage.tsx**
4. **Debounced rename clobbered unsaved edits** — the 800ms rename timer called `load()`, overwriting any edits made to other fields during the window. Now merges only the renamed field into the saved snapshot (new `syncSavedProjectName` / `syncSavedAgentName`, modeled on the existing `syncSavedIdle`); the optimistic update already reflects the new name in local state.
5. **Swallowed load error → infinite spinner** — a failed initial `/api/config` read left `config` null and the "Loading…" placeholder spinning forever. Adds an error + **Retry** state (pattern from `HomeDashboard:116-138`).

**ControlBar.tsx**
6. **Reset Agents had no confirm** — a single click killed all 4 agents, unlike every other destructive button here. Adds the same two-click confirm + 4s auto-clear used by Full Reset / Re-seed.
7. *(fold)* Feedback-clear `setTimeout` leaked (never stored/cleared); now held in a ref, cleared before re-arm and on unmount.

**TerminalPanel.tsx**
8. **Resize spam** — `fit()` sent a resize frame every animation frame during output bursts even when dimensions were unchanged. Now tracks last-sent `cols/rows` and only sends on an actual change (seeded from the `onopen` initial resize).

**QueueManager.tsx**
9. **Bootstrap WebSocket leak** — the WS opened to spawn the Head PTY was never closed, leaking for the page lifetime. Now closed in a `finally` after use (the server keeps the PTY alive with zero viewers — verified in `server/index.js:1726` `ws.on("close")`, which only removes the viewer). The fixed 500ms spawn sleep is replaced with polling `/api/sessions` for liveness; the CLI warm-up stays a short fixed delay since no liveness signal exists for CLI readiness.

## EPIC Alignment (#967)
EPIC #967 Phase 3 — isolated frontend correctness pass, no server change (Phases 1–2 landed the atomic-config / field-scoped write backend). This PR only touches `src/components/*`, keeping the display-layer/logic-layer split the project enforces.

## Self-Verification
- `npx tsc --noEmit` → clean (exit 0)
- `npm test` (server suite, what CI runs) → **59 passed, 0 failed, 2 skipped**
- `npm run build` (Next.js production) → compiled successfully; `/settings` and `/project/[id]/queue` (the changed components' routes) prerender cleanly
- `npx eslint` on the 5 files → 0 new errors (only pre-existing `<img>` warnings + pre-existing `SystemSection` ref warnings I did not touch)

## Design Fidelity

5 of the 7 bugs are logic-only (no rendered output): ChatPanel 403-count + poll-race guard, SettingsPage rename merge, TerminalPanel resize gate, QueueManager WS lifecycle, ControlBar feedback-timer, ChatPanel attachment `key`s. Only **two** changes render new UI; both reuse existing components' token vocabulary with no new visual primitives.

### 1 — ControlBar "Reset Agents" destructive-confirm (`src/components/ControlBar.tsx:305-316`)

| Aspect | Requirement | Evidence |
|---|---|---|
| Pattern reuse | Match sibling destructive buttons (Full Reset / Re-seed) | Armed state reuses their **identical** class string `text-error border-error/60 bg-error/10 hover:bg-error/20` (`:309-311`, same as Full Reset `:321`) |
| Colors | Design tokens only | `--error` `#ff4444` (armed), `--accent` `#00ff88` (idle hover), `--border` `#2a2a2a` — no literals added |
| Typography | Match row | `text-[10px]`, Geist Mono inherited — same as every button in the Server row |
| Spacing / layout | No layout drift | `px-1.5 py-0.5`; button stays in the existing `flex items-center gap-1.5 flex-wrap` row — no structural change |
| Corners / depth | Sharp, no shadow/glow | no `rounded`/`shadow` classes — matches dev-tool aesthetic |
| States | idle → armed → loading → auto-reset | idle `t.resetAgents` → armed `t.confirmResetAgents` (`:314`) → `"..."` while `loading==="reset"` → 4s auto-clear (`:218-224`); `disabled:opacity-50` |
| i18n | en + ko copy | `:22` / `:75` added to existing COPY tables |
| Responsive | inherits row | no new breakpoints; row already `flex-wrap` |

### 2 — SettingsPage load-error + Retry (`src/components/SettingsPage.tsx:838-852`)

| Aspect | Requirement | Evidence |
|---|---|---|
| Pattern reuse | Reuse the app's error-banner vocabulary | Banner `border border-error/30 bg-error/5 text-error text-[11px] px-3 py-2` (`:841`) mirrors the `HomeDashboard:198` load-error banner |
| Retry control | Standard secondary button | `border border-border text-text-muted hover:text-text hover:border-accent` (`:846-849`) — same as other secondary buttons on the page |
| Colors | Design tokens only | `--error` (banner), `--accent` (button hover), `--border` — tokens only |
| Typography | Match page scale | banner `text-[11px]`, button `text-[12px]` — consistent with surrounding Settings text |
| Spacing / layout | Match replaced placeholder | container `p-6 flex flex-col items-start gap-3` — same `p-6` as the `Loading…` placeholder it supersedes (`:854`) |
| States | null+error → error/Retry → recovery | replaces the infinite spinner; Retry re-invokes `load()`, which clears `loadError` (`:391`) and re-fetches |
| i18n | en + ko copy | `:77` / `:166` added |
| Dark-mode only | no light theme | all classes resolve to the dark palette; no light branch introduced |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
