### PR TITLE
[#999] Add GPT-5.6 Sol/Terra/Luna to codex model dropdown

### DIFF
--- a/server/agentModels.test.js
+++ b/server/agentModels.test.js
@@ -31,6 +31,7 @@ const ok = (c, m) => {
 // ── optionsForBackend: raw lists incl. the "" CLI-default row ──
 ok(optionsForBackend("codex").some((o) => o.value === ""), "optionsForBackend(codex) includes the (CLI default) row");
 ok(optionsForBackend("codex").some((o) => o.value === "gpt-5.4"), "optionsForBackend(codex) lists codex models");
+ok(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"].every((s) => optionsForBackend("codex").some((o) => o.value === s)), "#999: optionsForBackend(codex) includes the GPT-5.6 Sol/Terra/Luna slugs");
 ok(optionsForBackend("nope").length === 1 && optionsForBackend("nope")[0].value === "", "optionsForBackend(unknown) → single CLI-default row");
 
 // ── modelsForBackend: concrete (non-"") options, claude fallback ──

--- a/src/lib/agentModels.ts
+++ b/src/lib/agentModels.ts
@@ -13,6 +13,12 @@ export const MODEL_OPTIONS: Record<string, { value: string; label: string }[]> =
     { value: "gpt-5.4", label: "gpt-5.4" },
     { value: "gpt-5", label: "gpt-5" },
     { value: "gpt-4o", label: "gpt-4o" },
+    // #999: GPT-5.6 Sol/Terra/Luna — new concrete slugs. Appended AFTER the
+    // existing rows so modelsForBackend("codex")[0] stays "gpt-5.4" (the #931
+    // default/heal target). Same append pattern as the #958 Fable-5 row.
+    { value: "gpt-5.6-sol", label: "gpt-5.6-sol" },
+    { value: "gpt-5.6-terra", label: "gpt-5.6-terra" },
+    { value: "gpt-5.6-luna", label: "gpt-5.6-luna" },
   ],
   claude: [
     { value: "", label: "(CLI default)" },


### PR DESCRIPTION
Closes #999

## EPIC Alignment
- **Parent:** none — standalone enhancement, NOT part of EPIC #967. Standard QuadWork merge flow applies.
- **This PR's role:** Append the GPT-5.6 Sol/Terra/Luna concrete slugs to the codex model dropdown so operators can select them without hand-editing `~/.quadwork/config.json`.
- **Contracts consumed/exposed:** none changed — pure data addition to `MODEL_OPTIONS.codex`. `effectiveModel`/`sanitizeModel` already accept any concrete slug.
- **Fits with merged siblings:** same append pattern as the #958 Fable-5 row; ordering invariant from #931 preserved.

## Self-Verification
- Scope: 2 files, +7/−0. `src/lib/agentModels.ts` appends 3 rows AFTER the existing concrete codex rows (label == value); `server/agentModels.test.js` adds one assertion.
- Ordering invariant: `modelsForBackend("codex")[0]` stays `"gpt-5.4"` (the #931 default/heal target) — no reorder. Existing test line 38 still guards this.
- Behavior-preserving: no logic changes; `effectiveModel`/`sanitizeModel` unchanged.
- Tests: `node server/run-tests.js` → 64 passed, 0 failed, 2 skipped (Jest-style, pre-existing #836 skips). New assertion: `optionsForBackend("codex")` includes `gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna` → PASS.
- Typecheck: `npx tsc --noEmit` → clean (exit 0).

## Deviations
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
