### PR TITLE
[#986] 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js",


### PR DESCRIPTION
Fixes #986

## EPIC Alignment
- **Parent:** #967 — QuadWork v2.4.0 hardening & quality pass
- **Epic goal:** Ship the hardening EPIC's fixes to users.
- **This PR's role:** Version bump 2.4.0 → 2.5.0 so all 9 merged fix tickets reach users via npm/auto-reseed.
- **Contracts consumed/exposed:** version fields only; minor bump per standing convention
- **Fits with merged siblings:** the release payload for #976·#969·#970·#968·#972·#971·#973·#974·#975 (all merged since v2.4.0)

## Self-Verification
- Bump: `npm version minor --no-git-tag-version` → v2.5.0; diff = package.json + package-lock.json only (+3/−3)
- Tests: `node --test server/pack-smoke.test.js` → pass 1, fail 0 (full suite gated by CI)
- Kill-list scan: clean (version fields only)

## Deviations
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
