### PR TITLE
[#997] 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js",


### PR DESCRIPTION
Fixes #997

## EPIC Alignment
- **Parent:** #967 — QuadWork hardening
- **This PR's role:** Version bump 2.5.1 → 2.6.0 shipping the folded/operational improvements merged since v2.5.1: #966 (reseed worktree CLAUDE.md), #957 (lifecycle-aware temp-dir cleanup), #992 (auto-respawn agents on restart when mid-batch), #961 (Operator MCP VPS/SSH docs). Refactors R1/R2/R3 deferred to v2.7.0.
- **Contracts consumed/exposed:** version fields only; minor bump per convention
- **Fits with merged siblings:** release payload for #966/#957/#992/#961

## Self-Verification
- Bump: `npm version minor --no-git-tag-version` → v2.6.0; diff = package.json + package-lock.json only (+3/−3)
- Tests: `node --test server/pack-smoke.test.js` → pass 1, fail 0 (full suite gated by CI)
- Kill-list scan: clean

## Deviations
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
