### PR TITLE
[#961] Clarify Operator MCP VPS loopback and SSH forwarding troubleshooting

### DIFF
--- a/docs/operator-mcp.md
+++ b/docs/operator-mcp.md
@@ -84,6 +84,45 @@ The operator server speaks to `127.0.0.1:8400` — the loopback of **whatever ma
 
 > ⚠️ **A local Claude Desktop registration reaches THIS device's `127.0.0.1`, not the VPS.** Use SSH or a port-forward so the client and QuadWork share a loopback.
 
+### Remote / VPS troubleshooting
+
+`quadwork-mcp-operator --port 8400` **always** connects to `127.0.0.1:8400` of the machine where that command runs (see [Remote / VPS registration](#remote--vps-registration) above). Most VPS confusion comes from expecting a *direct* connection to the VPS's public IP — which is deliberately closed.
+
+**Expected failures — these are normal, not bugs:**
+
+- `nc -vz <vps-ip> 8400` → *connection refused*, and a browser to `http://<vps-ip>:8400` failing, are **expected** when the backend binds VPS loopback only (the default). Nothing is broken — the port is simply not exposed publicly.
+- **Do not open port 8400 publicly to "fix" this.** The backend is not meant to be a public, internet-facing auth boundary; exposing it is a security regression. Forward it over SSH instead.
+
+**The fix — forward the port over SSH, then connect to the local loopback:**
+
+```bash
+ssh -N -L 8400:127.0.0.1:8400 <ssh-alias-or-user@vps>
+# then, in another local shell:
+quadwork-mcp-operator --port 8400   # now reaches the VPS via the forwarded 127.0.0.1:8400
+```
+
+`-N` opens the tunnel without starting a remote shell; `-L 8400:127.0.0.1:8400` maps your **local** `127.0.0.1:8400` onto the VPS's loopback `8400`. (Alternatively, run the MCP client over SSH *on* the VPS, as in option 1 above — then no forward is needed.)
+
+**Verify each layer independently, bottom-up:**
+
+```bash
+ssh -G <alias> | sed -n '1,20p'           # 1. confirm the alias's user + hostname
+lsof -iTCP:8400 -sTCP:LISTEN -n -P        # 2. is something listening on local 8400 (the tunnel)?
+quadwork-mcp-operator --port 8400         # 3. end-to-end: list_projects should return
+```
+
+> ⚠️ **`ssh <alias>` and `ssh <ip>` can resolve to different users and identity files.** `ssh -G quadwork` may report `user quadwork`, while `ssh -G 178.x.x.x` falls back to your **local** username — so a direct-IP check can silently test the wrong login. Always confirm with `ssh -G` before assuming you're reaching the intended VPS account.
+
+**Symptom → cause → fix:**
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `nc -vz <vps-ip> 8400` → refused | Backend binds VPS loopback only (expected) | Not a bug — use the SSH tunnel; do **not** expose 8400 publicly |
+| MCP client can't reach QuadWork from your laptop | The client hits **your laptop's** `127.0.0.1`, not the VPS | `ssh -N -L 8400:127.0.0.1:8400 <vps>`, then rerun the client |
+| `nc -vz <vps-ip> 22` works but MCP still fails | SSH host reachable, but no forward for 8400 | Add `-L 8400:127.0.0.1:8400` (or run the client on the VPS) |
+| `ssh <ip>` uses the wrong user | Direct IP uses your **local** username, not the alias's | Use the alias (`ssh quadwork`) or `user@ip`; confirm with `ssh -G` |
+| stdio JSON-RPC returns nothing | Pipe closed before the server wrote its responses | Keep the trailing `sleep` in the [stdio examples](#direct-stdio-json-rpc-invocation) below (raise it on slow links) |
+
 ## Direct stdio JSON-RPC invocation
 
 Use this only when your MCP client does not surface tools directly, or when you
@@ -107,6 +146,10 @@ The minimal flow is:
 
 Each request is one JSON object. The examples below write newline-delimited
 JSON-RPC requests and pipe them into the installed bin.
+
+The trailing `sleep` in each example keeps stdin open long enough for the MCP
+server to write its responses before the pipe closes — without it you may see
+no output. Raise it for slower links or heavier calls.
 
 ### List projects / verify connection
 


### PR DESCRIPTION
Closes #961

## Summary

Docs-only. The Operator MCP VPS path in `docs/operator-mcp.md` was technically correct but easy to misread during troubleshooting (surfaced while recovering a PlotLink OWS operator session). Adds a focused **Remote / VPS troubleshooting** subsection directly under the existing *Remote / VPS registration* section — it **references** that section rather than duplicating its commands.

New content:
- Restates the loopback rule: `quadwork-mcp-operator --port 8400` always connects to `127.0.0.1:8400` of the machine running the command.
- **"Expected failures"**: `nc -vz <vps-ip> 8400` refused (and a browser to `http://<vps-ip>:8400` failing) is **normal** when the backend binds VPS loopback only; **do not open 8400 publicly** to "fix" it (security regression) — forward over SSH instead.
- The exact copy-pasteable tunnel command: `ssh -N -L 8400:127.0.0.1:8400 <ssh-alias-or-user@vps>`.
- A bottom-up verify checklist (`ssh -G`, `lsof -iTCP:8400 -sTCP:LISTEN`, `quadwork-mcp-operator`).
- Warns that `ssh <ip>` and `ssh <alias>` can resolve to **different users/identity files** — verify with `ssh -G` before assuming you're hitting the intended VPS login.
- A symptom → cause → fix table.
- Notes why the stdio JSON-RPC examples carry a trailing `sleep` (keep stdin open so the server flushes responses before the pipe closes).

## EPIC Alignment

EPIC #967 — folded / isolated (per the batch brief). Docs-only, low risk; no epic-tracked surface touched.

## Self-Verification

**Adversarial diff re-read** — the diff is confined to `docs/operator-mcp.md`: one new `### Remote / VPS troubleshooting` subsection + a one-paragraph note in the stdio intro. No other file changed.

**Kill-list / safety invariants:**
- **Docs-only, no code/behavior change** — only a `.md` file changed (`git status` shows just `docs/operator-mcp.md`).
- **Does not contradict existing content** — the new subsection restates and *references* the Registration section (`#remote--vps-registration`) and the stdio examples (`#direct-stdio-json-rpc-invocation`); the `-N -L` tunnel is a refinement of the existing `-L` example, not a conflicting instruction.
- **pack-smoke passes.**

**Build + test evidence:**
- `node server/pack-smoke.test.js` → PASS (24 shipped Node files, 11 runtime assets).
- Rendered the new section — table well-formed; both intra-doc anchor links resolve (`#remote--vps-registration`, `#direct-stdio-json-rpc-invocation`).

**Acceptance criteria (1:1):**
- Distinguishes SSH-to-VPS working / direct `<vps-ip>:8400` failing normally / local forwarded `127.0.0.1:8400` working ✅
- Copy-pasteable `-N -L` SSH tunnel command ✅
- Explains why opening 8400 publicly is not the right fix ✅
- Calls out SSH alias vs direct-IP user/identity differences ✅
- Direct stdio examples remain accurate and mention response-wait timing (the `sleep` note) ✅

## Deviations

None.