### PR TITLE
[#1021] 2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadwork",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quadwork",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadwork",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Unified dashboard for multi-agent coding teams — 4 AI agents, one terminal",
   "bin": {
     "quadwork": "./bin/quadwork.js",


### PR DESCRIPTION
Closes #1021.

Release-source bump `2.7.0` → `2.7.1` from main `31708d5`. npm `latest` is `2.7.0`, so a publish without this bump would fail as a duplicate version. Version strings only — no dependency, source, docs, or build-output diff.

## EPIC Alignment

- **Parent:** none — standalone patch release (NOT EPIC #967). Standard QuadWork merge flow.
- **This ticket's role:** create the release-source bump; the GitHub release/tag and `npm publish` are explicitly **not** part of this PR.
- **Contracts respected:** version strings only; `package.json` root and both lockfile version fields stay identical; source merges before any tag/release/publish.
- **Out of scope:** publishing, npm credentials, rollout, and any source change beyond the three version fields.

## Changes (2 files, +3/−3)

Exactly the three fields the ticket names, edited **by path, not by global replacement**:

| Field | File |
|---|---|
| `version` | `package.json:3` |
| `version` | `package-lock.json:3` |
| `packages[""].version` | `package-lock.json:9` |

Path-specific editing matters here even though a global replace would happen to be safe today: `package-lock.json` also carries dependency versions (e.g. `2.6.1`, `2.1.1`), so a string sweep is safe only by coincidence of no dep sharing the release version. Verified no `2.7.0` occurrence remains in either file, and lockfile dependency resolutions are untouched.

## Included since v2.7.0

- **#1010** — restore reliable Claude file-chat wake delivery under continuous TUI repaint, without cap-injecting into Codex/Gemini (PR #1020).
- **#1018** — add `claude-opus-5` as an explicit pinned Claude model while preserving `opus (latest)` (PR #1019).
- **#1003–#1009** — governed-batch and installation/operator documentation refresh (PRs #1011–#1017).

## Self-Verification

- `npm test` → **64 passed, 0 failed, 2 skipped** (the two skips are the pre-existing Jest-style files, out of #836 scope).
- `npm run build` → **succeeds**, TypeScript clean.
- `npm pack --dry-run` → **succeeds**: `quadwork-2.7.1.tgz`, 150 files, 1.1 MB packed / 3.3 MB unpacked, `version: 2.7.1` — confirms the bump reaches the tarball and the `files` allowlist still resolves (the #937/#939 guard).
- `git diff` against the baseline is exactly the three version lines in two files; `grep` confirms no residual `2.7.0` in either.
- Baseline: branched from `main` @ `31708d5`, the commit named in the ticket.
- **`release:patch` was not used and must not be** — it chains `npm version patch && git push origin main --follow-tags && gh release create --latest && npm publish`, which both pushes directly to `main` (against the project rule) and performs the public release plus publish in one non-interruptible command.

## After merge

Per the ticket's release flow, this PR stops at the source bump. After @head merges I will verify final main reads `2.7.1` and **stop there**. Creating the `v2.7.1` GitHub release/tag requires a separate explicit public-release authorization and is the PO's action — not chained from merge verification — and `npm publish` is an operator-only gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)