### PR TITLE
[#1054] Batch review fixes into CI candidates

### DIFF
--- a/docs/ci-economy.md
+++ b/docs/ci-economy.md
@@ -59,11 +59,13 @@ Fast CI is the feedback loop for a candidate push. It is not a smaller copy of t
 
 Triggered by one of:
 
+- a non-draft `pull_request: opened`
 - `pull_request: ready_for_review`
 - `pull_request: labeled` when the added label is `ci:full`
-- `push` to `main`
+- a version/release tag
 - `schedule`
 - `workflow_dispatch`
+- optionally a `main` push when immediate deployment integrity requires a second full run
 
 It owns expensive or broad verification:
 
@@ -86,9 +88,11 @@ name: CI Fast
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
 
 concurrency:
-  group: ci-fast-${{ github.event.pull_request.number }}
+  group: ci-fast-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -110,11 +114,11 @@ name: CI Full Candidate
 
 on:
   pull_request:
-    types: [ready_for_review, labeled]
+    types: [opened, ready_for_review, labeled]
   push:
-    branches: [main]
+    tags: ["v*"]
   schedule:
-    - cron: "17 4 * * *"
+    - cron: "17 4 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -135,8 +139,12 @@ jobs:
           EVENT: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
           LABEL: ${{ github.event.label.name }}
+          DRAFT: ${{ github.event.pull_request.draft }}
         run: |
-          if [ "$EVENT" != pull_request ] || [ "$ACTION" = ready_for_review ] || [ "$LABEL" = ci:full ]; then
+          if [ "$EVENT" != pull_request ] || \
+             [ "$ACTION" = ready_for_review ] || \
+             [ "$LABEL" = ci:full ] || \
+             { [ "$ACTION" = opened ] && [ "$DRAFT" = false ]; }; then
             echo 'run=true' >> "$GITHUB_OUTPUT"
           else
             echo 'run=false' >> "$GITHUB_OUTPUT"
@@ -152,6 +160,20 @@ jobs:
 ```
 
 The small `plan` job is optional when every expensive job can share the same direct `if:` expression. It is useful when a workflow has a large matrix and you want one audited decision point.
+
+## Unsplit-workflow fallback
+
+Some mature repositories have one large, tightly coupled workflow that cannot be split safely in the same change. Candidate batching still cuts its largest waste immediately.
+
+When a genuinely necessary intermediate remote push cannot wait for both reviewers, put GitHub's `[skip ci]` instruction in that intermediate commit message. This suppresses `push` and `pull_request` workflows that honor GitHub skip instructions. Then:
+
+1. continue the review round;
+2. collect both verdicts;
+3. apply one consolidated local fix;
+4. push a **real, non-skipped final candidate commit**; and
+5. require all checks and both approvals on that later SHA.
+
+A skipped HEAD is never mergeable evidence. Do not use an empty remote mutation/revert pair to manufacture a non-skipped run, and do not use skip trailers on the final candidate. This fallback is for exceptional remote coordination, not a replacement for local-first work.
 
 ## Path classification
 
@@ -201,7 +223,7 @@ A repository averaging three PR pushes plus one main run can commonly move from 
 
 - two or fewer fast pipelines,
 - one full candidate pipeline, and
-- one main pipeline or release-train publication.
+- one inexpensive main check or a release-train publication.
 
 Repositories with large OS matrices, E2E shards, or container matrices see the largest reduction. The review standard remains unchanged; only redundant remote execution is removed.
 

--- a/docs/ci-economy.md
+++ b/docs/ci-economy.md
@@ -1,0 +1,218 @@
+# CI Economy for QuadWork Projects
+
+QuadWork's two-review workflow is valuable, but a repository can accidentally multiply CI cost when every small push runs release-grade verification. The cost model is multiplicative:
+
+```text
+remote candidates per ticket × runner-minutes per candidate
+```
+
+The solution is not to weaken review. It is to make a **candidate** the unit of remote work.
+
+## The candidate lifecycle
+
+```text
+local implementation
+  → local fast verification
+  → candidate C1 push
+  → RE1 + RE2 review the same SHA
+  → aggregate both verdicts
+  → local consolidated fix
+  → candidate C2 push
+  → delta review + full candidate CI
+  → merge
+```
+
+A candidate is a commit that Dev believes could merge. Work-in-progress commits, deliberately broken mutations, and one-reviewer-at-a-time fixes remain local.
+
+### Invariants
+
+1. The two reviewers remain independent.
+2. Both final approvals name the same current SHA.
+3. A push invalidates approvals and full-CI evidence for the previous SHA.
+4. Dev waits for both verdicts before starting the next review revision.
+5. One review round produces at most one remote push.
+6. Negative controls and mutation/revert pairs never enter the remote PR history.
+
+## Repository workflow contract
+
+A QuadWork-friendly repository exposes two checks with stable names.
+
+### Fast CI
+
+Triggered by ordinary pull-request activity:
+
+- `opened`
+- `synchronize`
+- `reopened`
+
+It should normally finish in a few minutes and include only inexpensive deterministic checks:
+
+- formatting and lint
+- type checking
+- focused or changed-package unit tests
+- source guards and no-stub checks
+- lightweight build or import smoke checks
+
+Fast CI is the feedback loop for a candidate push. It is not a smaller copy of the release pipeline.
+
+### Full Candidate CI
+
+Triggered by one of:
+
+- `pull_request: ready_for_review`
+- `pull_request: labeled` when the added label is `ci:full`
+- `push` to `main`
+- `schedule`
+- `workflow_dispatch`
+
+It owns expensive or broad verification:
+
+- complete OS/runtime matrices
+- full E2E and browser suites
+- container builds
+- release-mode compilation
+- database restore/dump verification
+- provenance and publish checks
+
+Do not include `synchronize` in the Full Candidate CI trigger. For a revised candidate, remove and re-add `ci:full` after the consolidated push. The label event then attaches full verification to the new HEAD without running it on intermediate commits.
+
+## Reference GitHub Actions shape
+
+### `.github/workflows/ci-fast.yml`
+
+```yaml
+name: CI Fast
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ci-fast-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fast:
+    name: fast
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/ci/fast
+```
+
+### `.github/workflows/ci-full.yml`
+
+```yaml
+name: CI Full Candidate
+
+on:
+  pull_request:
+    types: [ready_for_review, labeled]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-full-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.plan.outputs.run }}
+    steps:
+      - id: plan
+        env:
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL: ${{ github.event.label.name }}
+        run: |
+          if [ "$EVENT" != pull_request ] || [ "$ACTION" = ready_for_review ] || [ "$LABEL" = ci:full ]; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+          fi
+
+  full:
+    needs: plan
+    if: needs.plan.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/ci/full
+```
+
+The small `plan` job is optional when every expensive job can share the same direct `if:` expression. It is useful when a workflow has a large matrix and you want one audited decision point.
+
+## Path classification
+
+Path filters reduce cost only when they are correct. Use these rules:
+
+- Unknown paths run the broader lane; false positives cost time, false negatives ship defects.
+- Workflow, lockfile, root configuration, Dockerfile, migration, and shared-package changes are broad-impact by default.
+- Documentation-only paths may skip runtime jobs when they are truly outside every build context.
+- Do not infer Docker impact from import graphs while the Dockerfile still uses `COPY . .`; first narrow the build context or stage copies.
+
+For monorepos, compute the merge-base diff once and publish explicit outputs such as `web`, `server`, `shared`, `docker`, and `workflow`. Downstream jobs consume those outputs rather than each repeating checkout and classification.
+
+## Containers and releases
+
+PR image builds should run only when Docker/runtime inputs changed and only for a full candidate. Main-branch image publication should be separated from ordinary CI when possible:
+
+- explicit deployment dispatch, or
+- a release-train branch/tag, or
+- a path-classified main push when immediate deployment is required.
+
+Publishing three images after every tiny merge turns ticket granularity into deployment cost. A release train can batch several independently reviewed tickets without weakening the review gate on any ticket.
+
+## Local evidence
+
+Mutation and negative-control evidence belongs in the PR body, for example:
+
+```markdown
+- Mutation: inverted `canManageGuests` result locally
+- Command: `pnpm test canManageGuests`
+- Observed: 2 failures, expected assertion names shown
+- Reverted locally before candidate SHA `abc1234`
+```
+
+Never push the broken mutation and a revert solely to prove the test. GitHub bills both candidates and may begin several jobs before cancellation takes effect.
+
+## Expected impact
+
+The savings depend on both factors:
+
+```text
+before = average remote pushes × full-run minutes
+
+after = candidate pushes × (fast-run minutes + occasional full-run minutes)
+```
+
+A repository averaging three PR pushes plus one main run can commonly move from four full pipelines per ticket to:
+
+- two or fewer fast pipelines,
+- one full candidate pipeline, and
+- one main pipeline or release-train publication.
+
+Repositories with large OS matrices, E2E shards, or container matrices see the largest reduction. The review standard remains unchanged; only redundant remote execution is removed.
+
+## Migration checklist
+
+1. Measure job-minutes by job family, not only workflow count.
+2. Establish `CI Fast` and `CI Full Candidate` as stable check names.
+3. Move complete matrices, full E2E, image verification, and release compilation to the full lane.
+4. Keep deterministic source gates in the fast lane.
+5. Add the `ci:full` label.
+6. Update branch protection to require the intended candidate checks.
+7. Run one negative control proving a red candidate cannot merge.
+8. Teach Dev to remove/re-add `ci:full` only after a consolidated candidate push.
+9. Review usage after one week and tighten path classification only with evidence.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "docs/troubleshooting.md",
     "docs/operator-mcp.md",
     "docs/review-batches.md",
+    "docs/ci-economy.md",
     "skills/"
   ],
   "scripts": {

--- a/server/ciEconomyTemplate.test.js
+++ b/server/ciEconomyTemplate.test.js
@@ -33,6 +33,11 @@ assert.match(
 );
 assert.match(
   template,
+  /\[skip ci\][\s\S]*final candidate MUST be a later, real non-skipped commit/,
+  "an unsplit repository must be able to suppress an exceptional intermediate push without suppressing the final candidate",
+);
+assert.match(
+  template,
   /both final approvals must name the same current candidate SHA/,
   "candidate batching must preserve exact-tip two-review evidence",
 );

--- a/server/ciEconomyTemplate.test.js
+++ b/server/ciEconomyTemplate.test.js
@@ -1,0 +1,55 @@
+// #1054: the CI-economy contract is instruction-level behavior, so pin the
+// shipped templates and package surface directly. Plain node:assert script;
+// server/run-tests.js discovers it automatically.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const template = fs.readFileSync(path.join(root, "templates", "CLAUDE.md"), "utf8");
+const guide = fs.readFileSync(path.join(root, "docs", "ci-economy.md"), "utf8");
+const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+
+assert.match(
+  template,
+  /wait for \*\*both verdicts\*\* before editing or pushing/i,
+  "Dev must collect both independent verdicts before starting the next remote revision",
+);
+assert.match(
+  template,
+  /Mutation testing, negative controls[\s\S]*\*\*local\/VPS-only\*\*/,
+  "deliberately broken mutations must stay off the remote PR branch",
+);
+assert.match(
+  template,
+  /pushes exactly one replacement candidate `C2`/,
+  "one review round must produce one consolidated candidate push",
+);
+assert.match(
+  template,
+  /Full Candidate CI[\s\S]*`ci:full` label is added/,
+  "the expensive lane must be tied to an explicit candidate event",
+);
+assert.match(
+  template,
+  /both final approvals must name the same current candidate SHA/,
+  "candidate batching must preserve exact-tip two-review evidence",
+);
+
+assert.match(
+  guide,
+  /Do not include `synchronize` in the Full Candidate CI trigger/,
+  "the migration guide must prevent full CI from returning on every push",
+);
+assert.match(
+  guide,
+  /remove and re-add `ci:full` after the consolidated push/,
+  "the guide must explain how a revised candidate requests full verification",
+);
+assert.ok(
+  pkg.files.includes("docs/ci-economy.md"),
+  "the operator guide must ship in the published npm package",
+);
+
+console.log("ciEconomyTemplate.test.js: all assertions passed");

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -50,11 +50,11 @@ Do not split one review round into “RE1 fix push” and “RE2 fix push.” Do
 Repositories should expose two stable checks:
 
 - **Fast CI** runs on ordinary PR `opened` / `synchronize` events and covers formatting, static analysis, focused unit tests, and other inexpensive deterministic gates.
-- **Full Candidate CI** runs only when the PR becomes ready for review, when the explicit `ci:full` label is added, on `main`, on a scheduled canary, or by manual dispatch. It owns full matrices, complete E2E, container verification, release builds, and other expensive checks.
+- **Full Candidate CI** runs when a non-draft candidate opens, the PR becomes ready for review, or the explicit `ci:full` label is added. It should also run on release tags, scheduled canaries, and manual dispatch; repositories may repeat it on `main` when immediate deployment integrity requires that extra run. It owns full matrices, complete E2E, container verification, release builds, and other expensive checks.
 
 For a revised candidate, remove and re-add `ci:full` only after the consolidated push. Removing the label is not a test request; adding it is. Do not leave a full-CI trigger attached while making intermediate pushes.
 
-If a repository has not adopted split CI yet, the same local-first and one-push-per-round rules still apply; they reduce redundant full runs immediately.
+If a repository has not adopted split CI yet, the same local-first and one-push-per-round rules still apply; they reduce redundant full runs immediately. When an exceptional intermediate remote push is unavoidable in such a repository, add GitHub's `[skip ci]` trailer to that intermediate commit. The final candidate MUST be a later, real non-skipped commit so required checks run on the exact SHA reviewed; never merge a skipped HEAD, and never create remote mutation/revert pairs merely to obtain evidence.
 
 ### Merge evidence
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -21,9 +21,51 @@
 5. Dev opens PR with the required body template: `Fixes #<issue>` + `## EPIC Alignment` + `## Self-Verification` (+ `## Design Fidelity` for UI) + `## Deviations`
 6. Dev requests review from **@re1 AND @re2** (NOT Head), one message
 7. RE1/RE2 review independently in order: structural gate → epic context load → Layer 1 EPIC Alignment → Layer 2 Kill-List → Layer 3 Design Fidelity (UI) → evidence-bound verdict to **@dev**. Missing PR-body sections or any kill-list hit = REQUEST CHANGES.
-8. Dev addresses findings, pushes, re-requests; reviewers re-review the delta only
-9. Dev aggregates both evidence-bound approvals, then notifies **@head**
-10. Head runs the **Merge Gate** (live approval re-read + PR-body sections present + both verdicts carry `### Checked (evidence)`), merges; Issue auto-closes; epic checklist updated
+8. Dev addresses findings through the **CI Economy Protocol** below; reviewers re-review only the candidate delta
+9. Dev aggregates both evidence-bound approvals for the same candidate SHA, then notifies **@head**
+10. Head runs the **Merge Gate** (live approval re-read + PR-body sections present + both verdicts carry `### Checked (evidence)` + required candidate checks belong to current HEAD), merges; Issue auto-closes; epic checklist updated
+
+## CI Economy Protocol
+
+This section refines **push and review cadence** without changing role authority, the 2-of-2 review gate, or exact-tip verification.
+
+### Local-first implementation
+
+- Dev may make as many local commits, test mutations, and corrective iterations as needed, but MUST NOT push merely to discover whether CI passes.
+- Mutation testing, negative controls, deliberately broken commits, and their reverts are **local/VPS-only**. Record the command and observed result in the PR; never push the broken state to GitHub.
+- Before the first remote push, Dev runs the repository's local fast checks and the ticket-specific checks. The first push represents a reviewable **candidate**, not work in progress.
+
+### One push per review round
+
+1. Dev pushes candidate SHA `C1`, opens or updates the PR, and sends one joint request to `@re1 @re2` naming `C1`.
+2. RE1 and RE2 review `C1` independently. Dev MUST wait for **both verdicts** before editing or pushing, even when the first verdict already requests changes.
+3. Dev combines both reviewers' findings into one local fix set, runs local verification, and pushes exactly one replacement candidate `C2`.
+4. Dev sends one joint delta-review request naming `C1..C2`. Reviewers inspect only that delta plus their own prior findings.
+5. Repeat only when a reviewer identifies a new blocking defect. A push invalidates approvals for the prior SHA; both final approvals must name the same current candidate SHA.
+
+Do not split one review round into “RE1 fix push” and “RE2 fix push.” Do not send speculative micro-fixes while the second review is still running. A genuinely independent emergency correction may break this rule only when waiting would cause data loss or expose a security secret; state that reason explicitly.
+
+### Fast CI versus full candidate CI
+
+Repositories should expose two stable checks:
+
+- **Fast CI** runs on ordinary PR `opened` / `synchronize` events and covers formatting, static analysis, focused unit tests, and other inexpensive deterministic gates.
+- **Full Candidate CI** runs only when the PR becomes ready for review, when the explicit `ci:full` label is added, on `main`, on a scheduled canary, or by manual dispatch. It owns full matrices, complete E2E, container verification, release builds, and other expensive checks.
+
+For a revised candidate, remove and re-add `ci:full` only after the consolidated push. Removing the label is not a test request; adding it is. Do not leave a full-CI trigger attached while making intermediate pushes.
+
+If a repository has not adopted split CI yet, the same local-first and one-push-per-round rules still apply; they reduce redundant full runs immediately.
+
+### Merge evidence
+
+Head merges only when:
+
+- RE1 and RE2 both approved the current candidate SHA;
+- the repository's required fast checks are green for that SHA;
+- Full Candidate CI is green for that SHA when the repository defines it; and
+- no newer push exists after either approval or candidate check.
+
+A cancelled superseded run is consumed budget, not free work. `cancel-in-progress` is a safety net, never a substitute for batching pushes.
 
 Branch naming (strict): `task/<issue-number>-<short-slug>`
 
@@ -32,6 +74,7 @@ Branch naming (strict): `task/<issue-number>-<short-slug>`
 - Agents may push **feature branches** (`task/*`) autonomously
 - Agents must **NEVER push to `main`** — branch protection enforces this
 - Before push: run build checks, fix all errors
+- Push only a reviewable candidate or one consolidated review revision; ordinary local progress stays local
 
 ## Communication Rules
 


### PR DESCRIPTION
Fixes #1054

## EPIC Alignment
- **Parent:** none — standalone
- **Epic goal:** reduce GitHub Actions amplification without weakening QuadWork's independent two-review merge gate.
- **This PR's role:** makes a reviewable candidate—not each local iteration—the unit of remote push, review, and full CI.
- **Contracts consumed/exposed:** seeded `templates/CLAUDE.md` now defines one-push-per-review-round, local-only mutation evidence, `CI Fast`/`CI Full Candidate`, an unsplit-workflow `[skip ci]` fallback, and exact-tip merge evidence; `docs/ci-economy.md` defines the downstream workflow contract.
- **Fits with merged siblings:** extends the existing seeded CLAUDE.md/reseed path rather than adding another runtime coordinator or changing role authority.

## Self-Verification
- Repository test suite: Actions run `33255212619`, job `test` → **success**; `npm ci` and `npm test` both completed successfully on head `8becfdc400f56cd9975a983a54b8eb3c1f44bbf9`.
- Template contract: `server/ciEconomyTemplate.test.js` is auto-discovered by `server/run-tests.js` and passed inside that `npm test` run.
- Diff verification: PR now contains 4 changed files, 7 commits, 347 additions and 3 deletions.
- Kill-list scan: clean; no runtime mock/stub, debug output, or speculative runtime coordinator was added.
- Manual check: read the seeded workflow and packaged guide end-to-end against issue #1054's six acceptance criteria.

## Changes
- Dev waits for both reviewer verdicts before editing or pushing.
- One review round yields one consolidated candidate push.
- Mutation/negative-control commits stay local/VPS-only.
- Full matrices/E2E/containers move behind a non-draft candidate open, `ready_for_review`, or `ci:full`; ordinary pushes use Fast CI.
- Repositories not yet split may mark an exceptional intermediate push `[skip ci]`, but the final candidate must be a later non-skipped commit and a skipped HEAD is never mergeable evidence.
- Both approvals and candidate checks must belong to the same current SHA.
- Adds a packaged migration guide and a test pinning the instruction contract.

## Deviations
- This PR does not rewrite downstream repository workflows; it defines the shared protocol and reference migration, while repository-specific PRs apply it to their own CI topology.