### PR TITLE
[#1008] docs(troubleshooting): Refresh current runtime recovery guidance

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,9 +8,19 @@ Common issues and fixes, structured as **Symptom > Cause > Fix**. Searchable by 
 
 **Symptom:** A Claude Code agent hangs on startup. Its terminal shows "Do you trust the files in this folder?" and waits for input.
 
-**Cause:** Claude Code requires explicit directory trust before running, and `--dangerously-skip-permissions` skips permission prompts but NOT the trust gate. QuadWork normally handles this for you: when an agent's terminal starts, a listener watches its output and auto-confirms the trust prompt within the first ~10 seconds. A hang means the prompt wasn't caught in that window (e.g. the agent was slow to render it, or was started outside the normal launch flow).
+**Cause:** Claude Code requires explicit directory trust before running, and `--dangerously-skip-permissions` skips permission prompts but NOT the trust gate. QuadWork pre-trusts each Claude-backed agent's worktree automatically during project creation, by running `claude -p` in it once, so the prompt normally never appears. A hang means that pre-trust didn't complete for this worktree — e.g. `claude` wasn't on `PATH` when the project was created, the worktree was recreated afterward, or the pre-trust timed out.
 
-**Fix:** Restart the agent from the QuadWork dashboard. The trust listener re-arms on the fresh terminal and answers the prompt automatically — no manual pre-trust step is required, and QuadWork no longer runs a separate `claude` pre-trust command.
+**Fix:** Re-trust the affected worktree(s) manually, then restart the agent from the dashboard:
+
+```bash
+# Run once in each affected worktree
+cd /path/to/<project>-head && claude -p "echo ok"
+cd /path/to/<project>-dev  && claude -p "echo ok"
+cd /path/to/<project>-re1  && claude -p "echo ok"
+cd /path/to/<project>-re2  && claude -p "echo ok"
+```
+
+This is the same command QuadWork runs at project creation; it writes the trust record so the agent's next launch skips the prompt. Re-running project setup also re-applies the pre-trust.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,20 +6,11 @@ Common issues and fixes, structured as **Symptom > Cause > Fix**. Searchable by 
 
 ## Claude Code trust prompt blocking agents
 
-**Symptom:** Claude Code agents hang on startup. Terminal shows "Do you trust the files in this folder?" and waits for input indefinitely.
+**Symptom:** A Claude Code agent hangs on startup. Its terminal shows "Do you trust the files in this folder?" and waits for input.
 
-**Cause:** Claude Code requires explicit directory trust before running. The `--dangerously-skip-permissions` flag skips permission prompts but does NOT skip the trust gate.
+**Cause:** Claude Code requires explicit directory trust before running, and `--dangerously-skip-permissions` skips permission prompts but NOT the trust gate. QuadWork normally handles this for you: when an agent's terminal starts, a listener watches its output and auto-confirms the trust prompt within the first ~10 seconds. A hang means the prompt wasn't caught in that window (e.g. the agent was slow to render it, or was started outside the normal launch flow).
 
-**Fix:** Pre-trust each worktree directory:
-
-```bash
-cd /path/to/project-dev && claude -p "echo ok"
-cd /path/to/project-head && claude -p "echo ok"
-cd /path/to/project-re1 && claude -p "echo ok"
-cd /path/to/project-re2 && claude -p "echo ok"
-```
-
-QuadWork v1.14.5+ automatically pre-trusts worktree directories for Claude-configured agents during project creation. If upgrading from an older version, run the commands above once.
+**Fix:** Restart the agent from the QuadWork dashboard. The trust listener re-arms on the fresh terminal and answers the prompt automatically — no manual pre-trust step is required, and QuadWork no longer runs a separate `claude` pre-trust command.
 
 ---
 
@@ -66,16 +57,15 @@ QuadWork v1.14.5+ automatically pre-trusts worktree directories for Claude-confi
 
 **Symptom:** An agent doesn't respond to chat messages. Other agents can send and receive normally.
 
-**Cause:** PTY injection isn't delivering messages to the agent process. The agent's MCP shim may not be configured, or the agent process may not be running.
+**Cause:** Messages reach agents two ways — the chat MCP shim (`server/mcp-chat-shim.js`, exposing `chat_read` / `chat_send`) and PTY injection into the agent's terminal. If the agent process isn't running, or its shim failed to start, delivery stalls. The shim is wired into each agent **automatically at launch** — it isn't configured by hand.
 
 **Fix:**
 1. Check that the agent process is running:
    ```bash
    ps aux | grep -E "claude|codex|gemini"
    ```
-2. Verify the agent's MCP shim is configured in the project's agent settings
-3. Check the agent's terminal in the QuadWork dashboard for errors
-4. Restart the agent from the dashboard if needed
+2. Open the agent's terminal in the QuadWork dashboard and look for MCP errors (e.g. the `chat` server failing to connect) or a stuck prompt.
+3. Restart the agent from the dashboard — this relaunches its terminal and re-provisions the chat MCP shim.
 
 ---
 


### PR DESCRIPTION
Closes #1008

## Summary
Docs-only. Ties `docs/troubleshooting.md` to current runtime behavior, fixing the two stale entries and re-verifying the rest. Scope: `docs/troubleshooting.md` only.

### Changes
- **Claude Code trust prompt:** removed the stale "QuadWork v1.14.5+" version wording and reframed the fix. The current mechanism: QuadWork pre-trusts each Claude-backed agent worktree at project creation by running `claude -p` there once (`server/routes.js:3924-3940`, #599) — the interactive prompt normally never appears. The `claude -p "echo ok"` block is now documented as the manual recovery when that pre-trust did not complete (re-run it in the affected worktree, then restart the agent). Per @re1: the onData listener at `server/index.js:1182` is Butler-only and is not claimed for the four agents.
- **Agent not receiving messages:** reworded the cause/fix to reflect that the chat MCP shim (`server/mcp-chat-shim.js`, `chat_read`/`chat_send`) is wired into each agent **automatically at launch**, not hand-configured; the useful diagnostic is checking the agent terminal for MCP errors and restarting the agent.

### Verified and intentionally preserved (already current)
- **Session token / cross-origin (#968):** the `quadwork_session_token` localStorage key is correct (`src/lib/sessionToken.ts:5,14`); WS endpoints `/ws/terminal`, `/ws/butler` match (`server/index.js:1735`); token auto-generated + stored in config (`server/index.js:30-39`); `/api/session-token` loopback-only (`isLocalTokenRequest`).
- **Reverse proxy `trusted_dashboard_hosts` (#988)** section and its **remote-exposure security warnings** — kept intact per the ticket.
- **Chat file permissions / JSONL corruption:** chat dir `~/.quadwork/<project>/chat/` + `general.jsonl`, files mode 0o600 (`server/file-chat.js:19,23,169`); server skips corrupt lines on read (`:95`).
- **temp_cleanup (#957):** `temp_cleanup: { enabled, max_age_hours }` (`server/index.js:800-805`); **pm2 PATH** wrapper; **non-root** guidance (anchor `install-vps.md#step-2-create-non-root-user-critical` resolves).

## EPIC Alignment
- **Batch 24 ticket #1008** owns *only* `docs/troubleshooting.md`. This diff touches exactly that file.
- **Ticket requirements** met: file-chat, MCP shim, worktree, session-token, reverse-proxy, CLI, and pm2 guidance tied to current behavior; no "restore a removed AgentChattr service" guidance (none present or added — `rg -i agentchattr` → 0); trusted-dashboard-host and remote-exposure security warnings preserved.
- **Out of scope, untouched:** runtime code, tests, package versions, legacy migration implementation, and other documents.

## Self-Verification
- **Agent pre-trust (regular agents):** `server/routes.js:3924-3940` (#599) runs `claude -p "echo ok"` per Claude worktree at creation; #975 made it async (`:3935-3937`), did not remove it. The onData listener at `server/index.js:1182` is Butler-only (`butlerSession.term`) and is not cited for the four agents.
- **MCP shim auto-provisioning:** `server/index.js:502-509`, `:570-610` (shim launched per agent with `--project/--agent/--port/--token`).
- **Token key + endpoints:** `src/lib/sessionToken.ts:14` (`getItem("quadwork_session_token")`); `server/index.js:1735` (WS pathnames).
- **Residual-stale scan:** `rg -in "1\.14|agentchattr" docs/troubleshooting.md` → no matches. Note: `claude -p "echo ok"` **intentionally remains** in the trust section as the documented manual recovery — it is the same command QuadWork runs at project creation (`server/routes.js:3937`), not stale content.
- **Scope:** `git diff --stat` → `docs/troubleshooting.md` only.
- **CI:** pending on push.

## Acceptance criteria
- [x] Every symptom, cause, and command tied to current behavior
- [x] No guidance to restore a removed AgentChattr service
- [x] trusted-dashboard-host and remote-exposure security warnings preserved
- [x] No runtime code changes; no edits outside `docs/troubleshooting.md`

