### PR TITLE
[#1005] docs(install-mac): Update macOS installation for the current QuadWork release

### DIFF
--- a/docs/install-mac.md
+++ b/docs/install-mac.md
@@ -89,10 +89,10 @@ codex
 npm install -g quadwork@latest
 ```
 
-Verify:
+Verify the install:
 ```bash
-quadwork --version
-# You should see the version number (e.g., 1.14.5)
+npm list -g quadwork
+# You should see the installed version, e.g. quadwork@2.7.0
 ```
 
 ### Troubleshooting: `EACCES: permission denied`
@@ -136,45 +136,41 @@ quadwork init
 quadwork start
 ```
 
-You should see output like:
-```
-QuadWork dashboard: http://localhost:8400
-```
-
-Open the dashboard URL in your browser to access the web UI.
+The dashboard starts on `http://127.0.0.1:8400` (the server binds loopback
+only). QuadWork opens that URL in your default browser automatically; if it
+doesn't, open it yourself to reach the web UI.
 
 ---
 
 ## Create Your First Project
 
-1. Open the dashboard at `http://localhost:8400`
+1. Open the dashboard at `http://127.0.0.1:8400`
 2. Click **"+ New Project"** or navigate to `/setup`
 3. Fill in the project details:
    - **Name:** Your project name
    - **Repo:** GitHub repo in `owner/repo` format
    - **Working directory:** Absolute path to the repo clone
-   - **Agent backends:** Choose Claude, Codex, or Gemini for each agent role
+   - **Agent backends & models:** In the **Agent Models** step, pick a CLI
+     backend — **Claude Code**, **Codex**, or **Gemini CLI** — for each of the
+     four roles (Head, Dev, RE1, RE2), and optionally select a specific model
+     per role (e.g. `opus` / `sonnet` for Claude, `gpt-5.4` / `gpt-5.6-*` for
+     Codex, `gemini-2.5-pro` / `gemini-2.5-flash` for Gemini). Leave a role on
+     **(CLI default)** to use the backend's own default model.
 4. Click **Create**
 
 QuadWork will:
-- Create worktree directories for each agent (e.g., `project-head/`, `project-dev/`, `project-re1/`, `project-re2/`)
-- Seed AGENTS.md files for each role
+- Create a git worktree for each agent next to your repo (e.g., `project-head/`, `project-dev/`, `project-re1/`, `project-re2/`)
+- Seed `AGENTS.md` and `CLAUDE.md` into each role's worktree
 
 ---
 
 ## Trust Prompt (Claude Code)
 
-On first launch, Claude Code agents may get stuck at a "Do you trust this directory?" prompt. QuadWork v1.14.5+ automatically pre-trusts worktree directories for Claude-configured agents during project creation.
-
-**If agents are still stuck** (e.g., upgraded from an older version), manually pre-trust each worktree:
-
-```bash
-# Run in each worktree directory
-cd /path/to/project-head && claude -p "echo ok"
-cd /path/to/project-dev && claude -p "echo ok"
-cd /path/to/project-re1 && claude -p "echo ok"
-cd /path/to/project-re2 && claude -p "echo ok"
-```
+On first launch, Claude Code shows a "Do you trust this directory?" prompt.
+QuadWork auto-answers it: when an agent's terminal starts, a listener watches
+its output for the trust prompt (within the first few seconds) and confirms it
+automatically, so Claude-backed agents reach a trusted session with no operator
+action. No manual pre-trust step is required.
 
 ---
 


### PR DESCRIPTION
Closes #1005

## Summary
Docs-only. Reconciles `docs/install-mac.md` with the current CLI, SetupWizard, README, and package metadata (v2.7.0), removing stale v1.14.5-era wording and correcting commands that no longer match the code. Scope: `docs/install-mac.md` only.

### Changes
- **Verify step:** `quadwork --version` is not a real subcommand — it falls through to the usage help (`bin/quadwork.js` dispatch: init/start/stop/add-project/cleanup/doctor/migrate-agent-slugs/ac-restore, else usage). Replaced with `npm list -g quadwork`, and updated the example version 1.14.5 → **2.7.0** (`package.json`).
- **Dashboard URL:** server binds loopback (`server/index.js:2324` → `server.listen(PORT, "127.0.0.1")`, logging `QuadWork server listening on http://127.0.0.1:${PORT}`) and the CLI auto-opens `http://127.0.0.1:${port}` (`bin/quadwork.js:928`). Corrected `localhost` → `127.0.0.1`, dropped the unverified `QuadWork dashboard: …` stdout example, and documented the auto-open behavior.
- **First-run setup / per-role models:** documented the **Agent Models** step — per-role CLI backend (Claude Code / Codex / Gemini CLI, `SetupWizard.tsx:188-192`) plus optional per-role model selection (`src/lib/agentModels.ts` — Claude `opus`/`sonnet`/…, Codex `gpt-5.4`/`gpt-5.6-*`, Gemini `gemini-2.5-pro`/`-flash`, `(CLI default)`). Corrected the seed-files note to `AGENTS.md` **and** `CLAUDE.md` per worktree (`SetupWizard.tsx:81`).
- **Trust prompt:** removed the stale "QuadWork v1.14.5+ automatically pre-trusts …" claim and the `claude -p "echo ok"` manual workaround — #975 **dropped** that synchronous pre-trust. Described the current behavior: an `onData` trust-listener on each agent PTY auto-answers the prompt at startup (`server/index.js:1114-1119`, `:1182`).

## EPIC Alignment
- **Batch 24 ticket #1005** owns *only* `docs/install-mac.md`. This diff touches exactly that file.
- **Shared invariant** (document current behavior only when verified): every changed claim is tied to a current source line cited above.
- **Out of scope, untouched:** runtime code, package versions, tests, legacy cleanup/migration implementation, and all other docs.

## Self-Verification
- **Version/metadata:** `package.json` → `name: quadwork`, `version: 2.7.0`, `engines: {node: ">=20"}`.
- **Subcommands:** `bin/quadwork.js:1352-1400` — no `--version`; unknown args print usage. `init`/`start`/`stop` all present and used as documented.
- **Loopback bind + auto-open:** `server/index.js:2324`; `bin/quadwork.js:928` (`dashboardUrl = http://127.0.0.1:${port}`).
- **Port default 8400 / server.pid / caffeinate:** `bin/quadwork.js:253,864,911,947`; `server/index.js:311` — unchanged doc claims re-confirmed accurate.
- **Backends + per-role models:** `src/components/SetupWizard.tsx:188-192`, `src/lib/agentModels.ts:10-45`.
- **Trust listener:** `server/index.js:1114-1119` (old pre-trust dropped), `:1182-1185` (auto-answer within first ~10s).
- **Worktree naming:** `bin/quadwork.js:630-631` — `project-head/`, `project-re1/`, `project-re2/`, `project-dev/`.
- **Residual-stale scan:** `rg -n "1\.14|localhost|claude -p|quadwork --version" docs/install-mac.md` → only the legitimate `node/git/gh --version` prereq lines remain.
- **Scope:** `git diff --stat` → `docs/install-mac.md` only.
- **CI:** pending on push.

## Acceptance criteria
- [x] Stale v1.14.5-era version language removed
- [x] Only commands verified against the current project retained
- [x] CLI install, authentication, first-run setup, per-role model selection, worktree creation, start/stop behavior distinguished
- [x] Optional bridge guidance kept accurate
- [x] No runtime code changes