### PR TITLE
[#1001] 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js",


### PR DESCRIPTION
Closes #1001

## EPIC Alignment
- **Parent:** none — release bump, NOT part of EPIC #967.
- **This PR's role:** version bump 2.6.0 → 2.7.0 (minor), shipping the feature merged since v2.6.0.
- **Contracts consumed/exposed:** none — version string only.

## Included since v2.6.0
- **#999** — Add GPT-5.6 Sol/Terra/Luna to the codex model dropdown (PR #1000, `f280d57`).

## Self-Verification
- Scope: 2 files, +3/−3 — `package.json` + `package-lock.json` version string only (`npm version 2.7.0 --no-git-tag-version`). No source changes.
- `node -p "require('./package.json').version"` → `2.7.0`.
- Merge flow: @dev review driver (no code); @re1 + @re2 review; after both APPROVE + CI green, @head merges.

## Post-merge (PO)
`gh release create v2.7.0 --target main --generate-notes`, then STOP at `npm publish` (operator gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
