### PR TITLE
[#1003] docs(readme): Reframe QuadWork around governed batch delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ Step-by-step guides for setting up QuadWork, designed for both humans and AI cod
 ## What is QuadWork?
 
 **QuadWork** is a local-first, open-source automation framework that
-orchestrates a collaborative team of four autonomous AI agents — **Head, Dev,
-and two Reviewers** — to manage a complete, production-grade GitHub workflow.
-By enforcing strict safety rails such as mandatory two-person independent code
-reviews and branch protection, it allows solo founders and engineers to ship
-code 24/7 through a reliable "Issue → Branch → PR → Merge" loop while
-maintaining high code quality without manual oversight.
+orchestrates a team of four AI agents — **Head** (`@head`), **Dev** (`@dev`),
+and two reviewers, **RE1** (`@re1`) and **RE2** (`@re2`) — through a governed
+GitHub workflow. Work moves one ticket at a time: Head assigns an issue, Dev
+opens a branch and PR, RE1 and RE2 each review it independently, and Head
+merges only after both approve before moving to the next ticket. The two
+mandatory independent reviews keep the
+`Issue → Branch → PR → Review × 2 → Merge` loop deliberate rather than
+one-agent-straight-to-`main`.
 
 <video src="https://github.com/user-attachments/assets/d1f6f3d6-27de-4afb-9b58-9fe1f87cddb8" width="720" controls></video>
 
@@ -63,16 +65,16 @@ Issue → Branch → PR → Review × 2 → Merge
   └──────── next ticket ───────────────┘
 ```
 
-Head creates issues and assigns them to Dev. Dev opens a PR. Reviewer 1
-and Reviewer 2 each review independently — approve, request changes, or
-veto. Dev iterates until both approve. Head merges and picks the next
-ticket. The cycle repeats autonomously until the batch is complete.
+Head creates issues and assigns them to Dev one at a time. Dev opens a
+PR. RE1 and RE2 each review it independently — approve, request changes,
+or veto. Dev iterates until both approve. Head merges and picks the next
+ticket. The cycle repeats until the batch queue is empty.
 
 ### Core Value Proposition
 
-- **Autonomous Reliability:** Runs overnight batches using a scheduled trigger, so you can wake up to a queue of successfully merged pull requests.
-- **Multi-Agent Governance:** Unlike single-agent tools, QuadWork uses a system of checks and balances where agents must convince each other through code review before merging to `main`.
-- **Privacy & Control:** Operates as a local Express server on your machine, managing your configured LLMs (Claude, OpenAI, Gemini) and GitHub CLI sessions without third-party proxying.
+- **Unattended batches:** A scheduled trigger advances the queue one ticket at a time, so you can kick off a batch and check back on the PRs it worked through.
+- **Multi-Agent Governance:** Unlike single-agent tools, QuadWork uses a system of checks and balances where a PR must clear two independent reviews before merging to `main`.
+- **Privacy & Control:** Operates as a local Express server on your machine, driving your configured Codex, Claude, or Gemini CLIs and GitHub CLI sessions without third-party proxying.
 - **Complete Visibility:** Features a comprehensive 4-quadrant dashboard with real-time agent terminals, chat history, and progress tracking.
 
 ## Why QuadWork?
@@ -113,13 +115,14 @@ GitHub-native workflow on them:
 
 | Agent | Role | What it does |
 |-------|------|-------------|
-| **Head** | Coordinator | Creates issues, assigns tasks, merges approved PRs |
-| **Dev** | Builder | Writes code, opens PRs, addresses review feedback |
-| **Reviewer1** | Reviewer | Independent code review with veto authority |
-| **Reviewer2** | Reviewer | Independent code review with veto authority |
+| **Head** (`@head`) | Coordinator | Creates issues, assigns them one at a time, merges approved PRs |
+| **Dev** (`@dev`) | Builder | Writes code, opens PRs, addresses review feedback |
+| **RE1** (`@re1`) | Reviewer | Independent code review with veto authority |
+| **RE2** (`@re2`) | Reviewer | Independent code review with veto authority |
 
-Every task follows the same cycle: **Issue → Branch → PR → 2 Reviews → Merge**.
-Branch protection ensures no agent can skip the process.
+Every task follows the same cycle: **Issue → Branch → PR → Review × 2 → Merge**.
+The two-review gate keeps any agent from merging to `main` unreviewed, and you
+can enable GitHub branch protection during setup as a server-side backstop.
 
 ### The full autonomous loop
 
@@ -136,15 +139,15 @@ Head: assigns the first issue to Dev
 Dev: opens a PR with code
      │
      ▼
-Reviewer1 + Reviewer2: independent reviews
+RE1 + RE2: independent reviews
      │
      ▼ (both approve)
 Head: merges, picks the next issue
      │
-     └──── repeat overnight ────┐
+     └──── repeat per ticket ───┐
                                 │
                                 ▼
-                       You wake up to merged PRs
+                       You return to merged PRs
 ```
 
 ### A concrete example
@@ -152,10 +155,10 @@ Head: merges, picks the next issue
 1. You drop a batch of 5 related tickets into chat: `@head start 5 sub-tickets under #123`.
 2. Head files the 5 issues on GitHub, writes them to `OVERNIGHT-QUEUE.md`, and asks you to click **Start Trigger**.
 3. You click it, close the laptop, and sleep.
-4. The Scheduled Trigger pulses the agents every 15 minutes. Each pulse, Head assigns the next queued issue to Dev.
-5. Dev opens a PR. Reviewer1 + Reviewer2 each review independently — approve, request changes, or veto. Dev iterates until both approve.
+4. The Scheduled Trigger pulses the agents on a recurring interval you set (default 30 minutes). Each pulse, Head advances the queue — assigning the next issue only once the current ticket has merged.
+5. Dev opens a PR. RE1 + RE2 each review independently — approve, request changes, or veto. Dev iterates until both approve.
 6. Head merges and picks the next ticket. Loop until the queue is empty or the duration expires.
-7. You wake up to 5 merged PRs, a clean queue, and a chat transcript you can scroll.
+7. You return to up to 5 merged PRs, a clean queue, and a chat transcript you can scroll.
 
 ## ─ Features
 
@@ -182,8 +185,8 @@ Head: merges, picks the next issue
 
 ### Safety
 
-- 🚧 **GitHub branch protection** enforced on `main`
-- ✅ **2-of-2 reviewer approval** required before merge
+- 🚧 **GitHub branch protection** — optional server-side backstop on `main`, enabled from the setup wizard
+- ✅ **2-of-2 reviewer approval** — the agent workflow requires both reviewers to approve before merge
 - 🛑 **Sender lockdown** — chat POSTs can't impersonate an agent (`head`, `dev`, …) from the UI
 - 🗄️ **Auto-snapshot** of chat history to `~/.quadwork/{project}/history-snapshots/` with an in-dashboard **Restore** button
 


### PR DESCRIPTION
Closes #1003

## EPIC Alignment
- **Parent:** none — standalone; part of the seven-ticket documentation-modernization batch (Batch 24).
- **This PR's role:** Establish the README product narrative for governed, one-ticket-at-a-time batch delivery (#1003).
- **Depends on:** none. **Enables:** #1004 (External Tools credits + stale AgentChattr guidance — NOT touched here).
- **Contracts respected:** Edits only the named README narrative sections (What is QuadWork → Features/Workflow/Safety → Architecture). Architecture/role/backend/workflow claims made only where verified against current code. External Tools credits deliberately left for #1004.

## Summary
Reframes the README product narrative around **governed, one-ticket-at-a-time batch delivery**. Docs-only; no source, test, package, or External Tools changes.

## Changes
- **What is QuadWork?** — rewritten to name all four roles accurately (**Head/@head, Dev/@dev, RE1/@re1, RE2/@re2**) and describe the sequential `Issue → Branch → PR → Review × 2 → Merge` pipeline. Dropped unsupported claims (production-grade, ship code 24/7, high code quality without oversight).
- **Core Value Proposition** — reframed the "successfully merged" guarantee into an unattended-batch description; backend mention now lists the actually-supported **Codex, Claude, or Gemini CLIs** instead of "Claude, OpenAI, Gemini".
- **Branch protection** — corrected from an enforced-guarantee assertion to what the product actually ships: an **optional server-side backstop the operator enables in the setup wizard** (`SetupWizard.tsx:738-759`). The always-true gate is the two independent reviews. Fixed in three places (What is QuadWork, How it Works, Safety) for consistency.
- **How it Works** table + loop diagram — reviewer rows/labels updated to RE1/RE2 with @mentions; cycle labeled `Review × 2`.
- **Concrete example** — corrected the scheduled-trigger interval: configurable, default **30 min**, not a fixed 15 min; clarified Head advances the queue only after the current ticket merges.

## Self-Verification
- **Scope:** 1 file, README.md only. Diff stops before the `## ─ External Tools` section — credits untouched.
- **Backends claim** — `server/index.js:257-259`: `isCliInstalled("claude" | "codex" | "gemini")`. All three CLIs verified supported → "Codex, Claude, or Gemini CLIs" is accurate.
- **Trigger interval claim** — `server/index.js:1516-1518`: `const ms = (interval || 30) * 60 * 1000;` → default 30 minutes, interval is caller-configurable. README's old "every 15 minutes" was wrong; corrected.
- **Branch protection** — `SetupWizard.tsx:738-759` exposes an **optional** toggle running `gh api repos/<repo>/branches/main/protection -X PUT ...`; it is not auto-enforced by QuadWork, and the live protection endpoint on this repo returns HTTP 404. README now presents it as an optional backstop rather than an enforced fact (per @re1).
- **Roles** — all four named as Head/@head, Dev/@dev, RE1/@re1, RE2/@re2, matching the top-of-README team badge and the Architecture worktree names (`{repo}-head/-dev/-re1/-re2`).
- **No source/behavior change** — only README.md is in the diff; no runtime code, tests, package versions, legacy migration code, or quadwork-web touched.
- **Links/commands preserved** — video/demo/website links and the Quick Start / Commands blocks are unchanged.

## Acceptance criteria (#1003)
- [x] No unsupported performance, cost, or safety claims (branch-protection assertion corrected).
- [x] All four roles named accurately.
- [x] Backends mentioned only where current code supports them.
- [x] Valid commands and links preserved.
- [x] No source or behavior changes.

## Merge flow
@dev (author) → independent @re1 + @re2 reviews → after both APPROVE + CI green, @head merges and selects #1004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)