### PR TITLE
[#1009] docs(operator-mcp): Make the Operator MCP guide backend-neutral and remote-safe

### DIFF
--- a/docs/operator-mcp.md
+++ b/docs/operator-mcp.md
@@ -1,6 +1,6 @@
-# Drive QuadWork from a Claude agent (Operator MCP)
+# Drive QuadWork from an MCP client (Operator MCP)
 
-QuadWork ships an **MCP operator server** — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that lets a Claude agent (Claude Code or Claude Desktop) **observe and drive** a running QuadWork instance: read team chat and batch progress, define and run overnight batches, and control individual agents.
+QuadWork ships an **MCP operator server** — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that lets any MCP-capable client (Claude Code, Claude Desktop, Codex, or another MCP agent) **observe and drive** a running QuadWork instance: read team chat and batch progress, define and run overnight batches, and control individual agents.
 
 It is the same surface a human operator uses from the dashboard, exposed as tools. It talks to the QuadWork backend over `http://127.0.0.1:<port>` (default **8400**) and is launched by the MCP client, **not** by QuadWork itself.
 
@@ -39,7 +39,7 @@ you act as the human operator by talking to them.
 
 ## Registration
 
-The package installs a dedicated bin, `quadwork-mcp-operator`. Always register with the bin (never a `<quadwork-dir>/server/...` path — that breaks on global/VPS installs).
+The package installs a dedicated bin, `quadwork-mcp-operator`. Always register with the bin (never a `<quadwork-dir>/server/...` path — that breaks on global/VPS installs). Every client launches the **same** command — `quadwork-mcp-operator --port <port>` — only the registration syntax differs. Examples for common clients follow; any MCP client that can launch a stdio server works the same way.
 
 ### Claude Code (local install)
 
@@ -48,6 +48,17 @@ claude mcp add quadwork -- quadwork-mcp-operator --port 8400
 ```
 
 Then, in a Claude Code session, the `list_projects`, `batch_status`, `start_batch`, … tools are available. Verify with `list_projects` — it should return your configured projects.
+
+### Codex CLI
+
+Codex registers MCP servers with `-c mcp_servers.<name>` config flags — the same mechanism QuadWork uses to attach its chat shim to Codex-backed agents:
+
+```bash
+codex -c 'mcp_servers.quadwork.command="quadwork-mcp-operator"' \
+      -c 'mcp_servers.quadwork.args=["--port","8400"]'
+```
+
+The `quadwork` tools are then available in the Codex session; verify with `list_projects`.
 
 ### Claude Desktop
 
@@ -68,7 +79,7 @@ Restart Claude Desktop. The QuadWork tools appear under the 🔌 tools menu.
 
 ### Remote / VPS registration
 
-The operator server speaks to `127.0.0.1:8400` — the loopback of **whatever machine the MCP client runs on**. If QuadWork runs on a VPS, a Claude Desktop registration on your laptop reaches **your laptop's** `127.0.0.1`, not the VPS. Two ways to register correctly:
+The operator server speaks to `127.0.0.1:8400` — the loopback of **whatever machine the MCP client runs on**. If QuadWork runs on a VPS, a local client registration on your laptop reaches **your laptop's** `127.0.0.1`, not the VPS. Two ways to register correctly:
 
 1. **Run Claude Code over SSH on the VPS host** — register there with the same command; it reaches the VPS's local QuadWork directly.
    ```bash
@@ -82,7 +93,7 @@ The operator server speaks to `127.0.0.1:8400` — the loopback of **whatever ma
    claude mcp add quadwork -- quadwork-mcp-operator --port 8400
    ```
 
-> ⚠️ **A local Claude Desktop registration reaches THIS device's `127.0.0.1`, not the VPS.** Use SSH or a port-forward so the client and QuadWork share a loopback.
+> ⚠️ **A local MCP-client registration reaches THIS device's `127.0.0.1`, not the VPS.** Use SSH or a port-forward so the client and QuadWork share a loopback.
 
 ### Remote / VPS troubleshooting
 
@@ -171,15 +182,15 @@ not fall back to SSH or HTTP endpoint calls.
 
 ### Read status and recent chat
 
-Replace `plotlink-ows` with the `id` returned by `list_projects`.
+Replace `myproject` with the `id` returned by `list_projects`.
 
 ```bash
 python3 - <<'PY'
 import json
 reqs = [
   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"operator-script","version":"1"}}},
-  {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"batch_status","arguments":{"project":"plotlink-ows"}}},
-  {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_chat","arguments":{"project":"plotlink-ows","limit":20}}},
+  {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"batch_status","arguments":{"project":"myproject"}}},
+  {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_chat","arguments":{"project":"myproject","limit":20}}},
 ]
 open('/tmp/qw-status.jsonl','w').write('\n'.join(json.dumps(r) for r in reqs) + '\n')
 PY
@@ -243,7 +254,7 @@ Each is 1–3 tool calls. Start every session with `list_projects` to get the
 
 **Start a code batch** — let HEAD plan and write the queue:
 1. `send_message(project, "@head start a batch for <feature>: #12 #15 #18")` — HEAD files issues + writes `OVERNIGHT-QUEUE.md`, then asks you to start.
-2. Kick it off: `start_batch(project, { interval_min: 15 })` for an overnight cadence (first pulse at T+interval), or `trigger_now(project)` for an immediate first pulse.
+2. Kick it off: `start_batch(project, { interval_min: 30 })` for an overnight cadence (30 min is the default; first pulse at T+interval), or `trigger_now(project)` for an immediate first pulse.
 3. Monitor (below).
 
 **Run a review batch** (review-only — no code, no merges). Just ask HEAD; it stamps the `**Batch type:**` marker — you never touch the queue:

--- a/docs/operator-mcp.md
+++ b/docs/operator-mcp.md
@@ -4,7 +4,7 @@ QuadWork ships an **MCP operator server** — a stdio [Model Context Protocol](h
 
 It is the same surface a human operator uses from the dashboard, exposed as tools. It talks to the QuadWork backend over `http://127.0.0.1:<port>` (default **8400**) and is launched by the MCP client, **not** by QuadWork itself.
 
-> **The MCP client must run on the same machine as QuadWork.** The server only reaches `127.0.0.1:<port>` — see [Remote / VPS](#remote--vps-registration) below.
+> **The client and QuadWork must share a loopback.** The server only reaches `127.0.0.1:<port>`, so either run the MCP client on the same machine as QuadWork, or bridge the two with the SSH local port-forward in [Remote / VPS](#remote--vps-registration) below.
 
 ## Operating model — read this first
 


### PR DESCRIPTION
Closes #1009

## Summary
Docs-only. Makes `docs/operator-mcp.md` describe a **generic tool-first MCP operator surface** rather than a Claude-only feature, adds a **verified** Codex registration, keeps the loopback/SSH-forward security model, and removes an environment-specific project id. Scope: `docs/operator-mcp.md` only.

### Changes
- **Backend-neutral:** retitled "from a Claude agent" → "from an MCP client"; intro now names Claude Code, Claude Desktop, Codex, or any MCP agent. Added a generic registration note (every client launches the same `quadwork-mcp-operator --port <port>` bin; only the syntax differs). Genericized the Remote/VPS "reaches your laptop's `127.0.0.1`" notes from Claude-Desktop-specific to any local client.
- **Codex (verified only):** added a Codex CLI registration using `-c mcp_servers.<name>` config flags — the exact mechanism QuadWork already uses to inject its chat shim into Codex agents (`src/lib/injectMode.js` codex→`proxy_flag`; `server/index.js:576-580`). No unverified/config.toml setup invented.
- **Remote-safe:** preserved the local-loopback security model, the "backend binds loopback only / do not expose port 8400 publicly" guidance, and the SSH local-forward remote-access flow.
- **No environment-specific identifiers:** replaced the sample project id `plotlink-ows` with a neutral `myproject`. (IPs/hosts elsewhere are placeholders: `<vps-ip>`, `<alias>`, `178.x.x.x`.)
- **Accuracy:** aligned the `start_batch` example to the verified default interval (30 min).

### Preserved per ticket
- Tool-first operating model and **@head owns the queue** (Operating model section).
- **Read-only (Tier 1) vs state-changing (Tier 2)** tool split.
- Local-loopback / no-public-port security warnings.

## EPIC Alignment
- **Batch 24 ticket #1009** (final) owns *only* `docs/operator-mcp.md`. This diff touches exactly that file.
- **Ticket requirements** met: generic MCP surface; @head queue ownership; current tool surface; secure local-forward remote access; read-only vs state-changing distinguished; no environment-specific hostnames/IPs; Codex mentioned only where verified.
- **Out of scope, untouched:** backend/runtime code, packages, tests, legacy migration implementation, other docs, and other repositories.

## Self-Verification
- **Tool surface (all 14 match):** `list_projects` `read_chat` `batch_status` `read_queue` `list_agents` (`server/mcp-operator/tools/{projects,read}.js`); `send_message` `start_batch` `trigger_now` `stop_batch` `agent_control` `interrupt_all` `set_batch` `append_batch` `ensure_batch` (`.../tools/{chat-send,triggers,agents,batch}.js`).
- **Codex MCP mechanism:** `src/lib/injectMode.js:27-29` (codex → `proxy_flag`); `server/index.js:576-580` (`-c mcp_servers.chat.command/args`). The operator equivalent uses `command="quadwork-mcp-operator"`, `args=["--port","8400"]`.
- **start_batch default 30:** `server/mcp-operator/tools/triggers.js:29,35`.
- **Loopback bind:** `server/index.js:2324` (`server.listen(PORT, "127.0.0.1")`).
- **No environment-specific IDs:** `rg -i plotlink docs/operator-mcp.md` → none; no real hostnames/IPs (placeholders only).
- **Scope:** `git diff --stat` → `docs/operator-mcp.md` only.
- **CI:** pending on push.

## Acceptance criteria
- [x] Describes a generic MCP operator surface (not Claude-only)
- [x] Tool-first model, @head queue ownership, read-only vs state-changing documented
- [x] Remote access via secure local forward; local-loopback security preserved
- [x] No environment-specific hostnames or IP addresses published
- [x] Codex-compatible usage mentioned only where verified
- [x] No backend/runtime changes; no edits outside `docs/operator-mcp.md`