### PR TITLE
[#1004] docs: Remove stale AgentChattr claims from repository guidance and README credits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What is QuadWork
 
-A unified local dashboard for 4-agent coding teams. Embeds terminals, AgentChattr chat, and GitHub board in one browser tab. See `docs/PROPOSAL.md` for full spec.
+A unified local dashboard for 4-agent coding teams. Embeds terminals, the file-based project chat, and GitHub board in one browser tab. See `README.md` for the full product overview.
 
 ## Tech Stack
 
@@ -47,8 +47,8 @@ Reference: [plotlink at `pre-design-overhaul`](https://github.com/realproject7/p
 
 ## Dependencies
 
-- AgentChattr: external dependency, cloned to `~/.quadwork/agentchattr` and run via `.venv/bin/python run.py`
-- Telegram bridge: external (`realproject7/agentchattr-telegram`), optional
+- Chat: built-in file-based JSONL chat (`server/file-chat.js`), exposed to agents through an MCP shim (`server/mcp-chat-shim.js`) as the `chat_send` / `chat_read` tools — no external chat service
+- Telegram bridge: built-in and optional (`server/bridges/telegram.js`)
 - Any new shared module `require`d by Node runtime code (`bin/`, `server/`) must live under a shipped dir or be added to `package.json` `files` — otherwise it's missing from the published tarball and crash-loops on fresh install (#937/#939). `server/pack-smoke.test.js` guards this; CI (`.github/workflows/ci.yml`) runs the suite on every PR and push to main (#976).
 
 ## Running locally

--- a/README.md
+++ b/README.md
@@ -254,9 +254,6 @@ Queue contract and full state vocabulary: **[docs/review-batches.md](docs/review
 
 QuadWork stands on top of some great open-source work. Explicit thanks:
 
-- **[AgentChattr](https://github.com/bcurts/agentchattr)** — by [@bcurts](https://github.com/bcurts).
-  QuadWork's file-based chat system was originally inspired by AgentChattr.
-  Thanks to bcurts for the foundational ideas.
 - **[GitHub CLI (`gh`)](https://cli.github.com)** — used by all four agents
   for issues, PRs, reviews, and merges.
 - **[Claude Code](https://github.com/anthropics/claude-code)** — Anthropic's


### PR DESCRIPTION
Closes #1004

## Summary
Docs-only. Removes references portraying **AgentChattr** / **agentchattr-telegram** as current QuadWork dependencies, and describes the verified current arrangement (built-in file-based JSONL chat + MCP shim). Scope limited to the three files named in #1004.

### Changes
- **README.md** (External Tools credit block): removed the AgentChattr credit bullet. Per the ticket, no credit should imply a current dependency; the remaining credits (gh, Claude Code, Codex, Next.js/Express, node-pty, xterm.js) are untouched.
- **CLAUDE.md** (What is QuadWork): `AgentChattr chat` → `the file-based project chat`; stale `docs/PROPOSAL.md` pointer (file does not exist) → `README.md` for the full product overview.
- **CLAUDE.md** (Dependencies): replaced the two stale bullets (AgentChattr external dependency; external `realproject7/agentchattr-telegram` bridge) with the current, verified arrangement — built-in file-based JSONL chat (`server/file-chat.js`) exposed via MCP shim (`server/mcp-chat-shim.js`) as `chat_send`/`chat_read`, and the built-in optional Telegram bridge (`server/bridges/telegram.js`).

## EPIC Alignment
- **Batch 24 ticket #1004** owns *only* README External Tools credits, AGENTS.md, and CLAUDE.md stale-AgentChattr guidance. This diff touches exactly README.md + CLAUDE.md; AGENTS.md needed no change (see below).
- **Shared invariant** (describe current file-based JSONL chat + MCP shim, current arrangement, only when verified): every replacement cites a real current source file confirmed to exist.
- **Out of scope, untouched:** README narrative owned by #1003, runtime code, tests, package versions, legacy cleanup/migration implementation (`bin/quadwork.js` `cleanup --legacy`, `server/migrate-ac.js`, `server/ac-restore.js`), and `realproject7/quadwork-web`.

## Self-Verification
- **Acceptance — `rg -i agentchattr README.md AGENTS.md CLAUDE.md` → no matches (exit 1).** ✓
- **AGENTS.md:** the top-level file is untracked (locally seeded from `templates/seeds/dev.AGENTS.md`); it and all tracked `templates/seeds/*.AGENTS.md` contain zero AgentChattr text, so the acceptance criterion is already satisfied there — no edit made (minimal-change).
- **Current-code verification of replacement claims:**
  - File-based JSONL chat: `server/file-chat.js:23` (`general.jsonl`), `:169` (`fs.appendFileSync`, mode 0o600).
  - MCP shim tools: `server/mcp-chat-shim.js:27` (`chat_send`), `:39` (`chat_read`), `:135` (`serverInfo name "quadwork-chat"`).
  - Built-in Telegram bridge: `server/bridges/telegram.js` (present; `discord.js` alongside).
  - `docs/PROPOSAL.md` confirmed **absent** (`ls` → No such file); repointed to `README.md` (present).
  - Telegram bridge is now built-in, not the external `agentchattr-telegram` repo; remaining `agentchattr` strings live only in legacy cleanup/migration paths (`bin/quadwork.js`) which are explicitly out of scope and untouched.
- **Scope:** `git diff --stat` → `CLAUDE.md` (+3/-3), `README.md` (-3); no other files staged.
- **CI:** pending on push.

## Acceptance criteria
- [x] `rg` over exactly README.md, AGENTS.md, CLAUDE.md finds no AgentChattr/agentchattr text
- [x] No credit implies a current dependency
- [x] Current file-chat + MCP-shim arrangement described only where verified
- [x] Legacy cleanup/migration implementation and tests untouched
- [x] quadwork-web not edited