### PR TITLE
[#990] 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js",


### PR DESCRIPTION
Fixes #990

## EPIC Alignment
- **Parent:** #967 — QuadWork hardening
- **This PR's role:** Version bump 2.5.0 → 2.5.1 shipping the #988 reverse-proxy WS-token hotfix (PR #989) that restores live terminal access on nginx-proxied dashboards.
- **Contracts consumed/exposed:** version fields only; PATCH per hotfix convention
- **Fits with merged siblings:** the release payload for #988

## Self-Verification
- Bump: `npm version patch --no-git-tag-version` → v2.5.1; diff = package.json + package-lock.json only (+3/−3)
- Tests: `node --test server/pack-smoke.test.js` → pass 1, fail 0 (full suite gated by CI)
- Kill-list scan: clean

## Deviations
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
